### PR TITLE
[Bugfix] Tweak umap height

### DIFF
--- a/photomap/frontend/static/css/umap-floating-window.css
+++ b/photomap/frontend/static/css/umap-floating-window.css
@@ -20,6 +20,7 @@
   padding: 4px;
   max-width: 100vw !important;
   max-height: 100vh !important;
+  padding-bottom: 20px;
 }
 
 #umapColorModeContainer {
@@ -116,3 +117,11 @@
 #umapColorModeContainer {
   font-size: 0.85em;
 }
+
+/* #umapHighlightSelection {
+  margin-bottom: 20px !important;
+}
+
+#umapColorModeContainer label:last-child {
+  padding-bottom: 10px;
+} */

--- a/photomap/frontend/templates/modules/umap-floating-window.html
+++ b/photomap/frontend/templates/modules/umap-floating-window.html
@@ -156,7 +156,7 @@
       <!-- Colorization Mode Controls (vertical column) -->
       <div
         id="umapColorModeContainer"
-        style="display: flex; flex-direction: column; margin-bottom: 12px"
+        style="display: flex; flex-direction: column; margin-bottom: 12px; padding-bottom:20px"
       >
         <label style="display: flex; align-items: center; gap: 8px">
           <input

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "photomapai"
-version = "0.7.0"
+version = "0.8.0"
 description = "AI-based image clustering and exploration tool"
 authors = [
     { name = "Lincoln Stein", email = "lincoln.stein@gmail.com" }


### PR DESCRIPTION
On the iPad, the floating umap window was just a tad too short, causing the bottom checkmark row to be partially cut off. This PR fixes the issue by adding 20px of bottom padding to the window.