### PR TITLE
[packaging] Automate docker build and tagging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,15 @@ docker-build:
 
 .PHONY: docker-demo
 docker-demo:
-	docker build -f docker/Dockerfile.demo -t photomapai-demo .
+	version=$$(grep '^version\s*=' pyproject.toml | sed -E 's/.*=\s*"([^"]+)".*/\1/') \
+	&& 	docker build -f docker/Dockerfile.demo -t lstein/photomapai-demo:v$$version . \
+	&& docker tag lstein/photomapai-demo:v$$version lstein/photomapai-demo:latest
 
 .PHONY: docker
 docker:
-	docker build -f docker/Dockerfile -t photomapai .
+	version=$$(grep '^version\s*=' pyproject.toml | sed -E 's/.*=\s*"([^"]+)".*/\1/') \
+	&& docker build -f docker/Dockerfile -t lstein/photomapai:v$$version  . \
+	&& docker tag lstein/photomapai:v$$version lstein/photomapai:latest 
 
 # Serve the mkdocs site w/ live reload
 .PHONY: docs

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -11,7 +11,7 @@ RUN python -c "import clip; clip.load('ViT-B/32')"
 
 # Copy contents of demo_images and its config file
 COPY ./demo_images ./demo_images
-COPY ./demo_config.yaml /root/.config/photomap/config.yaml
+COPY ./docker/demo_config.yaml /root/.config/photomap/config.yaml
 RUN pip cache purge
 RUN rm -rf ./photomap ./build ./dist ./demo_images/photomap_index/
 RUN index_images --embeddings ./demo_images/photomap_index/embeddings.npz ./demo_images

--- a/docker/demo_config.yaml
+++ b/docker/demo_config.yaml
@@ -1,9 +1,9 @@
 albums:
   demo:
-    description: ~5000 random license-free images from Open Images
+    description: ~4500 random license-free images from Open Images
     image_paths:
     - /app/demo_images
     index: /app/demo_images/photomap_index/embeddings.npz
-    name: Open Images Demo
+    name: PhotoMapAI Demo (with album management disabled)
     umap_eps: 0.13
 config_version: 1.0.0


### PR DESCRIPTION
This pull request updates the Docker build process and demo configuration for the project. The main changes include versioned Docker image tagging, a fix to the demo config file path in the Dockerfile, and updates to the demo configuration details.

**Docker build and tagging improvements:**

* The `Makefile` now builds and tags Docker images with the version from `pyproject.toml`, using the format `lstein/photomapai[:demo]:v<version>` and also tags them as `latest` for convenience.

**Demo configuration and Dockerfile fixes:**

* The demo configuration file is now correctly copied from `docker/demo_config.yaml` instead of the project root, ensuring the right config is used for demo builds.
* The demo configuration (`docker/demo_config.yaml`, previously `demo_config.yaml`) updates the album description, album name, and clarifies that album management is disabled.