### PR TITLE
[bugfix] Prevent navigation buttons fighting over the same swiper

### DIFF
--- a/photomap/frontend/static/javascript/grid-view.js
+++ b/photomap/frontend/static/javascript/grid-view.js
@@ -108,8 +108,8 @@ class GridViewManager {
       },
       spaceBetween: 6,
       navigation: {
-        prevEl: ".swiper-button-prev",
-        nextEl: ".swiper-button-next",
+        prevEl: "#gridSwiperPrevButton",
+        nextEl: "#gridSwiperNextButton",
       },
       mousewheel: {
         enabled: true,

--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -51,8 +51,8 @@ class SwiperManager {
       slidesPerView: 1,
       spaceBetween: 0,
       navigation: {
-        prevEl: ".swiper-button-prev",
-        nextEl: ".swiper-button-next",
+        prevEl: "#singleSwiperPrevButton",
+        nextEl: "#singleSwiperNextButton",
       },
       autoplay: {
         delay: state.currentDelay * 1000,

--- a/photomap/frontend/templates/main.html
+++ b/photomap/frontend/templates/main.html
@@ -87,13 +87,15 @@
 
 <div id="singleSwiperContainer">
      {% include "modules/swiper.html" %} 
+     <div class="swiper-button-prev" id="singleSwiperPrevButton"></div>
+     <div class="swiper-button-next" id="singleSwiperNextButton"></div>
 </div>
 
 <div id="gridViewContainer">
       {% include "modules/grid-view.html" %}
+      <div class="swiper-button-prev" id="gridSwiperPrevButton"></div>
+      <div class="swiper-button-next" id="gridSwiperNextButton"></div>
 </div>
-<div class="swiper-button-prev" id="swiperPrevButton"></div>
-<div class="swiper-button-next" id="swiperNextButton"></div>
 
     {% include "modules/metadata-drawer.html" %}
     <div id="panelStackContainer">


### PR DESCRIPTION
This pull request updates how navigation buttons are managed for the Swiper components in both the single image and grid views. The main improvement is assigning unique IDs to the navigation buttons for each Swiper instance, which clarifies their association and prevents potential conflicts when multiple Swipers are used on the same page.

**Navigation button updates:**

* Changed the Swiper navigation configuration in `grid-view.js` to use `#gridSwiperPrevButton` and `#gridSwiperNextButton` as selectors instead of the generic class selectors.
* Changed the Swiper navigation configuration in `swiper.js` to use `#singleSwiperPrevButton` and `#singleSwiperNextButton` as selectors.

**Template structure improvements:**

* Updated `main.html` to add uniquely identified navigation button elements within the respective containers for both single and grid Swipers, and removed the old global navigation buttons.