### PR TITLE
[Feat] Better overlay drawer

### DIFF
--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -79,7 +79,7 @@ _ The *Previous slide* and *Next slide* buttons advance the images in the album 
 - The *Magnifier* button opens up a search dialogue that lets you search by image similarity and/or a text description of image content.
 - The "Clear search* button clears any search that is currently active and returns to album browsing mode.
 
-Finally, the inconspicuous tab with the yellow arrow on the left margin of the window opens a drawer that displays the image's EXIF date, including the date the photo was taken, GPS information (if available), and camera information.
+Finally, the yellow tab with the black arrow on the left margin of the window opens a drawer that displays the image's EXIF date, including the date the photo was taken, GPS information (if available), and camera information. Once you open the drawer up, you can drag it around by clicking on any of its edges. Click the black arrow again to return it to its home location and close it.
 
 ### Jumping Forward and Back
 

--- a/photomap/frontend/static/css/delete-modal.css
+++ b/photomap/frontend/static/css/delete-modal.css
@@ -1,0 +1,68 @@
+#deleteConfirmModal.modal {
+  position: fixed;
+  z-index: 9999;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#deleteConfirmModal .modal-content {
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 24px 32px;
+  border-radius: 12px;
+  min-width: 320px;
+  box-shadow: 0 2px 16px rgba(0,0,0,0.4);
+  font-family: inherit;
+}
+
+#deleteConfirmText {
+  color: #faea0e; /* Match the yellow from settings.css */
+  font-weight: bold;
+  margin-bottom: 1em;
+  white-space: pre-line;
+}
+
+#deleteDontAskAgain {
+  accent-color: #faea0e;
+}
+
+#deleteConfirmModal label {
+  color: #faea0e;
+  font-size: 1em;
+  font-weight: normal;
+}
+
+#deleteConfirmModal button {
+  background: #faea0e;
+  color: #000;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5em 1.2em;
+  font-size: 1em;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.15);
+}
+
+#deleteConfirmModal button:hover {
+  background: #fff700;
+  color: #222;
+}
+
+#deleteConfirmModal #deleteCancelBtn {
+  background: #333;
+  color: #fff;
+  border: 1px solid #faea0e;
+}
+
+#deleteConfirmModal #deleteCancelBtn:hover {
+  background: #222;
+  color: #faea0e;
+}

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -154,7 +154,7 @@
 .drawer-handle {
   width: 100%;
   height: 100%;
-  background: rgba(240, 209, 209, 0.5);
+  background: rgba(209, 209, 0, 0.5);
   clip-path: polygon(0% 0%, 80% 20%, 80% 80%, 0% 100%);
   display: flex;
   align-items: center;
@@ -168,9 +168,9 @@
   background: rgba(255, 255, 255, 0.6);
 }
 
-.banner-drawer-container.visible .drawer-handle {
+/* .banner-drawer-container.visible .drawer-handle {
   background: rgba(0, 0, 0, 0.5);
-}
+} */
 
 .drawer-arrow {
   transition: transform 0.3s ease;
@@ -179,8 +179,8 @@
   width: 48px;
   height: 48px;
   border-radius: 50%;
-  color: #faea0e;
-  fill: #faea0e;
+  color: black;
+  fill: black;
 }
 
 .banner-drawer-container.visible .drawer-arrow {

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -3,7 +3,7 @@
 .filename-banner {
   position: relative;
   width: 100%;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.75);
   color: #fff;
   padding: 1em 2em;
   box-sizing: border-box;

--- a/photomap/frontend/static/css/spinners.css
+++ b/photomap/frontend/static/css/spinners.css
@@ -6,7 +6,7 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 10000;
+  z-index: 100000;
   display: none;
 }
 

--- a/photomap/frontend/static/javascript/grid-view.js
+++ b/photomap/frontend/static/javascript/grid-view.js
@@ -131,8 +131,6 @@ export async function initializeGridSwiper() {
   updateCurrentSlide();
 
   gridInitialized = true;
-  hideSpinner();
-
   // For console debugging
   window.gridSwiper = state.swiper;
 }
@@ -308,10 +306,9 @@ function addDoubleTapHandler(slideEl, globalIndex) {
 async function resetAllSlides() {
   if (!gridInitialized) return;
   if (!state.swiper) return;
-
+  showSpinner();
   await waitForBatchLoadingToFinish();
   setBatchLoading(true);
-  showSpinner();
 
   const targetIndex = slideState.getCurrentIndex();
 
@@ -341,8 +338,8 @@ async function resetAllSlides() {
     await loadBatch(targetIndex, false); // Prepend a screen if not at start
   }
   updateCurrentSlide();
-  hideSpinner();
   setBatchLoading(false);
+  hideSpinner();
 }
 
 // Load a batch of slides starting at startIndex

--- a/photomap/frontend/static/javascript/metadata-drawer.js
+++ b/photomap/frontend/static/javascript/metadata-drawer.js
@@ -216,3 +216,108 @@ if (copyMetadataBtn && metadataTextArea) {
     }
   });
 }
