### PR TITLE
[feature] Highlight unclustered images on umap

### DIFF
--- a/photomap/frontend/static/javascript/score-display.js
+++ b/photomap/frontend/static/javascript/score-display.js
@@ -38,7 +38,6 @@ export class ScoreDisplay {
   }
 
   showCluster(cluster, color, index = null, total = null) {
-      console.log("Showing cluster:", cluster, color, index, total);
     if (cluster !== undefined && cluster !== null) {
       let text = (cluster === "unclustered") ? "unclustered images" : `cluster ${cluster}`;
       if (index !== null && total !== null) {

--- a/photomap/frontend/static/javascript/score-display.js
+++ b/photomap/frontend/static/javascript/score-display.js
@@ -38,8 +38,9 @@ export class ScoreDisplay {
   }
 
   showCluster(cluster, color, index = null, total = null) {
+      console.log("Showing cluster:", cluster, color, index, total);
     if (cluster !== undefined && cluster !== null) {
-      let text = (cluster === "unclustered") ? "unclustered image" : `cluster ${cluster}`;
+      let text = (cluster === "unclustered") ? "unclustered images" : `cluster ${cluster}`;
       if (index !== null && total !== null) {
         text += ` (${index}/${total})`;
       }

--- a/photomap/frontend/static/javascript/score-display.js
+++ b/photomap/frontend/static/javascript/score-display.js
@@ -39,7 +39,7 @@ export class ScoreDisplay {
 
   showCluster(cluster, color, index = null, total = null) {
     if (cluster !== undefined && cluster !== null) {
-      let text = `cluster ${cluster}`;
+      let text = (cluster === "unclustered") ? "unclustered image" : `cluster ${cluster}`;
       if (index !== null && total !== null) {
         text += ` (${index}/${total})`;
       }


### PR DESCRIPTION
When an unclustered image is selected, all unclustered images will be highlighted, consistent with behavior of other clusters.
This pull request updates the cluster and UMAP visualization logic in the frontend, focusing on improving the handling and display of unclustered images, simplifying cluster color logic, and refining marker opacity for better visual clarity. The most important changes are grouped below.

**Cluster Handling and Display:**

* The `ScoreDisplay` class now displays "unclustered images" instead of a cluster number for unclustered points, making the UI clearer for users when viewing unclustered data.
* When building cluster member objects, the cluster label for unclustered points is now consistently set to `"unclustered"` (lowercase), standardizing the terminology across the application.

**Cluster Color and Selection Logic:**

* Cluster color assignment in `handleClusterClick` is now always determined by the `getClusterColor` function, simplifying and unifying the color logic for clusters.

**UMAP Interaction and Visualization:**

* The selection event handler (`plotly_selected`) was removed, so selecting points on the UMAP plot no longer triggers a `searchResultsChanged` event. This may affect how cluster selections are communicated elsewhere in the app.
* Marker opacity (`markerAlphas`) for unclustered points is now set to `0.25` (previously `0.1`) for better visibility, and the logic for highlighting search results was simplified to only highlight selected points, regardless of cluster.

**Event Handling:**

* The `plotly_redraw` event handler now accepts the event data parameter, aligning its signature with other Plotly event handlers and potentially enabling future use of event data.