### PR TITLE
[feature] Add timestamps to both internal log entries and uvicorn's

### DIFF
--- a/photomap/backend/__init__.py
+++ b/photomap/backend/__init__.py
@@ -24,7 +24,9 @@ class UvicornStyleFormatter(logging.Formatter):
         return super().format(record)
 
 
-formatter = UvicornStyleFormatter("%(levelname)s:%(uvicorn_pad)s%(message)s")
+formatter = UvicornStyleFormatter(
+    "%(asctime)s %(levelname)s:%(uvicorn_pad)s%(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+)
 
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -36,7 +36,7 @@ class Album(BaseModel):
         expanded = [str(Path(path).expanduser()) for path in v]
         for path in expanded:
             if not Path(path).exists():
-                print(f"Warning: Image path does not exist: {path}")
+                logger.warn(f"Image path does not exist: {path}")
         return expanded
 
     @field_validator("index")

--- a/photomap/backend/photomap_server.py
+++ b/photomap/backend/photomap_server.py
@@ -112,6 +112,41 @@ def start_photomap_loop():
                 logger.error(f"Server exited with error code {e.returncode}")
 
 
+# Set up Uvicorn Logging
+def uvicorn_logging():
+    return {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "default": {
+                "()": "photomap.backend.UvicornStyleFormatter",
+                "fmt": "%(asctime)s %(levelname)s:%(uvicorn_pad)s%(message)s",
+                "datefmt": "%Y-%m-%d %H:%M:%S",
+            },
+        },
+        "handlers": {
+            "default": {
+                "formatter": "default",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stderr",
+            },
+        },
+        "loggers": {
+            "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": False},
+            "uvicorn.error": {
+                "handlers": ["default"],
+                "level": "INFO",
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "handlers": ["default"],
+                "level": "INFO",
+                "propagate": False,
+            },
+        },
+    }
+
+
 # Main Entry Point
 def main():
     """Main entry point for the slideshow server."""
@@ -153,6 +188,7 @@ def main():
         ssl_keyfile=str(args.key) if args.key else None,
         ssl_certfile=str(args.cert) if args.cert else None,
         log_level="info",
+        log_config=uvicorn_logging(),
     )
 
 


### PR DESCRIPTION
This pull request updates logging throughout the backend to improve consistency and readability, especially for Uvicorn logs. The main changes include introducing a custom logging configuration for Uvicorn, updating log message formatting to include timestamps, and switching from print statements to proper logger usage for warnings.

**Logging improvements:**

* Added a custom `uvicorn_logging` function in `photomap/backend/photomap_server.py` to define a logging configuration for Uvicorn, ensuring consistent formatting and log levels.
* Updated the Uvicorn log formatter in `photomap/backend/__init__.py` to include timestamps and a custom date format for clearer log entries.
* Modified the server startup in `photomap/backend/photomap_server.py` to use the new Uvicorn logging configuration by passing it to the server initialization.

**Codebase consistency:**

* Replaced a print statement with a logger warning in `photomap/backend/config.py` for missing image paths, ensuring all warnings use the logging system.