+
+let isDraggingDrawer = false;
+let dragOffset = { x: 0, y: 0 };
+let originalPosition = { left: null, top: null };
+
+// Helper to get/set drawer position
+function setDrawerPosition(left, top) {
+  const container = document.getElementById("bannerDrawerContainer");
+  container.style.left = `${left}px`;
+  container.style.top = `${top}px`;
+  container.style.transform = "none";
+}
+
+function resetDrawerPosition() {
+  const container = document.getElementById("bannerDrawerContainer");
+  container.style.left = "";
+  container.style.top = "";
+  container.style.transform = ""; // Restore original transform
+}
+
+// Mouse/touch drag handlers
+function onDrawerMouseDown(e) {
+  // Only drag if background, not handle or children
+  if (
+    e.target.classList.contains("banner-drawer-container") ||
+    e.target.id === "filenameBanner" ||
+    e.target.classList.contains("filename-banner")
+  ) {
+    isDraggingDrawer = true;
+    const container = document.getElementById("bannerDrawerContainer");
+    const rect = container.getBoundingClientRect();
+    dragOffset.x = e.clientX - rect.left;
+    dragOffset.y = e.clientY - rect.top;
+    // Save original position for snapping back
+    originalPosition.left = rect.left;
+    originalPosition.top = rect.top;
+    document.body.style.userSelect = "none";
+  }
+}
+
+function onDrawerMouseMove(e) {
+  if (!isDraggingDrawer) return;
+  const left = e.clientX - dragOffset.x;
+  const top = e.clientY - dragOffset.y;
+  setDrawerPosition(left, top);
+}
+
+function onDrawerMouseUp() {
+  isDraggingDrawer = false;
+  document.body.style.userSelect = "";
+}
+
+// Touch support
+function onDrawerTouchStart(e) {
+  if (
+    e.target.classList.contains("banner-drawer-container") ||
+    e.target.id === "filenameBanner" ||
+    e.target.classList.contains("filename-banner")
+  ) {
+    isDraggingDrawer = true;
+    const container = document.getElementById("bannerDrawerContainer");
+    const rect = container.getBoundingClientRect();
+    const touch = e.touches[0];
+    dragOffset.x = touch.clientX - rect.left;
+    dragOffset.y = touch.clientY - rect.top;
+    originalPosition.left = rect.left;
+    originalPosition.top = rect.top;
+    document.body.style.userSelect = "none";
+  }
+}
+
+function onDrawerTouchMove(e) {
+  if (!isDraggingDrawer) return;
+  const touch = e.touches[0];
+  const left = touch.clientX - dragOffset.x;
+  const top = touch.clientY - dragOffset.y;
+  setDrawerPosition(left, top);
+}
+
+function onDrawerTouchEnd() {
+  isDraggingDrawer = false;
+  document.body.style.userSelect = "";
+}
+
+// Attach event listeners
+const drawer = document.getElementById("bannerDrawerContainer");
+if (drawer) {
+  drawer.addEventListener("mousedown", onDrawerMouseDown);
+  window.addEventListener("mousemove", onDrawerMouseMove);
+  window.addEventListener("mouseup", onDrawerMouseUp);
+
+  drawer.addEventListener("touchstart", onDrawerTouchStart, { passive: false });
+  window.addEventListener("touchmove", onDrawerTouchMove, { passive: false });
+  window.addEventListener("touchend", onDrawerTouchEnd);
+}
+
+// 2. Snap back when handle is clicked
+const handle = document.querySelector(".drawer-handle");
+if (handle) {
+  handle.addEventListener("click", () => {
+    resetDrawerPosition();
+    // Optionally, also close the drawer:
+    // hideMetadataOverlay();
+  });
+}

