### PR TITLE
[bugfix] Fix issues with indexer

### DIFF
--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -43,10 +43,10 @@ class Album(BaseModel):
     @classmethod
     def validate_index_path(cls, v: str) -> str:
         """Validate index path format."""
-        index_path = Path(v)
+        index_path = Path(v).expanduser()
         if not index_path.suffix == ".npz":
             raise ValueError("Index file must have .npz extension")
-        return v
+        return index_path.as_posix()
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert album to dictionary format for YAML."""

--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -312,6 +312,7 @@ class Embeddings(BaseModel):
     def _save_embeddings(self, index_result: IndexResult) -> None:
         """Save embeddings to disk and clear cache."""
         # Ensure directory exists
+        logger.info(f"Saving embeddings to {self.embeddings_path}")
         self.embeddings_path.parent.mkdir(parents=True, exist_ok=True)
         np.savez(
             self.embeddings_path,
@@ -417,6 +418,7 @@ class Embeddings(BaseModel):
         total_images = len(image_paths)
         progress_callback = tqdm_progress_callback(total_images)
 
+        logger.info(f"Creating index {self.embeddings_path}...")
         self.embeddings_path.parent.mkdir(parents=True, exist_ok=True)
         result = self._process_images_batch(
             image_paths, progress_callback=progress_callback

--- a/photomap/frontend/static/javascript/album.js
+++ b/photomap/frontend/static/javascript/album.js
@@ -919,7 +919,7 @@ export class AlbumManager {
       setTimeout(async () => {
         const album = await this.getCurrentAlbum(albumKey);
         this.updateAlbumCardIndexStatus(cardElement, album);
-      }, 5000);
+      }, 2000);
     }
 
     // If in setup mode, set the album and exit setup mode
@@ -929,11 +929,18 @@ export class AlbumManager {
       this.enableClosing();
       this.removeSetupMessage();
       // Now close the album manager window after a short delay
-      setTimeout(() => {
+      setTimeout(async () => {
         this.completeSetupMode();
         this.hide();
         // send the albumChanged message
-        window.dispatchEvent(new Event("albumChanged"));
+        const album = await getIndexMetadata(albumKey);
+        window.dispatchEvent(
+          new CustomEvent("albumChanged", {
+            detail: {
+              totalImages: album ? album.filename_count : 0,
+            },
+          })
+        );
       }, AlbumManager.AUTO_INDEX_DELAY);
     }
 
@@ -954,6 +961,16 @@ export class AlbumManager {
       if (errorDiv) {
         errorDiv.remove();
       }
+    }
+    if (albumKey === state.album) {
+      const album = await getIndexMetadata(albumKey);
+      window.dispatchEvent(
+        new CustomEvent("albumChanged", {
+          detail: {
+            totalImages: album ? album.filename_count : 0,
+          },
+        })
+      );
     }
   }
 


### PR DESCRIPTION
This pull request fixes a bad bug in which the path "~" was being passed through literally to the indexer, causing the creation of a spurious directory named "~". It also improves the behavior of the slideshow when indexing is performed on an existing album.

**Backend improvements:**

* Path handling and validation:
  - The `validate_index_path` method in `photomap/backend/config.py` now expands user home directories in file paths and returns the path in POSIX format, ensuring more robust and consistent path handling.

* Logging and embedding management:
  - Added logging to indicate when embeddings are being saved and when an index is being created in `photomap/backend/embeddings.py`, improving traceability of backend operations. [[1]](diffhunk://#diff-c07c18205985fd8860789e8a5ee7cb1fa8dcd1520db6d622ea32670db5f33bb5R315) [[2]](diffhunk://#diff-c07c18205985fd8860789e8a5ee7cb1fa8dcd1520db6d622ea32670db5f33bb5R421)

**Frontend improvements:**

* Album change event handling:
  - The frontend now dispatches a `CustomEvent` for `albumChanged` with the total number of images in the album as part of the event detail, providing more precise information to listeners. This is done both after setup completion and when updating the album card index status. [[1]](diffhunk://#diff-401185f6f1ad18ed22031e699c14f85343d68dcef7d7a8749790ab2b68e4f8cfL932-R943) [[2]](diffhunk://#diff-401185f6f1ad18ed22031e699c14f85343d68dcef7d7a8749790ab2b68e4f8cfR965-R974)

* User experience tweaks:
  - Reduced the delay for updating the album card index status from 5 seconds to 2 seconds, making the UI more responsive.