### PR TITLE
[Bugfix] Fix pyinstallers

### DIFF
--- a/.github/workflows/deploy-pyinstaller.yml
+++ b/.github/workflows/deploy-pyinstaller.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         torch_variant: [cpu, cu129]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             platform: linux-x64
             build_script: ./INSTALL/pyinstaller/make_pyinstaller_image.sh
             executable_ext: ""

--- a/.github/workflows/deploy-pyinstaller.yml
+++ b/.github/workflows/deploy-pyinstaller.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         torch_variant: [cpu, cu129]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             platform: linux-x64
             build_script: ./INSTALL/pyinstaller/make_pyinstaller_image.sh
             executable_ext: ""

--- a/INSTALL/pyinstaller/make_pyinstaller_image.ps1
+++ b/INSTALL/pyinstaller/make_pyinstaller_image.ps1
@@ -31,11 +31,14 @@ switch ($TorchVariant) {
 }
 
 # Set PyInstaller mode based on torch variant
-if ($TorchVariant -eq "cpu") {
-    $pyinstallerMode = "--onefile"
-} else {
-    $pyinstallerMode = "--onedir"
-}
+# if ($TorchVariant -eq "cpu") {
+#     $pyinstallerMode = "--onefile"
+# } else {
+#     $pyinstallerMode = "--onedir"
+# }
+
+# --onefile has too many problems with large packages like torch!
+$pyinstallerMode = "--onedir"
 
 # Upgrade build tools and hooks
 python -m pip install -U pip wheel setuptools

--- a/INSTALL/pyinstaller/make_pyinstaller_image.sh
+++ b/INSTALL/pyinstaller/make_pyinstaller_image.sh
@@ -35,8 +35,9 @@ fi
 # Set PyInstaller mode based on torch variant and platform
 if [[ "$MACOS_APP" == true ]]; then
     PYINSTALLER_MODE="--windowed"
-elif [[ "$TORCH_VARIANT" == cpu ]]; then
-    PYINSTALLER_MODE="--onefile"
+# always use --onedir for CPU builds to avoid startup issues
+# elif [[ "$TORCH_VARIANT" == cpu ]]; then
+#     PYINSTALLER_MODE="--onefile"
 else
     PYINSTALLER_MODE="--onedir"
 fi

--- a/INSTALL/pyinstaller/make_pyinstaller_image.sh
+++ b/INSTALL/pyinstaller/make_pyinstaller_image.sh
@@ -140,7 +140,8 @@ if [[ "$MACOS_APP" == true ]]; then
     LAUNCHER="$MACOS_DIR/run_in_terminal.sh"
     cat > "$LAUNCHER" <<EOF
 #!/bin/bash
-exec osascript -e 'tell application "Terminal" to do script "'"$MACOS_DIR/$BIN_NAME"'"'
+PWD=$(dirname "$0")
+exec osascript -e 'tell application "Terminal" to do script "'"$PWD/$BIN_NAME"'"'
 EOF
     chmod +x "$LAUNCHER"
 


### PR DESCRIPTION
This pull request updates the PyInstaller build scripts to consistently use the `--onedir` mode for all builds, including CPU variants, to address issues with large packages like torch. It also improves the macOS launcher script to reliably locate the binary using its directory path.

Build process improvements:

* [`INSTALL/pyinstaller/make_pyinstaller_image.ps1`](diffhunk://#diff-3221a3a8cffc07743c245b480b09482da7a80f0dfb08a30d593a8006506d8739L34-L38): Changed logic to always use `--onedir` mode for PyInstaller builds, regardless of the torch variant, due to problems with `--onefile` and large packages.
* [`INSTALL/pyinstaller/make_pyinstaller_image.sh`](diffhunk://#diff-8d369fde9a98f777fc44920a6262f7407e279bd9b048594bb23df15ee9e42238L38-R40): Updated to always use `--onedir` for CPU builds, commenting out previous logic that used `--onefile` for CPUs.

macOS launcher reliability:

* [`INSTALL/pyinstaller/make_pyinstaller_image.sh`](diffhunk://#diff-8d369fde9a98f777fc44920a6262f7407e279bd9b048594bb23df15ee9e42238L143-R145): Modified the macOS launcher script to use the directory of the script (`$PWD`) when launching the binary, ensuring correct path resolution.