### PR TITLE
(feature) When slideshow reaches end, wrap around to beginning

### DIFF
--- a/photomap/frontend/static/javascript/slide-state.js
+++ b/photomap/frontend/static/javascript/slide-state.js
@@ -196,15 +196,14 @@ class SlideStateManager {
    */
   resolveOffset(offset) {
     if (this.isSearchMode && this.searchResults.length > 0) {
-      let searchIndex = this.currentSearchIndex + offset;
+      let searchIndex = (this.currentSearchIndex + offset) % this.searchResults.length;
       if (searchIndex < 0 || searchIndex >= this.searchResults.length) {
         return { globalIndex: null, searchIndex: null }; // Out of bounds
       }
-
       let globalIndex = this.searchResults[searchIndex]?.index;
       return { globalIndex, searchIndex };
     } else {
-      let globalIndex = this.currentGlobalIndex + offset;
+      let globalIndex = (this.currentGlobalIndex + offset) % this.totalAlbumImages;
       if (globalIndex < 0 || globalIndex >= this.totalAlbumImages) {
         return { globalIndex: null, searchIndex: null }; // Out of bounds
       }


### PR DESCRIPTION
This pull request updates the offset resolution logic in the `SlideStateManager` class to use modulo arithmetic, ensuring that offsets wrap around the available images or search results instead of exceeding array bounds.

Navigation improvements:

* Updated `resolveOffset` in `slide-state.js` so that both `searchIndex` and `globalIndex` use modulo with the length of `searchResults` or `totalAlbumImages`, respectively, allowing navigation to wrap around when reaching the beginning or end of the list.