### PR TITLE
[bugfix] add logic to handle rotation events that occur when grid view not active

### DIFF
--- a/photomap/frontend/static/javascript/events.js
+++ b/photomap/frontend/static/javascript/events.js
@@ -510,7 +510,7 @@ export async function toggleGridSwiperView(gridView = null) {
     gridContainer.style.opacity = "0";
     await new Promise((resolve) => requestAnimationFrame(resolve));
     gridContainer.style.opacity = "1";
-    state.grid_swiper.resetAllSlides();
+    state.grid_swiper.resetOrInitialize();
   } else {
     // Fade out grid view
     gridContainer.classList.add("fade-out");

--- a/photomap/frontend/templates/main.html
+++ b/photomap/frontend/templates/main.html
@@ -5,7 +5,8 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      {# content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes" #}
     />
     <link rel="icon" type="image/x-icon" href="static/icons/favicon.ico" />
     <link


### PR DESCRIPTION
This pull request introduces improvements to the grid view management logic in the photomap frontend, focusing on better handling of grid geometry changes and swiper initialization. The main changes include adding a new method to detect and respond to grid geometry changes, refactoring the swiper reset logic, and updating the HTML viewport settings for improved mobile compatibility.

**Grid view logic improvements:**

* Added a `gridGeometryChanged` method to `GridViewManager` to encapsulate logic for detecting changes in grid geometry, such as rows, columns, or tile size.
* Introduced a new `resetOrInitialize` method in `GridViewManager` that either resets all slides or re-initializes the swiper based on whether the grid geometry has changed. This method replaces the previous `resetAllSlides` call in the grid view toggle logic. [[1]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117R319-R327) [[2]](diffhunk://#diff-e5cd947ec04d58ea3157d576075b4b2348a7bca707a35733110c9ab76cf42646L513-R513)
* Refactored the grid resize handler to use the new `gridGeometryChanged` method and updated the sequence of operations for handling grid resizing, improving reliability and code clarity.

**Codebase and debugging enhancements:**

* Added debugging output for `slidesPerBatch` to aid in development and troubleshooting.
* Removed commented-out navigation configuration from the swiper initialization for cleaner code.

**Frontend compatibility:**

* Updated the HTML viewport meta tag to restrict zooming and improve mobile usability by setting `maximum-scale=1.0` and `user-scalable=no`.