### PR TITLE
(chore) do not attempt to upload the CUDA installers; they are too large

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Upload artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/*cpu*/*.zip
+          files: artifacts/*cpu*/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
During the last step of release, the release workflow tries to upload the installer artifacts into the github release page. However, this fails for the *cu129* CUDA-enabled packages, because they exceed GitHubs upload limits. This PR uploads just the smaller *cpu* packages.