--- a/photomap/frontend/static/javascript/settings.js
+++ b/photomap/frontend/static/javascript/settings.js
@@ -307,3 +307,46 @@ async function initializeSettings() {
 // Initialize settings from the server and local storage
 document.addEventListener("DOMContentLoaded", initializeSettings);
 document.addEventListener("settingsUpdated", initializeSettings);
+
+// CSS styles
+const styles = `
+.setting-row {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  align-items: center;
+  gap: 1em;
+  margin-top: 1em;
+}
+
+.setting-row label {
+  font-size: 16px;
+  color: #faea0e;
+  text-align: right;
+  justify-self: end;
+  margin-bottom: 0;
+  white-space: nowrap;
+}
+
+.setting-row input[type="checkbox"],
+.setting-row input[type="password"],
+.setting-row select,
+.setting-row .album-selector-group {
+  justify-self: start;
+}
+
+.setting-row .album-selector-group {
+  display: flex;
+  gap: 0.5em;
+  align-items: center;
+}
+
+.setting-row small {
+  grid-column: 2 / 3;
+}
+`;
+
+// Append styles to the document
+const styleSheet = document.createElement("style");
+styleSheet.type = "text/css";
+styleSheet.innerText = styles;
+document.head.appendChild(styleSheet);

--- a/photomap/frontend/static/javascript/settings.js
+++ b/photomap/frontend/static/javascript/settings.js
@@ -25,7 +25,6 @@ function cacheElements() {
     settingsBtn: document.getElementById("settingsBtn"),
     settingsOverlay: document.getElementById("settingsOverlay"),
     closeSettingsBtn: document.getElementById("closeSettingsBtn"),
-    highWaterMarkInput: document.getElementById("highWaterMarkInput"),
     delayValueSpan: document.getElementById("delayValue"),
     modeRandom: document.getElementById("modeRandom"),
     modeChronological: document.getElementById("modeChronological"),
@@ -37,6 +36,7 @@ function cacheElements() {
     showControlPanelTextCheckbox: document.getElementById(
       "showControlPanelTextCheckbox"
     ),
+    confirmDeleteCheckbox: document.getElementById("confirmDeleteCheckbox"),
   };
 }
 
@@ -149,7 +149,6 @@ function toggleSettingsModal() {
 }
 
 async function populateModalFields() {
-  elements.highWaterMarkInput.value = state.highWaterMark;
   elements.delayValueSpan.textContent = state.currentDelay;
   if (elements.albumSelect)
     elements.albumSelect.value = state.album;
@@ -157,20 +156,11 @@ async function populateModalFields() {
   elements.modeChronological.checked = state.mode === "chronological";
   elements.showControlPanelTextCheckbox.checked = state.showControlPanelText;
 
-  await loadLocationIQApiKey();
-}
+  // Set the confirm delete checkbox state
+  if (elements.confirmDeleteCheckbox)
+    elements.confirmDeleteCheckbox.checked = !state.suppressDeleteConfirm;
 
-// Function to validate the high water mark
-function validateAndSetHighWaterMark(value) {
-  let newHighWaterMark = parseInt(value, 10);
-  if (isNaN(newHighWaterMark) || newHighWaterMark < WATERMARK_CONFIG.min) {
-    newHighWaterMark = WATERMARK_CONFIG.min;
-  }
-  if (newHighWaterMark > WATERMARK_CONFIG.max) {
-    newHighWaterMark = WATERMARK_CONFIG.max;
-  }
-  state.highWaterMark = newHighWaterMark;
-  saveSettingsToLocalStorage();
+  await loadLocationIQApiKey();
 }
 
 // Event listener setup
@@ -234,9 +224,11 @@ function setupAlbumSelector() {
   });
 }
 
