### PR TITLE
[bugfix] Clean up umap fullscreen logic

### DIFF
--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -440,13 +440,6 @@ document.addEventListener("DOMContentLoaded", () => {
 // --- Update colorization after search or cluster selection ---
 window.addEventListener("searchResultsChanged", function (e) {
   setUmapColorMode();
-  console.log(
-    "Last unshaded size:",
-    lastUnshadedSize,
-    " fullscreen:",
-    isFullscreen
-  );
-
   // deactivate fullscreen mode when search results have come in
   if (state.searchResults.length > 0 && isFullscreen) {
     toggleFullscreen(false);

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -439,12 +439,17 @@ document.addEventListener("DOMContentLoaded", () => {
 
 // --- Update colorization after search or cluster selection ---
 window.addEventListener("searchResultsChanged", function (e) {
-  const highlightCheckbox = document.getElementById("umapHighlightSelection");
-  const highlight = highlightCheckbox && highlightCheckbox.checked;
   setUmapColorMode();
+  console.log(
+    "Last unshaded size:",
+    lastUnshadedSize,
+    " fullscreen:",
+    isFullscreen
+  );
+
   // deactivate fullscreen mode when search results have come in
   if (state.searchResults.length > 0 && isFullscreen) {
-    toggleFullscreen();
+    toggleFullscreen(false);
   }
 });
 
@@ -544,7 +549,7 @@ function ensureUmapWindowInView() {
   }
 }
 
-window.addEventListener("albumChanged", async () => {
+async function initializeUmapWindow() {
   // Fetch the album's default EPS value and update the spinner
   const result = await fetch("get_umap_eps/", {
     method: "POST",
@@ -557,8 +562,11 @@ window.addEventListener("albumChanged", async () => {
     if (epsSpinner) epsSpinner.value = data.eps;
   }
   state.dataChanged = true;
+  lastUnshadedSize = "medium"; // Reset to medium on album change
+  setSemanticMapTitle();
   fetchUmapData();
-});
+  toggleFullscreen(true); // Force fullscreen on album change
+}
 
 // --- Thumbnail Preview on Hover ---
 let umapThumbnailDiv = null;
@@ -1243,7 +1251,7 @@ function setUmapWindowSize(sizeKey) {
 document.addEventListener("DOMContentLoaded", () => {
   updateUmapColorModeAvailability();
   makeDraggable("umapTitlebar", "umapFloatingWindow");
-  toggleUmapWindow()
+  toggleUmapWindow();
 });
 
 // Shading/restoring
@@ -1292,9 +1300,23 @@ addButtonHandlers("umapResizeSmall", () => {
   saveCurrentPosition();
   isFullscreen = false;
 });
-function toggleFullscreen() {
+function toggleFullscreen(turnOn = null) {
   const win = document.getElementById("umapFloatingWindow");
-  if (isFullscreen) {
+  if (turnOn === null) {
+    turnOn = !isFullscreen;
+  }
+  if (turnOn && isFullscreen)
+    return; // already in fullscreen
+
+  if (turnOn) {
+    lastUnshadedSize = getCurrentWindowSize();
+    lastUnshadedPosition.left = win.style.left;
+    lastUnshadedPosition.top = win.style.top;
+    setUmapWindowSize("fullscreen");
+    win.style.left = "0px";
+    win.style.top = "0px";
+    isFullscreen = true;
+  } else {
     setUmapWindowSize(lastUnshadedSize);
     if (
       lastUnshadedPosition.left !== null &&
@@ -1304,14 +1326,6 @@ function toggleFullscreen() {
       win.style.top = lastUnshadedPosition.top;
     }
     isFullscreen = false;
-  } else {
-    lastUnshadedSize = getCurrentWindowSize();
-    lastUnshadedPosition.left = win.style.left;
-    lastUnshadedPosition.top = win.style.top;
-    setUmapWindowSize("fullscreen");
-    win.style.left = "0px";
-    win.style.top = "0px";
-    isFullscreen = true;
   }
   // if any hover thumbnail is visible, remove it
   removeUmapThumbnail();
@@ -1350,7 +1364,5 @@ function setSemanticMapTitle() {
 }
 
 // Set initial title on DOMContentLoaded
-document.addEventListener("DOMContentLoaded", setSemanticMapTitle);
-
-// Update title when album changes
-window.addEventListener("albumChanged", setSemanticMapTitle);
+document.addEventListener("DOMContentLoaded", initializeUmapWindow);
+window.addEventListener("albumChanged", initializeUmapWindow);


### PR DESCRIPTION
This pull request refactors and improves the behavior of the UMAP floating window in the frontend. The main changes include consolidating album change logic, enhancing fullscreen toggling, and streamlining initialization and title updates. 

The main visual effect of this PR is that the umap window consistently leaves fullscreen when a search has been performed, allowing user to see the search results. In addition, when the DOM is loaded or the album changed, the window enters fullscreen mode.