### PR TITLE
[Deploy] Refactor upload artifacts

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -2,8 +2,6 @@ name: Upload Release Artifacts
 
 on:
     workflow_call:
-    workflow_dispatch:
-
 jobs:
   upload-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove workflow_dispatch from the upload action. Won't work unless part of the release workflow.