### PR TITLE
feat(invoke): show "Use as Ref Image" button for any image when InvokeAI is configured

### DIFF
--- a/photomap/backend/metadata_formatting.py
+++ b/photomap/backend/metadata_formatting.py
@@ -9,7 +9,12 @@ import logging
 from pathlib import Path
 
 from .config import get_config_manager
-from .metadata_modules import SlideSummary, format_exif_metadata, format_invoke_metadata
+from .metadata_modules import (
+    SlideSummary,
+    format_exif_metadata,
+    format_invoke_metadata,
+    use_ref_button_html,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,23 +38,30 @@ def format_metadata(
         index=index,
         total=total_slides,
     )
-    if not metadata:
-        result.description = "<i>No metadata available.</i>"
-        return result
 
-    # This is a fragile heuristic. Better to infer the type of metadata when the embeddings are
-    # created, but this is a quick fix to avoid breaking existing metadata.
-    if (
+    config_manager = get_config_manager()
+    invokeai_configured = bool(config_manager.get_invokeai_settings().get("url"))
+
+    # The "Use as Ref Image" button only needs an image to upload — it works
+    # for any file regardless of metadata. The full Recall/Remix group, on the
+    # other hand, requires recallable Invoke generation parameters and is
+    # rendered by ``format_invoke_metadata`` itself.
+    is_invoke_metadata = bool(metadata) and (
         "app_version" in metadata
         or "generation_mode" in metadata
         or "canvas_v2_metadata" in metadata
-    ):
-        config_manager = get_config_manager()
-        invokeai_url = config_manager.get_invokeai_settings().get("url")
+    )
+
+    if not metadata:
+        result.description = "<i>No metadata available.</i>"
+    elif is_invoke_metadata:
         return format_invoke_metadata(
-            result, metadata, show_recall_buttons=bool(invokeai_url)
+            result, metadata, show_recall_buttons=invokeai_configured
         )
     else:
-        config_manager = get_config_manager()
         api_key = config_manager.get_locationiq_api_key()
-        return format_exif_metadata(result, metadata, api_key)
+        result = format_exif_metadata(result, metadata, api_key)
+
+    if invokeai_configured:
+        result.description = (result.description or "") + use_ref_button_html()
+    return result

--- a/photomap/backend/metadata_modules/__init__.py
+++ b/photomap/backend/metadata_modules/__init__.py
@@ -1,5 +1,5 @@
 from .exif_formatter import format_exif_metadata
-from .invoke_formatter import format_invoke_metadata
+from .invoke_formatter import format_invoke_metadata, use_ref_button_html
 from .slide_summary import SlideSummary
 
 # re-export the format_invoke_metadata and format_exif_metadata functions
@@ -7,4 +7,5 @@ __all__ = [
     "SlideSummary",
     "format_invoke_metadata",
     "format_exif_metadata",
+    "use_ref_button_html",
 ]

--- a/photomap/backend/metadata_modules/invoke_formatter.py
+++ b/photomap/backend/metadata_modules/invoke_formatter.py
@@ -75,6 +75,15 @@ _USE_REF_SVG = (
 )
 
 
+_USE_REF_BUTTON_HTML = (
+    '<button type="button" class="invoke-recall-btn" data-recall-mode="use_ref" '
+    'title="Upload this image to InvokeAI and use it as a reference image">'
+    f'{_USE_REF_SVG}<span class="invoke-recall-label">Use as Ref Image</span>'
+    '<span class="invoke-recall-status" aria-live="polite"></span>'
+    "</button>"
+)
+
+
 def _recall_buttons_html() -> str:
     """Render the recall / remix / use-ref button group shown at the bottom of the drawer."""
     return (
@@ -89,11 +98,22 @@ def _recall_buttons_html() -> str:
         f'{_RECALL_SVG}<span class="invoke-recall-label">Recall</span>'
         '<span class="invoke-recall-status" aria-live="polite"></span>'
         "</button>"
-        '<button type="button" class="invoke-recall-btn" data-recall-mode="use_ref" '
-        'title="Upload this image to InvokeAI and use it as a reference image">'
-        f'{_USE_REF_SVG}<span class="invoke-recall-label">Use as Ref Image</span>'
-        '<span class="invoke-recall-status" aria-live="polite"></span>'
-        "</button>"
+        f"{_USE_REF_BUTTON_HTML}"
+        "</div>"
+    )
+
+
+def use_ref_button_html() -> str:
+    """Render the standalone "Use as Ref Image" button.
+
+    The Recall and Remix buttons need recallable InvokeAI generation parameters
+    in the image metadata, but "Use as Ref Image" only needs the image itself —
+    so it is appended to non-Invoke metadata views as well, whenever an
+    InvokeAI backend is configured.
+    """
+    return (
+        '<div class="invoke-recall-controls" data-invoke-recall="1">'
+        f"{_USE_REF_BUTTON_HTML}"
         "</div>"
     )
 
@@ -119,14 +139,18 @@ def format_invoke_metadata(
         isinstance(value, str | int | float | bool | type(None))
         for value in metadata.values()
     ):
-        slide_data.description = _scalar_table(metadata)
+        slide_data.description = _scalar_table(metadata) + (
+            use_ref_button_html() if show_recall_buttons else ""
+        )
         return slide_data
 
     try:
         parsed = GenerationMetadataAdapter().parse(metadata)
     except ValidationError as exc:
         logger.warning("Failed to parse invoke metadata: %s", exc)
-        slide_data.description = "<i>Unknown invoke metadata format.</i>"
+        slide_data.description = "<i>Unknown invoke metadata format.</i>" + (
+            use_ref_button_html() if show_recall_buttons else ""
+        )
         return slide_data
 
     view = InvokeMetadataView(parsed)

--- a/tests/backend/test_invoke_metadata.py
+++ b/tests/backend/test_invoke_metadata.py
@@ -23,7 +23,10 @@ from photomap.backend.metadata_modules.invoke.invoke_metadata_view import (
     LoraTuple,
     ReferenceImageTuple,
 )
-from photomap.backend.metadata_modules.invoke_formatter import format_invoke_metadata
+from photomap.backend.metadata_modules.invoke_formatter import (
+    format_invoke_metadata,
+    use_ref_button_html,
+)
 from photomap.backend.metadata_modules.invokemetadata import GenerationMetadataAdapter
 from photomap.backend.metadata_modules.slide_summary import SlideSummary
 
@@ -895,3 +898,50 @@ class TestFormatInvokeRecallButtons:
         assert 'data-recall-mode="use_ref"' in html
         assert "Use as Ref Image" in html
         assert html.count('class="invoke-recall-btn"') == 3
+
+    def test_scalar_only_metadata_appends_use_ref_button_when_enabled(self):
+        """A flat-scalars custom-workflow image carries no recallable
+        parameters, but the image itself can still be uploaded as a reference.
+        """
+        metadata = {"Custom Field": "value", "Steps": 20}
+        html = format_invoke_metadata(
+            _slide(), metadata, show_recall_buttons=True
+        ).description
+        assert 'data-recall-mode="use_ref"' in html
+        # Recall and Remix make no sense without parsed parameters.
+        assert 'data-recall-mode="recall"' not in html
+        assert 'data-recall-mode="remix"' not in html
+        assert html.count('class="invoke-recall-btn"') == 1
+
+    def test_scalar_only_metadata_no_buttons_when_disabled(self):
+        metadata = {"Custom Field": "value"}
+        html = format_invoke_metadata(_slide(), metadata).description
+        assert "invoke-recall-controls" not in html
+
+    def test_unknown_invoke_format_appends_use_ref_button_when_enabled(self):
+        """Payloads that look like Invoke metadata but fail discriminator
+        validation should still expose the Use-as-Ref button (the file on
+        disk is fine even if its metadata makes no sense).
+        """
+        # ``metadata_version: 99`` is not a known discriminator, so parsing
+        # raises ValidationError and we fall into the "unknown format" branch.
+        # The nested dict also keeps us out of the "flat-scalars" fast path.
+        metadata = {
+            "metadata_version": 99,
+            "app_version": "9.9.9",
+            "model": {"wat": "not a recognizable model"},
+        }
+        html = format_invoke_metadata(
+            _slide(), metadata, show_recall_buttons=True
+        ).description
+        assert "Unknown invoke metadata format" in html
+        assert 'data-recall-mode="use_ref"' in html
+        assert 'data-recall-mode="recall"' not in html
+        assert 'data-recall-mode="remix"' not in html
+
+    def test_use_ref_button_html_renders_single_button(self):
+        html = use_ref_button_html()
+        assert 'class="invoke-recall-controls"' in html
+        assert 'data-recall-mode="use_ref"' in html
+        assert "Use as Ref Image" in html
+        assert html.count('class="invoke-recall-btn"') == 1

--- a/tests/backend/test_metadata_formatting.py
+++ b/tests/backend/test_metadata_formatting.py
@@ -1,0 +1,92 @@
+"""Tests for the top-level metadata-formatting dispatcher.
+
+The interesting cases here aren't the renderers themselves (those are covered
+in ``test_invoke_metadata.py``) but the orchestration: deciding which renderer
+to call and conditionally appending the standalone "Use as Ref Image" button
+to the non-Invoke paths whenever an InvokeAI backend is configured.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from photomap.backend.config import get_config_manager
+from photomap.backend.metadata_formatting import format_metadata
+
+
+@pytest.fixture
+def clear_invokeai_config():
+    manager = get_config_manager()
+    manager.set_invokeai_settings(url=None, username=None, password=None)
+    yield
+    manager.set_invokeai_settings(url=None, username=None, password=None)
+
+
+@pytest.fixture
+def with_invokeai_url(clear_invokeai_config):
+    manager = get_config_manager()
+    manager.set_invokeai_settings(url="http://localhost:9090")
+    yield "http://localhost:9090"
+    manager.set_invokeai_settings(url=None, username=None, password=None)
+
+
+def _filepath() -> Path:
+    return Path("/tmp/example.png")
+
+
+class TestNoMetadata:
+    def test_renders_placeholder_without_invokeai(self, clear_invokeai_config):
+        result = format_metadata(_filepath(), {}, 0, 1)
+        assert "No metadata available" in result.description
+        assert "invoke-recall-controls" not in result.description
+
+    def test_appends_use_ref_button_when_invokeai_configured(self, with_invokeai_url):
+        result = format_metadata(_filepath(), {}, 0, 1)
+        assert "No metadata available" in result.description
+        assert 'data-recall-mode="use_ref"' in result.description
+        # No Recall/Remix without parameters to recall.
+        assert 'data-recall-mode="recall"' not in result.description
+        assert 'data-recall-mode="remix"' not in result.description
+
+
+class TestExifMetadata:
+    EXIF = {"Make": "Canon", "Model": "EOS R5", "FNumber": 2.8}
+
+    def test_no_button_without_invokeai(self, clear_invokeai_config):
+        result = format_metadata(_filepath(), self.EXIF, 0, 1)
+        assert "Canon" in result.description
+        assert "invoke-recall-controls" not in result.description
+
+    def test_use_ref_button_added_when_invokeai_configured(self, with_invokeai_url):
+        result = format_metadata(_filepath(), self.EXIF, 0, 1)
+        assert "Canon" in result.description
+        assert 'data-recall-mode="use_ref"' in result.description
+        assert 'data-recall-mode="recall"' not in result.description
+        assert 'data-recall-mode="remix"' not in result.description
+
+
+class TestInvokeMetadata:
+    INVOKE = {
+        "metadata_version": 3,
+        "app_version": "3.5.0",
+        "positive_prompt": "anything",
+        "seed": 1,
+        "model": {"model_name": "m"},
+    }
+
+    def test_no_buttons_without_invokeai(self, clear_invokeai_config):
+        result = format_metadata(_filepath(), self.INVOKE, 0, 1)
+        assert "anything" in result.description
+        assert "invoke-recall-controls" not in result.description
+
+    def test_full_recall_group_when_invokeai_configured(self, with_invokeai_url):
+        result = format_metadata(_filepath(), self.INVOKE, 0, 1)
+        assert 'data-recall-mode="recall"' in result.description
+        assert 'data-recall-mode="remix"' in result.description
+        assert 'data-recall-mode="use_ref"' in result.description
+        # The use_ref button should be inside the same control group as the
+        # recall buttons (one container, three buttons), not a duplicate
+        # standalone container appended afterwards.
+        assert result.description.count('class="invoke-recall-controls"') == 1


### PR DESCRIPTION
## Summary

- The "Use as Ref Image" button only needs the image file itself (it uploads the file and asks InvokeAI to use it as a reference) — it doesn't need any recallable generation parameters in the image metadata.
- So it is now exposed from every metadata-drawer path whenever an InvokeAI backend URL is configured: EXIF-only images, images with no metadata at all, scalar-only custom-workflow InvokeAI images, and images whose Invoke metadata fails to parse.
- The Recall / Remix buttons still require recallable Invoke parameters and remain gated on a successful parse — only the standalone use-ref button follows this broader rule.

## Implementation notes

- Extracted the single-button markup into `_USE_REF_BUTTON_HTML` and added a public `use_ref_button_html()` helper that wraps it in its own `.invoke-recall-controls` container.
- `format_invoke_metadata` now appends the standalone helper on the scalar-only and validation-error branches when `show_recall_buttons=True`; the fully-parsed path still renders the three-button group in a single container.
- `format_metadata` computes `invokeai_configured` once, dispatches to the Invoke/EXIF/no-metadata renderer as before, and appends the standalone button for the non-Invoke paths when configured.

## Test plan

- [x] `ruff check photomap tests` passes.
- [x] `pytest tests/backend` — 117 passed (new `test_metadata_formatting.py` covers the three dispatch paths × InvokeAI configured/not; new formatter tests cover scalar-only / validation-error + standalone helper).
- [x] `npm test` — 233 passed.
- [ ] Manual: browse an album containing a non-Invoke (phone camera) image with InvokeAI configured and verify the "Use as Ref Image" button appears in the drawer and uploads the file.
- [ ] Manual: clear the InvokeAI URL in settings and verify no recall buttons appear on any image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)