### PR TITLE
[release] Revert to using API token, not trusted publisher

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -53,4 +53,5 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://upload.pypi.org/legacy/
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,8 @@ jobs:
   deploy-pypi:
     needs: tag-release
     uses: ./.github/workflows/deploy-pypi.yml
+    secrets:
+      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
   deploy-dockerhub:
     needs: deploy-pypi


### PR DESCRIPTION
Trusted publishing doesn't work for reusable workflows, so reverting to the older token-based authentication system.