### PR TITLE
(chore) fix artifact upload step (again)

### DIFF
--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -6,9 +6,10 @@ jobs:
   upload-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Download all workflow run artifacts
+      - name: Download CPU installer package artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: "*-cpu-*"
           path: artifacts
 
       - name: List downloaded artifacts
@@ -17,6 +18,6 @@ jobs:
       - name: Upload artifacts to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/*cpu*/*
+          files: artifacts/*-cpu-*/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -11,7 +11,7 @@ The second image is `photomapai`. This is the full-featured version of the appli
 Assuming you have [Docker](https://docker.com installed on your system, run the following command to launch the demo version:
 
 ```
-docker -p 8050:8050 lstein/photomapai-demo:latest
+docker run -p 8050:8050 lstein/photomapai-demo:latest
 ```
 
 This will download the latest version of PhotoMapAI from DockerHub and run it, while mapping your desktop's network port 8050 to port 8050 running inside the container. You will see some startup messages. When they finish, point your browser to http://localhost:8050. You will see the PhotoMapAI user interface.
@@ -19,7 +19,7 @@ This will download the latest version of PhotoMapAI from DockerHub and run it, w
 Running the full version is almost as easy:
 
 ```
-docker -p 8050:8050 -v /path/to/my/pictures:/Pictures lstein/photomapai:latest
+docker run -p 8050:8050 -v /path/to/my/pictures:/Pictures lstein/photomapai:latest
 ```
 
 The additional `-v` option maps a folder on your desktop machine to the `/Pictures` folder in the container. Replace `/path/to/my/pictures` with the appropriate folder path on your system. You may provide multiple `-v` options to map more directories. Once PhotoMapAI is running, point your browser to http://localhost:8050 and proceed to define an album as described in [Managing Albums](user-guide/albums.md).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -27,6 +27,17 @@ Or you can permanently fix these environment variables by setting them in your s
 
 On Windows systems, setting environment variables can be done through the GUI as well as on the command line. See [How to Set Environment Variables in Windows](https://phoenixnap.com/kb/windows-set-environment-variable) for a good walkthrough.
 
+## Limiting the Available Albums
+
+You may wish to expose an instance of PhotoMapAI that only shows a subset of albums. To do this, run `start_photomap` with `--album-locked list,of,albums`. Use the album key(s) to select which albums to display, separating the keys with commas. Only these albums will then be available to users of the web application.
+
+It may also be handy to pair this with a specific URL that starts PhotoMapAI with a specific album. The format to start with an album named "my_album" is:
+
+```bash
+http://your.photomap.host/:8050?album=my_album
+```
+
+
 ## Running PhotoMapAI Under HTTPS
 
 By default, PhotoMapAI runs as a non-secure `HTTP` service. This generates a warning icon in some browsers, but more seriously prevents cut and paste between the PhotoMapAI tab and browser tabs and desktop applications. 


### PR DESCRIPTION
This prevents an out of disk space error during the artifact DOWNLOAD step, which occurs prior to the UPLOAD to the GitHub release page.