### PR TITLE
Start server via module argument instead of script path

### DIFF
--- a/photomap/backend/photomap_server.py
+++ b/photomap/backend/photomap_server.py
@@ -109,9 +109,7 @@ async def get_root(
 def start_photomap_loop():
     """Start the PhotoMapAI server loop."""
     running = True
-    exe_dir = os.path.dirname(sys.executable)
-    photomap_server_exe = os.path.join(exe_dir, Path(sys.argv[0]).name)
-    args = [photomap_server_exe] + sys.argv[1:] + ["--once"]
+    args = [sys.executable] + ["-m", "photomap.backend.photomap_server"] + sys.argv[1:] + ["--once"]
 
     while running:
         try:


### PR DESCRIPTION
The current method of starting the server doesn't work when installed in a conda environment (scripts like start_photomap are placed in a Scripts subdirectory, but this assumes they're next to the python executable). This PR changes it to start the server via a module argument to the python executable.