### PR TITLE
[install] Fix the macintosh install script; bump version

### DIFF
--- a/INSTALL/install_linux_mac.sh
+++ b/INSTALL/install_linux_mac.sh
@@ -100,7 +100,7 @@ create_mac_launcher() {
     local install_path="$1"
     local desktop_dir="$HOME/Desktop"
     local app_dir="$desktop_dir/PhotoMap.app"
-    local repo_root="$(dirname "$0")/.."
+    local repo_root=.
     local icon_path="$repo_root/photomap/frontend/static/icons/favicon-32x32.icns"
 
     # Create app bundle structure

--- a/README.md
+++ b/README.md
@@ -93,11 +93,16 @@ Navigate to `http://localhost:8050` and follow the prompts to create and populat
 
 Download the PhotoMap source code as a .zip file from the latest stable [Releases page](https://github.com/lstein/PhotoMapAI/releases). For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMap home page.
 
-Choose a convenient location in your home directory and unzip the file to create a new folder named `PhotoMap`.
+Choose a convenient location in your home or downloads directory and unzip the file to create a new folder named `PhotoMap-X.X.X` (where X.X.X is the current release).
 
 #### 2. Run the installer script
 
-Navigate to the `PhotoMap` folder and launch the `install_linux_mac` shell script file. The script will check that Python and other requirements are installed, download the necessary library files, and create a launcher script named `start_photomap` on your desktop.
+Launch a command line shell ("Terminal" on the Mac) and navigate to the `PhotoMap-X.X.X` folder. Launch the `INSTALL/install_linux_mac.sh` shell script file. The script will check that Python and other requirements are installed, download the necessary library files, and create a launcher script named `start_photomap` on your desktop. If you are uncomfortable with the command line, here are the commands you need:
+
+```
+cd ~/Downloads/PhotoMap-X.X.X/INSTALL
+/bin/sh install_linux_mac.sh
+```
 
 #### 3. Start the server
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,11 +62,16 @@ To relaunch the server, run the `start_photomap` .bat script again. For your con
 
 Download the PhotoMapAI source code as a .zip file from the latest stable Releases page. For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMapAI home page.
 
-Choose a convenient location in your home directory and unzip the file to create a new folder named `PhotoMapAI`.
+Choose a convenient location in your Downloads directory and unzip the file to create a new folder named `PhotoMapAI-X.X.X`, where X.X.X is the current release number
 
 ### 2. Run the installer script
 
-Navigate to the `PhotoMapAI` folder and launch the `install_linux_mac` shell script file. The script will check that Python and other requirements are installed, download the necessary library files, and create a launcher script named `start_photomap` on your desktop.
+Launch a command-line shell ("Terminal" on the Mac) and navigate to the `PhotoMap-X.X.X` folder. Launch the `INSTALL/install_linux_mac.sh` shell script file. The script will check that Python and other requirements are installed, download the necessary library files, and create a launcher script named `start_photomap` on your desktop. If you are uncomfortable with the command line, here are the commands you need:
+
+```
+cd ~/Downloads/PhotoMap-X.X.X/INSTALL
+/bin/sh install_linux_mac.sh
+```
 
 ### 3. Start the server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "photomapai"
-version = "0.8.0"
+version = "0.8.1"
 description = "AI-based image clustering and exploration tool"
 authors = [
     { name = "Lincoln Stein", email = "lincoln.stein@gmail.com" }


### PR DESCRIPTION
This pull request updates documentation and installation scripts to improve clarity and consistency for users installing PhotoMapAI, and also bumps the project version. The main changes include updating installation instructions in the documentation, clarifying folder naming conventions, and incrementing the version number.

Documentation and installation instructions:

* Updated both `README.md` and `docs/installation.md` to clarify that users should unzip the downloaded release into a `PhotoMap-X.X.X` or `PhotoMapAI-X.X.X` folder (where `X.X.X` is the current version), and provided explicit command-line instructions for running the installer script. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L96-R105) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L65-R74)

Installer script adjustment:

* In `INSTALL/install_linux_mac.sh`, changed the `repo_root` variable to use the current directory (`.`) instead of a relative path, improving robustness when creating the Mac launcher.

Version bump:

* Updated the project version from `0.8.0` to `0.8.1` in `pyproject.toml` to reflect these changes.