### PR TITLE
(bugfix) restore behavior of iPad image menu on long touch

### DIFF
--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -278,23 +278,31 @@ class SwiperManager {
     // Double-tap (touch devices)
     let lastTap = 0;
     let tapCount = 0;
+    let tapTimer = null;
 
-    // Prevent default on touchstart when it's a potential double-tap
     slideEl.addEventListener(
       "touchstart",
       (e) => {
         if (e.touches.length === 1) {
           tapCount++;
+          
+          // Only prevent default on the second tap within the double-tap window
           if (tapCount === 2) {
-            e.preventDefault(); // Prevent zoom on second tap
+            const now = Date.now();
+            if (now - lastTap < 350) {
+              e.preventDefault(); // Prevent zoom only on actual double-tap
+            }
           }
-          setTimeout(() => {
+          
+          // Reset tap count after the double-tap window expires
+          clearTimeout(tapTimer);
+          tapTimer = setTimeout(() => {
             tapCount = 0;
           }, 350);
         }
       },
       { passive: false }
-    ); // passive: false allows preventDefault
+    );
 
     slideEl.addEventListener("touchend", async (e) => {
       // Only trigger on single-finger touch
@@ -310,6 +318,8 @@ class SwiperManager {
         e.preventDefault();
         await toggleGridSwiperView(true);
         lastTap = 0;
+        tapCount = 0;
+        clearTimeout(tapTimer);
       } else {
         lastTap = now;
       }


### PR DESCRIPTION
This pull request improves the double-tap detection logic for touch devices in the `SwiperManager` class, making the user experience more reliable by ensuring that default behaviors (like zoom) are only prevented for actual double-tap events. It also enhances the reset logic for tap tracking to avoid false positives.

Touch event handling improvements:

* Modified the double-tap detection logic to only prevent default behavior (such as zoom) on the second tap if it occurs within the double-tap window, rather than on every second tap regardless of timing. (`photomap/frontend/static/javascript/swiper.js`)
* Added a timer (`tapTimer`) to reliably reset the tap count after the double-tap window expires, preventing accidental double-tap detection outside the intended interval. (`photomap/frontend/static/javascript/swiper.js`)
* Ensured that tap count and timer are reset after a successful double-tap action, improving consistency in tap detection. (`photomap/frontend/static/javascript/swiper.js`)