-function setupHighWaterMarkControl() {
-  elements.highWaterMarkInput.addEventListener("input", function () {
-    validateAndSetHighWaterMark(this.value);
+function setupConfirmDeleteControl() {
+  if (!elements.confirmDeleteCheckbox) return;
+  elements.confirmDeleteCheckbox.addEventListener("change", function () {
+    state.suppressDeleteConfirm = !this.checked;
+    saveSettingsToLocalStorage();
   });
 }
 
@@ -308,8 +300,8 @@ async function initializeSettings() {
   setupModeControls();
   setupModalControls();
   setupAlbumSelector();
-  setupHighWaterMarkControl();
   setupLocationIQApiKeyControl();
+  setupConfirmDeleteControl();
 }
 
 // Initialize settings from the server and local storage

--- a/photomap/frontend/static/javascript/state.js
+++ b/photomap/frontend/static/javascript/state.js
@@ -16,6 +16,7 @@ export const state = {
   album: null, // Default album to use
   availableAlbums: [], // List of available albums
   dataChanged: true, // Flag to indicate if umap data has changed (TO DO - REVISIT THIS)
+  suppressDeleteConfirm: false,
 };
 
 document.addEventListener("DOMContentLoaded", async function () {
@@ -82,6 +83,11 @@ export async function restoreFromLocalStorage() {
   if (storedGridViewActive !== null) {
     state.gridViewActive = storedGridViewActive === "true";
   }
+
+  const storedSuppressDeleteConfirm = localStorage.getItem("suppressDeleteConfirm");
+  if (storedSuppressDeleteConfirm !== null) {
+    state.suppressDeleteConfirm = storedSuppressDeleteConfirm === "true";
+  }
 }
 
 // Save state to local storage
@@ -95,6 +101,7 @@ export function saveSettingsToLocalStorage() {
     state.showControlPanelText || ""
   );
   localStorage.setItem("gridViewActive", state.gridViewActive ? "true" : "false");
+  localStorage.setItem("suppressDeleteConfirm", state.suppressDeleteConfirm ? "true" : "false");
 }
 
 export async function setAlbum(newAlbumKey, force = false) {

--- a/photomap/frontend/templates/main.html
+++ b/photomap/frontend/templates/main.html
@@ -50,6 +50,7 @@
     <link rel="stylesheet" type="text/css" href="static/css/settings.css" />
     <link rel="stylesheet" type="text/css" href="static/css/album-manager.css" />
     <link rel="stylesheet" type="text/css" href="static/css/umap-floating-window.css" />
+    <link rel="stylesheet" type="text/css" href="static/css/delete-modal.css" />
     <link rel="stylesheet" type="text/css" href="static/css/about.css" />
 
     <script>
@@ -76,6 +77,7 @@
     {% include "modules/settings.html" %}
     {% include "modules/album-manager.html" %} 
     {% include "modules/metadata-modal.html" %}
+    {% include "modules/delete-modal.html" %}
     {% include "modules/about.html" %}
   </body>
 </html>

--- a/photomap/frontend/templates/modules/delete-modal.html
+++ b/photomap/frontend/templates/modules/delete-modal.html
@@ -1,0 +1,13 @@
+<div id="deleteConfirmModal" class="modal" style="display:none;">
+  <div class="modal-content">
+    <p id="deleteConfirmText"></p>
+    <label style="display: flex; align-items: center; gap: 8px; margin-top: 12px;">
+      <input type="checkbox" id="deleteDontAskAgain" />
+      Don't ask again
+    </label>
+    <div style="margin-top: 16px; display: flex; gap: 12px; justify-content: flex-end;">
+      <button id="deleteCancelBtn">Cancel</button>
+      <button id="deleteConfirmBtn">Delete</button>
+    </div>
+  </div>
+</div>

--- a/photomap/frontend/templates/modules/settings.html
+++ b/photomap/frontend/templates/modules/settings.html
@@ -56,48 +56,41 @@
     <!-- Row for control panel text visibility -->
     <div class="setting-row">
       <label for="showControlPanelTextCheckbox">Show Button Labels:</label>
-      <div class="setting-input-container">
-        <input type="checkbox" id="showControlPanelTextCheckbox" />
-      </div>
+      <input type="checkbox" id="showControlPanelTextCheckbox" />
     </div>
 
     <div class="setting-row">
       <label for="confirmDeleteCheckbox">Confirm before deleting images:</label>
-      <div class="setting-input-container">
-        <input type="checkbox" id="confirmDeleteCheckbox" />
-      </div>
+      <input type="checkbox" id="confirmDeleteCheckbox" />
     </div>
 
     <!-- Input for the LocationIQ API Key -->
     {% if not album_locked %}
     <div class="setting-row">
       <label for="locationiqApiKeyInput">LocationIQ Map API Key:</label>
-      <div class="setting-input-container">
-        <form id="locationiqApiKeyForm" autocomplete="off" style="margin: 0">
-          <input
-            type="password"
-            id="locationiqApiKeyInput"
-            placeholder="Enter your LocationIQ API key (optional)"
-            autocomplete="pk-xxxxxxxx"
-          />
-        </form>
-        <small
-          style="
-            color: #666;
-            font-size: 0.85em;
-            display: block;
-            margin-top: 4px;
-          "
+      <input
+        type="password"
+        id="locationiqApiKeyInput"
+        placeholder="Enter your LocationIQ API key (optional)"
+        autocomplete="pk-xxxxxxxx"
+      />
+      <small
+        style="
+          color: #666;
+          font-size: 0.85em;
+          display: block;
+          margin-top: 4px;
+          grid-column: 2 / 3;
+        "
+      >
+        Optional: Enables location names and maps in EXIF data.
+        <a
+          href="https://locationiq.com"
+          target="_blank"
+          style="color: #007bff"
+          >Get a free key</a
         >
-          Optional: Enables location names and maps in EXIF data.
-          <a
-            href="https://locationiq.com"
-            target="_blank"
-            style="color: #007bff"
-            >Get a free key</a
-          >
-        </small>
-      </div>
+      </small>
     </div>
     {% endif %}
 

--- a/photomap/frontend/templates/modules/settings.html
+++ b/photomap/frontend/templates/modules/settings.html
@@ -53,25 +53,18 @@
     </div>
 
     <!-- Settings rows -->
-    <div class="setting-row">
-      <label for="highWaterMarkInput">Max Images in History:</label>
-      <div class="setting-input-container">
-        <input
-          id="highWaterMarkInput"
-          type="number"
-          min="2"
-          max="100"
-          value="10"
-          autocomplete="nope"
-        />
-      </div>
-    </div>
-
     <!-- Row for control panel text visibility -->
     <div class="setting-row">
       <label for="showControlPanelTextCheckbox">Show Button Labels:</label>
       <div class="setting-input-container">
         <input type="checkbox" id="showControlPanelTextCheckbox" />
+      </div>
+    </div>
+
+    <div class="setting-row">
+      <label for="confirmDeleteCheckbox">Confirm before deleting images:</label>
+      <div class="setting-input-container">
+        <input type="checkbox" id="confirmDeleteCheckbox" />
       </div>
     </div>
 
@@ -108,7 +101,6 @@
     </div>
     {% endif %}
 
-        
     <!-- Album selection row -->
     {% if not album_locked %}
     <div class="setting-row">


### PR DESCRIPTION
This pull request enhances the usability and appearance of the metadata drawer in the photo album interface. The main improvements include making the drawer draggable, updating the user guide to reflect this new functionality, and refining the drawer's visual styling for clarity and consistency.

**User interaction improvements:**

* Added drag-and-drop functionality to the metadata drawer, allowing users to move it around the screen by clicking and dragging its edges. The drawer snaps back to its original position when the handle (black arrow) is clicked. This includes both mouse and touch support. (`photomap/frontend/static/javascript/metadata-drawer.js`)
* Updated the user guide to explain the new draggable behavior and how to return the drawer to its home location. (`docs/user-guide/basic-usage.md`)

**Visual and style updates:**

* Changed the drawer handle background to a yellow color with partial transparency for better visibility, and updated the arrow icon color to black for improved contrast. (`photomap/frontend/static/css/metadata-drawer.css`) [[1]](diffhunk://#diff-27c3cd2d44cf8f32b5d1ac19d469332753b63af6eac6dc41aab3aaa6536903baL157-R157) [[2]](diffhunk://#diff-27c3cd2d44cf8f32b5d1ac19d469332753b63af6eac6dc41aab3aaa6536903baL182-R183)
* Increased the opacity of the filename banner background for improved readability. (`photomap/frontend/static/css/metadata-drawer.css`)
* Commented out an unused style rule for the visible drawer handle background to avoid conflicting styles. (`photomap/frontend/static/css/metadata-drawer.css`)