### PR TITLE
[docker] Add command-line option to disable inline version upgrading

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,4 +19,5 @@ EXPOSE 8050
 
 # Start the server
 ENTRYPOINT ["python3", "-mphotomap.backend.photomap_server"]
-CMD ["--host", "0.0.0.0", "--port", "8050"]
+# Do not respawn the server after it exits. Do not allow inline upgrades into the docker image.
+CMD ["--host", "0.0.0.0", "--port", "8050", "--once", "--no-inline-upgrade"]

--- a/docker/Dockerfile.demo
+++ b/docker/Dockerfile.demo
@@ -21,4 +21,5 @@ EXPOSE 8050
 
 # Start the server
 ENTRYPOINT ["python3", "-mphotomap.backend.photomap_server"]
-CMD ["--host", "0.0.0.0", "--port", "8050", "--album-lock", "demo"]
+# Do not respawn the server after it exits. Do not allow inline upgrades into the docker image.
+CMD ["--host", "0.0.0.0", "--port", "8050", "--album-lock", "demo", "--once", "--no-inline-upgrade"]

--- a/photomap/backend/args.py
+++ b/photomap/backend/args.py
@@ -3,8 +3,8 @@ Return parsed command-line arguments
 """
 
 import argparse
-from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 
 def get_version():
@@ -13,6 +13,7 @@ def get_version():
         return version("photomapai")
     except PackageNotFoundError:
         return "unknown"
+
 
 def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the PhotoMap slideshow server.")
@@ -64,8 +65,12 @@ def get_args() -> argparse.Namespace:
         help="Show the version number and exit",
     )
     parser.add_argument(
-        "--once",
-        action="store_true",
-        help="Run server once; do not respawn"
+        "--once", action="store_true", help="Run server once; do not respawn"
+    )
+    parser.add_argument(
+        "--inline-upgrade",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Perform inline database upgrades",
     )
     return parser.parse_args()

--- a/photomap/frontend/templates/modules/about.html
+++ b/photomap/frontend/templates/modules/about.html
@@ -27,3 +27,8 @@
     </div>
   </div>
 </div>
+
+{% if inline_upgrades_allowed %}
+<div id="inline-upgrades-allowed"></div>
+{% endif %}
+


### PR DESCRIPTION
Because inline upgrading is probably a bad idea when running in a dockerfile, this PR adds a command-line option `--no-inline-upgrade` that inhibits display of the upgrade button.

This option is now passed to the docker image build.