### PR TITLE
[refactor] Remove redundant calls to get slide element index

### DIFF
--- a/photomap/frontend/static/javascript/slide-state.js
+++ b/photomap/frontend/static/javascript/slide-state.js
@@ -137,7 +137,7 @@ class SlideStateManager {
 
     this.notifySlideChanged();
   }
-
+  
   /**
    * Exit search mode and return to album browsing
    */


### PR DESCRIPTION
This pull request refactors how slide indices are retrieved within the `GridViewManager` class in `grid-view.js`, improving code clarity and reducing repetitive parsing logic. The changes introduce a new helper method for extracting slide indices and update event handlers to use this method, making the codebase more maintainable and less error-prone.

Refactoring for slide index retrieval:

* Added a new helper method `getIndexForSlideElement` to encapsulate and standardize extraction of the slide's global index from the DOM element.
* Updated all instances where slide indices were previously parsed directly from the DOM (`dataset.globalIndex`) to use the new `getIndexForSlideElement` method, including in "slideNextTransitionStart", "slidePrevTransitionStart", and external state updates. [[1]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117L202-R215) [[2]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117L232-R241) [[3]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117L269-R270)

Event handling improvements:

* Ensured that spinner display and batch loading logic are only triggered when appropriate, by checking `suppressSlideChange` before proceeding in swiper event handlers. [[1]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117L202-R215) [[2]](diffhunk://#diff-f9be89800083df96c1a43761dacb31dad3050cafa78d3d30ea7791f629955117L232-R241)

Code style and readability:

* Improved formatting of the batch loading debug log for better readability.