### PR TITLE
[release] Split deployments into two actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,12 @@
+name: Deploy to PyPI and DockerHub
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pypi-deploy:
+    uses: ./.github/workflows/pypi.yml
+
+  dockerhub-deploy:
+    needs: pypi
+    uses: ./.github/workflows/dockerhub.yml

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,0 +1,50 @@
+name: Deploy To DockerHub
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  dockerhub-deploy:
+    runs-on: ubuntu-latest
+    environment: dockerhub
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Extract version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(python -c "
+          try:
+              import tomllib
+              with open('pyproject.toml', 'rb') as f:
+                  data = tomllib.load(f)
+              print(data['project']['version'])
+          except Exception as e:
+              print(f'Error reading version: {e}', file=sys.stderr)
+              exit(1)
+          ")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/photomapai:${{ steps.get_version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/photomapai:latest

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,10 +1,11 @@
-name: Release to PyPi & DockerHub
+name: Release to PyPi
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 jobs:
-  release:
+  pypi-deploy:
     runs-on: ubuntu-latest
     environment: pypi
 
@@ -24,7 +25,16 @@ jobs:
       - name: Extract version from pyproject.toml
         id: get_version
         run: |
-          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          VERSION=$(python -c "
+          try:
+              import tomllib
+              with open('pyproject.toml', 'rb') as f:
+                  data = tomllib.load(f)
+              print(data['project']['version'])
+          except Exception as e:
+              print(f'Error reading version: {e}', file=sys.stderr)
+              exit(1)
+          ")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Tag the release
@@ -51,26 +61,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://upload.pypi.org/legacy/
-        # env:
-        #   TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Log in to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build Docker image
-        run: |
-          VERSION=${{ steps.get_version.outputs.version }}
-          docker build -f docker/Dockerfile -t ${{ secrets.DOCKERHUB_USERNAME }}/photomapai:${VERSION} .
-          docker tag ${{ secrets.DOCKERHUB_USERNAME }}/photomapai:${VERSION} ${{ secrets.DOCKERHUB_USERNAME }}/photomapai:latest
-
-      - name: Push Docker image (versioned)
-        run: |
-          VERSION=${{ steps.get_version.outputs.version }}
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/photomapai:${VERSION}
-
-      - name: Push Docker image (latest)
-        run: |
-          docker push ${{ secrets.DOCKERHUB_USERNAME }}/photomapai:latest


### PR DESCRIPTION
This pull request refactors the release workflow to separate PyPI and DockerHub deployments into distinct GitHub Actions workflows. The PyPI deployment is now handled in its own workflow, while DockerHub deployment has been moved to a dedicated workflow that can be triggered independently or as part of a coordinated deploy. Additionally, the process for extracting the project version from `pyproject.toml` has been improved for better error handling.

**CI/CD Workflow Refactoring:**

* Introduced a new `.github/workflows/deploy.yml` workflow to coordinate deployments to both PyPI and DockerHub, using workflow dispatch and reusable workflow calls.
* Split DockerHub deployment into its own workflow file `.github/workflows/dockerhub.yml`, with improved steps for version extraction, Docker login, and image build/push.
* Renamed `.github/workflows/release.yml` to `.github/workflows/pypi.yml` and updated it to handle only the PyPI deployment, removing all DockerHub-related steps. [[1]](diffhunk://#diff-1baea138c19b06c7531655c5e977dbbcca5bd9147709625e2ee40984905502c5L1-R8) [[2]](diffhunk://#diff-1baea138c19b06c7531655c5e977dbbcca5bd9147709625e2ee40984905502c5L54-L76)

**Process Improvements:**

* Enhanced the version extraction command in both the PyPI and DockerHub workflows to provide error handling and clearer failure messages if the version cannot be read from `pyproject.toml`. [[1]](diffhunk://#diff-1baea138c19b06c7531655c5e977dbbcca5bd9147709625e2ee40984905502c5L27-R37) [[2]](diffhunk://#diff-79be07d4634c4c8e630c58e010635d3621a19f63e92861570af1570120df38b6R1-R50)