### PR TITLE
Start application with umap in fullscreen mode

### DIFF
--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -1243,6 +1243,7 @@ function setUmapWindowSize(sizeKey) {
 document.addEventListener("DOMContentLoaded", () => {
   updateUmapColorModeAvailability();
   makeDraggable("umapTitlebar", "umapFloatingWindow");
+  toggleUmapWindow()
 });
 
 // Shading/restoring


### PR DESCRIPTION
This pull request introduces a minor update to the initialization behavior of the UMAP floating window in the frontend. Now, when the document is loaded, the UMAP window will automatically toggle its visibility, improving the user experience by ensuring that PhotoMap's unique feature is highlighted.

* Initialization enhancement:
  * [`photomap/frontend/static/javascript/umap.js`](diffhunk://#diff-7de53b8897649940db7e88f36d0bb59b5b5a6589fcb568b00de84d2518650207R1246): Added a call to `toggleUmapWindow()` in the DOMContentLoaded event handler to automatically toggle the UMAP window when the page loads.