### PR TITLE
[Docs] enable the code copy button on mkdocs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,11 +82,12 @@ To relaunch the server, run the `start_photomap` launcher again. For your conven
 
 ## PyPi  Installation
 
-If you are familiar with installing Python packages, here is a quick four line recipe:
+If you are familiar with installing Python packages, here is a quick recipe:
 
 ```bash
-pip -mvenv photomap --prompt photomap
+python -mvenv photomap --prompt photomap
 source photomap/bin/activate
+pip install --upgrade pip
 pip install photomapai
 start_photomap
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,8 @@ theme:
   name: material
   palette:
     scheme: slate
+  features:
+    -content.code.copy
 
 extra_css:
   - stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ development = [
     "build",
     "mkdocs-material",
     "twine",
+    "pymdown-extensions",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Simply enable the mkdocs Material theme feature of putting a copy code icon in the corner of code blocks.