### PR TITLE
[bugfix] Remove trash and confirm delete checkbox when album-locked

### DIFF
--- a/photomap/frontend/templates/modules/control-panel.html
+++ b/photomap/frontend/templates/modules/control-panel.html
@@ -50,6 +50,7 @@
       </button>
       <div class="button-label">Settings</div>
     </div>
+    {% if not album_locked %}
     <div class="control-icon-container">
       <button id="deleteCurrentFileBtn" title="Delete image">
         <svg
@@ -72,6 +73,7 @@
       </button>
       <div class="button-label">Delete</div>
     </div>
+    {% endif %}
     <div class="control-icon-container">
       <button id="fullscreenBtn" title="Fullscreen">
         <svg width="32" height="32" viewBox="0 0 24 24" fill="#fff">

--- a/photomap/frontend/templates/modules/settings.html
+++ b/photomap/frontend/templates/modules/settings.html
@@ -71,10 +71,13 @@
       <input type="checkbox" id="showControlPanelTextCheckbox" />
     </div>
 
+    {% if not album_locked %}
     <div class="setting-row">
       <label for="confirmDeleteCheckbox">Confirm before deleting images:</label>
       <input type="checkbox" id="confirmDeleteCheckbox" />
     </div>
+    {% endif %}
+
 
     <!-- Input for the LocationIQ API Key -->
     {% if not album_locked %}


### PR DESCRIPTION
When --album-locked set at startup, do not display the trash icon or the checkbox related to confirming deletions.