### PR TITLE
[Deploy] Put the artifact upload step into its own action file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,17 +52,4 @@ jobs:
 
   upload-release:
     needs: [deploy-pypi, deploy-dockerhub, deploy-pyinstaller]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Upload to release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            artifacts/**/*.{zip,tar.gz,app}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/upload-artifacts.yml

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -1,0 +1,24 @@
+name: Upload Release Artifacts
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+jobs:
+  upload-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List downloaded artifacts
+        run: ls -lR artifacts
+
+      - name: Upload artifacts to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request refactors the workflow for uploading release artifacts by moving the upload logic to a reusable workflow file. The main change is to improve maintainability and reusability of the GitHub Actions configuration by centralizing the artifact upload process.

Workflow refactoring:

* The `upload-release` job in `.github/workflows/deploy.yml` now uses the reusable workflow `.github/workflows/upload-artifacts.yml`, replacing the inline steps for downloading and uploading artifacts.
* Added a new workflow file `.github/workflows/upload-artifacts.yml` that defines the steps for downloading artifacts, listing them, and uploading them to the GitHub Release. This workflow supports both `workflow_call` and `workflow_dispatch` triggers for flexibility.