### PR TITLE
Sort smaller clusters using a random walk

### DIFF
--- a/photomap/frontend/static/javascript/seek-slider.js
+++ b/photomap/frontend/static/javascript/seek-slider.js
@@ -265,7 +265,6 @@ function resetFadeOutTimer() {
       sliderContainer.classList.remove("visible");
       sliderVisible = false;
       fadeOutTimeoutId = null;
-      console.log("Slider faded out due to inactivity.");
     }
   }, FADE_OUT_DELAY);
 }


### PR DESCRIPTION
This pull request introduces an improved ordering algorithm for displaying cluster points in the photomap's UMAP visualization, aiming to enhance the user experience when interacting with clusters. The main change is the addition of a greedy random walk ordering for cluster points, which provides a more intuitive and visually coherent sequence when a cluster is clicked. For very large clusters, the system falls back to a simpler proximity-based ordering for performance reasons. Minor cleanups and formatting improvements are also included.

### Cluster point ordering improvements
* Added a greedy random walk algorithm (`randomWalkClusterOrder`) for ordering cluster points when a cluster is clicked, resulting in a more natural and visually connected sequence. For clusters larger than 2000 points, a proximity-based fallback is used (`proximityClusterOrder`). [[1]](diffhunk://#diff-7de53b8897649940db7e88f36d0bb59b5b5a6589fcb568b00de84d2518650207R942-R988) [[2]](diffhunk://#diff-7de53b8897649940db7e88f36d0bb59b5b5a6589fcb568b00de84d2518650207L956-R1013) [[3]](diffhunk://#diff-7de53b8897649940db7e88f36d0bb59b5b5a6589fcb568b00de84d2518650207R16)
* Updated the cluster click handler to use the new ordering algorithms, replacing the previous simple distance sort.

### Minor code cleanups and formatting
* Removed unnecessary blank lines and improved formatting in several places for readability. [[1]](diffhunk://#diff-7de53b8897649940db7e88f36d0bb59b5b5a6589fcb568b00de84d2518650207L51) [[2]](diffhunk://#diff-7de53b8897649940db7e88f36d0bb59b5b5a6589fcb568b00de84d2518650207L1024) [[3]](diffhunk://#diff-7de53b8897649940db7e88f36d0bb59b5b5a6589fcb568b00de84d2518650207L1301-R1340)
* Added a missing blank line for clarity in the `colorizeUmap` function.

### Logging removal
* Removed a debug log statement from the slider fade-out timer for cleaner console output.