### PR TITLE
[Bugfix] Fix syntax errors in seek-slider

### DIFF
--- a/photomap/frontend/static/javascript/seek-slider.js
+++ b/photomap/frontend/static/javascript/seek-slider.js
@@ -276,14 +276,10 @@ class SeekSlider {
     }, this.FADE_OUT_DELAY);
   }
 
-function resetFadeOutTimer() {
-  clearFadeOutTimer();
-  fadeOutTimeoutId = setTimeout(() => {
-    // Only fade out if mouse is NOT inside hoverZone
-    if (!sliderContainer.querySelector(":hover")) {
-      sliderContainer.classList.remove("visible");
-      sliderVisible = false;
-      fadeOutTimeoutId = null;
+  clearFadeOutTimer() {
+    if (this.fadeOutTimeoutId) {
+      clearTimeout(this.fadeOutTimeoutId);
+      this.fadeOutTimeoutId = null;
     }
   }
 


### PR DESCRIPTION
This pull request refactors the fade-out timer logic in the `SeekSlider` class to improve code organization and maintainability. The main change is converting the standalone `resetFadeOutTimer` function into a class method and updating its logic to use instance properties.

Refactoring and code organization:

* Converted the `resetFadeOutTimer` function into the `clearFadeOutTimer` method of the `SeekSlider` class, ensuring it operates on the instance's `fadeOutTimeoutId` property and properly clears the timeout.