### PR TITLE
[refactor\ simplify call to index_images in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY ./demo_images ./demo_images
 COPY ./demo_config.yaml /root/.config/photomap/config.yaml
 RUN pip cache purge
 RUN rm -rf ./photomap ./build ./dist ./demo_images/photomap_index/
-RUN python -c 'from photomap.backend.imagetool import do_index; do_index()' --embeddings ./demo_images/photomap_index/embeddings.npz ./demo_images
+RUN index_images --embeddings ./demo_images/photomap_index/embeddings.npz ./demo_images
 
 # Expose the port your app runs on
 EXPOSE 8050


### PR DESCRIPTION
This small PR replaces a complex command-line to index demo images in the docker image with a simpler one.