### PR TITLE
[bugfix] Add checks to prevent slides from updating during grid to swiper transition

### DIFF
--- a/photomap/frontend/static/javascript/slide-state.js
+++ b/photomap/frontend/static/javascript/slide-state.js
@@ -261,6 +261,7 @@ class SlideStateManager {
   }
 
   seekToSlideIndex() {
+    console.log("Sending seekToSlideIndex event")
     const slideInfo = this.getCurrentSlide();
     window.dispatchEvent(
       new CustomEvent("seekToSlideIndex", {

--- a/photomap/frontend/static/javascript/state.js
+++ b/photomap/frontend/static/javascript/state.js
@@ -18,6 +18,7 @@ export const state = {
   dataChanged: true, // Flag to indicate if umap data has changed (TO DO - REVISIT THIS)
   suppressDeleteConfirm: false,
   gridThumbSizeFactor: 1.0,
+  isTransitioning: false, // Flag set when transitioning from grid->swiper view
 };
 
 document.addEventListener("DOMContentLoaded", async function () {

--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -306,6 +306,7 @@ export async function addSlideByIndex(
   prepend = false
 ) {
   if (!state.swiper) return;
+  if (state.isTransitioning) return; // Prevent adding slides during transitions
 
   // pick a random slide if settings.mode is random
   if (state.mode === "random" && !slideState.isSearchMode) {
@@ -475,6 +476,7 @@ export function enforceHighWaterMark(backward = false) {
   const maxSlides = state.highWaterMark || 50;
   const swiper = state.swiper;
   const slides = swiper.slides.length;
+  if (state.isTransitioning) return; // don't trim while transitioning
 
   if (slides > maxSlides) {
     let slideShowRunning = swiper.autoplay.running;


### PR DESCRIPTION
This pull request introduces improvements to the grid/swiper view transitions in the photo map frontend, focusing on preventing race conditions and ensuring smoother user interactions. The main change is the introduction and consistent use of an `isTransitioning` flag in the global `state` object to block navigation and slide modifications during view transitions and batch loading. This helps avoid issues where events or asynchronous operations could interfere with each other, especially during rapid user actions.

**Transition and event handling improvements:**

* Added an `isTransitioning` flag to the global `state` object to indicate when a grid/swiper view transition is in progress, and used this flag to block navigation, slide additions, and batch loading during transitions in both `events.js`, `grid-view.js`, and `swiper.js`. [[1]](diffhunk://#diff-80f8e26d08e34ff4c23a15a496d0ea638165d4c0e0487679ca1514f535b529d7R21) [[2]](diffhunk://#diff-e5cd947ec04d58ea3157d576075b4b2348a7bca707a35733110c9ab76cf42646R482-R517) [[3]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117R294-R296) [[4]](diffhunk://#diff-4eca1c715150188c4a8aa9ebd6442035d55df3a9fb20c0bfde3ff0975c4a999aR309)
* Updated event listeners and batch loading logic in `grid-view.js` to await batch loading completion and prevent double execution or race conditions by checking and setting the `isTransitioning` flag. [[1]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117R208-R211) [[2]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117L222-R234) [[3]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117L237-R243)
* Modified batch loading and slide trimming functions to early return if a transition is in progress, ensuring no changes are made to slides during transitions. [[1]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117R426) [[2]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117R466) [[3]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117R496) [[4]](diffhunk://#diff-4eca1c715150188c4a8aa9ebd6442035d55df3a9fb20c0bfde3ff0975c4a999aR479)

**Code consistency and bug fixes:**

* Fixed a typo in the event name for loading more slides at the start of the grid view (`slidePrevTransitionStas.seart` → `slidePrevTransitionStart`).
* Updated event handlers and listeners to consistently use `async`/`await` for functions that perform asynchronous operations, including toggling views and handling button clicks.

**Utility and debugging enhancements:**

* Imported the new `waitForBatchLoadingToFinish` utility function and integrated it into view transition logic to ensure all batch loading is complete before proceeding.
* Added a debug log statement in `seekToSlideIndex` to track when slide seek events are dispatched.