### PR TITLE
(feature) remove the save to image icon from the plotly menu

### DIFF
--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -232,7 +232,7 @@ export async function fetchUmapData() {
     };
 
     const config = {
-      "modeBarButtons": [["zoom2d", "pan2d", "zoomIn2d", "zoomOut2d", "autoScale2d"]],
+      "modeBarButtons": [["zoom2d", "pan2d", "zoomIn2d", "zoomOut2d", "autoScale2d", "toImage"]],
       scrollZoom: true,
     };
 


### PR DESCRIPTION
This pull request makes a minor update to the Plotly configuration in the `fetchUmapData` function. The change moves the "toImage" button to the far right of the Plotly mode bar, and removes the "resetScale2d" button. In addition, after the zoom2d button is used, the mode bar switches back to pan2d. This avoids common navigation errors.