### PR TITLE
chore: bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "photomapai"
-version = "1.0.2"
+version = "1.0.2post1"
 description = "AI-based image clustering and exploration tool"
 authors = [
     { name = "Lincoln Stein", email = "lincoln.stein@gmail.com" }


### PR DESCRIPTION
This bumps the version to 1.0.2post1 to distinguish from the released 1.0.2