### PR TITLE
[refactor] Refactor seek-slider into a Javascript class

### DIFF
--- a/photomap/frontend/static/javascript/seek-slider.js
+++ b/photomap/frontend/static/javascript/seek-slider.js
@@ -276,10 +276,14 @@ class SeekSlider {
     }, this.FADE_OUT_DELAY);
   }
 
-  clearFadeOutTimer() {
-    if (this.fadeOutTimeoutId) {
-      clearTimeout(this.fadeOutTimeoutId);
-      this.fadeOutTimeoutId = null;
+function resetFadeOutTimer() {
+  clearFadeOutTimer();
+  fadeOutTimeoutId = setTimeout(() => {
+    // Only fade out if mouse is NOT inside hoverZone
+    if (!sliderContainer.querySelector(":hover")) {
+      sliderContainer.classList.remove("visible");
+      sliderVisible = false;
+      fadeOutTimeoutId = null;
     }
   }
 


### PR DESCRIPTION
This PR converts seek-slider.js, which was using a bunch of package globals, into a proper class for code maintainability and reusability.