### PR TITLE
Bugfix(backend): prevent crash on some invokeai metadata formats

### DIFF
--- a/photomap/backend/metadata_modules/invoke/v5.py
+++ b/photomap/backend/metadata_modules/invoke/v5.py
@@ -1,6 +1,8 @@
 """
 Extract Invoke5 metadata from the raw metadata dictionary.
 """
+
+import itertools
 import logging
 
 from .invoke_metadata_abc import (
@@ -84,24 +86,32 @@ class Invoke5Metadata(InvokeMetadataABC):
         This is called to get the reference image when the metadata contains a ref_images field.
         """
         reference_images = self.raw_metadata.get("ref_images", [])
-        return [
-            ReferenceImage(
-                model_name=image.get("config", {})
-                .get("model", {})
-                .get("name", "Unknown Model"),
-                image_name=image.get("config", {})
-                .get("image", {})
-                .get("image_name", "")
-                or image.get("config", {})
-                .get("image", {})
-                .get("original", {})
-                .get("image", {})
-                .get("image_name", "Unknown Image"),
-                weight=image.get("config", {}).get("weight", 1.0),
+        # for some reason, ref_images can be a list of lists
+        if any(isinstance(img, list) for img in reference_images):
+            reference_images = list(itertools.chain.from_iterable(reference_images))
+
+        reference_image_list = []
+        for image in reference_images:
+            if image.get("isEnabled", False) == False:
+                continue
+            model = image.get("config", {}).get("model", {}) or {}
+            model_name = model.get("name", "N/A")
+            image_name = image.get("config", {}).get("image", {}).get(
+                "image_name", ""
+            ) or image.get("config", {}).get("image", {}).get("original", {}).get(
+                "image", {}
+            ).get(
+                "image_name", "Unknown Image"
             )
-            for image in reference_images
-            if image.get("isEnabled", False)
-        ]
+            weight = image.get("config", {}).get("weight", 1.0)
+            reference_image_list.append(
+                ReferenceImage(
+                    model_name=model_name,
+                    image_name=image_name,
+                    weight=weight,
+                )
+            )
+        return reference_image_list
 
     def _get_reference_images_from_canvas_v2(self) -> list[ReferenceImage]:
         """

--- a/photomap/backend/metadata_modules/invoke/v5.py
+++ b/photomap/backend/metadata_modules/invoke/v5.py
@@ -92,7 +92,7 @@ class Invoke5Metadata(InvokeMetadataABC):
 
         reference_image_list = []
         for image in reference_images:
-            if image.get("isEnabled", False) == False:
+            if image.get("isEnabled", False) is False:
                 continue
             model = image.get("config", {}).get("model", {}) or {}
             model_name = model.get("name", "N/A")

--- a/photomap/backend/metadata_modules/invoke_formatter.py
+++ b/photomap/backend/metadata_modules/invoke_formatter.py
@@ -102,7 +102,7 @@ def format_invoke_metadata(slide_data: SlideSummary, metadata: dict) -> SlideSum
     if raster_images:
         html += f"<tr><th>Raster Images</th><td>{', '.join(raster_images)}</td></tr>"
     if reference_image_table:
-        html += f"<tr><th>IPAdapters</th><td>{reference_image_table}</td></tr>"
+        html += f"<tr><th>Reference Images</th><td>{reference_image_table}</td></tr>"
     if control_layer_table:
         html += f"<tr><th>Control Layers</th><td>{control_layer_table}</td></tr>"
     html += "</table>"

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -12,7 +12,7 @@
   margin: 0;
   order: 1;
   pointer-events: auto;
-  overflow: hidden;
+  overflow: visible;
 }
 
 /* Draggable Titlebar */
@@ -52,7 +52,7 @@
   align-items: center;
   justify-content: flex-start;
   gap: 0.5em;
-  white-space: nowrap;
+  flex-wrap: wrap;
 }
 
 #descriptionText {
@@ -162,7 +162,7 @@
   top: 120px;
   transform: translateX(-100%);
   width: auto;
-  max-width: 60vw;
+  max-width: 50vw;
   z-index: 4001;
   transition: transform 0.4s ease, top 0.2s;
   pointer-events: auto;


### PR DESCRIPTION
This PR corrects a backend crash on reading InvokeAI metadata when either:
1. One of the images in the InvokeAI references_images list has a model of None.
2. The references_images list contains nested lists.