### PR TITLE
feat(invoke): add image-board selector for reference uploads

### DIFF
--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -93,6 +93,13 @@ class Config(BaseModel):
         default=None,
         description="Password for authenticating against InvokeAI (future use)",
     )
+    invokeai_board_id: str | None = Field(
+        default=None,
+        description=(
+            "ID of the InvokeAI board that reference-image uploads should be "
+            "placed in. None means Uncategorized."
+        ),
+    )
 
     @field_validator("config_version")
     @classmethod
@@ -123,6 +130,7 @@ class Config(BaseModel):
             "invokeai_url": self.invokeai_url,
             "invokeai_username": self.invokeai_username,
             "invokeai_password": self.invokeai_password,
+            "invokeai_board_id": self.invokeai_board_id,
         }
 
 
@@ -185,6 +193,7 @@ class ConfigManager:
             "url": config.invokeai_url,
             "username": config.invokeai_username,
             "password": config.invokeai_password,
+            "board_id": config.invokeai_board_id,
         }
 
     def set_invokeai_settings(
@@ -192,6 +201,7 @@ class ConfigManager:
         url: str | None = None,
         username: str | None = None,
         password: str | None = None,
+        board_id: str | None = None,
     ) -> None:
         """Update the InvokeAI connection settings.
 
@@ -208,6 +218,7 @@ class ConfigManager:
         config.invokeai_url = _clean(url)
         config.invokeai_username = _clean(username)
         config.invokeai_password = _clean(password)
+        config.invokeai_board_id = _clean(board_id)
         self._config = config
         self.save_config()
         self._config = None
@@ -238,6 +249,7 @@ class ConfigManager:
                         invokeai_url=config_data.get("invokeai_url"),
                         invokeai_username=config_data.get("invokeai_username"),
                         invokeai_password=config_data.get("invokeai_password"),
+                        invokeai_board_id=config_data.get("invokeai_board_id"),
                     )
 
                 except Exception as e:

--- a/photomap/backend/routers/invoke.py
+++ b/photomap/backend/routers/invoke.py
@@ -116,7 +116,7 @@ def _invalidate_token_cache() -> None:
     _token_username = None
 
 
-async def _post_with_auth_fallback(
+async def _request_with_auth_fallback(
     base_url: str,
     username: str | None,
     password: str | None,
@@ -156,11 +156,12 @@ async def _post_with_auth_fallback(
 
 
 class InvokeAISettings(BaseModel):
-    """Mirrors the three config fields we expose via the settings panel."""
+    """Mirrors the config fields we expose via the settings panel."""
 
     url: str | None = None
     username: str | None = None
     password: str | None = None
+    board_id: str | None = None
 
 
 class RecallRequest(BaseModel):
@@ -195,6 +196,7 @@ async def get_invokeai_config() -> dict:
         "url": settings["url"] or "",
         "username": settings["username"] or "",
         "has_password": bool(settings["password"]),
+        "board_id": settings["board_id"] or "",
     }
 
 
@@ -202,17 +204,20 @@ async def get_invokeai_config() -> dict:
 async def set_invokeai_config(settings: InvokeAISettings) -> dict:
     """Persist the InvokeAI connection settings.
 
-    A password of ``None`` leaves the existing stored password untouched so
-    the settings panel can re-submit without clobbering what was saved.
+    A password or board_id of ``None`` leaves the existing stored value
+    untouched so the settings panel can PATCH individual fields without
+    clobbering what was saved.  Send an empty string to explicitly clear.
     """
     _invalidate_token_cache()
     existing = config_manager.get_invokeai_settings()
     password = settings.password if settings.password is not None else existing["password"]
+    board_id = settings.board_id if settings.board_id is not None else existing["board_id"]
     try:
         config_manager.set_invokeai_settings(
             url=settings.url,
             username=settings.username,
             password=password,
+            board_id=board_id,
         )
     except Exception as exc:
         logger.exception("Failed to persist InvokeAI settings")
@@ -220,6 +225,115 @@ async def set_invokeai_config(settings: InvokeAISettings) -> dict:
             status_code=500, detail=f"Failed to save settings: {exc}"
         ) from exc
     return {"success": True}
+
+
+@invoke_router.get("/status")
+async def invokeai_status() -> dict:
+    """Report whether the configured URL is reachable and looks like InvokeAI.
+
+    Probes the unauthenticated ``/api/v1/app/version`` endpoint.  A successful
+    JSON response with a ``version`` field is the signal the settings UI uses
+    to reveal the username/password/board rows.  Returns
+    ``{"reachable": False, "detail": ...}`` for any network or HTTP failure
+    rather than raising, so the frontend can render a neutral hint instead of
+    an error banner while the user is still typing.
+    """
+    settings = config_manager.get_invokeai_settings()
+    base_url = settings["url"]
+    if not base_url:
+        return {"reachable": False, "detail": "No InvokeAI URL configured"}
+
+    version_url = f"{base_url.rstrip('/')}/api/v1/app/version"
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.get(version_url)
+    except httpx.RequestError as exc:
+        return {"reachable": False, "detail": f"Could not reach backend: {exc}"}
+
+    if resp.status_code != 200:
+        return {
+            "reachable": False,
+            "detail": f"Backend returned HTTP {resp.status_code}",
+        }
+    try:
+        payload = resp.json()
+    except ValueError:
+        return {"reachable": False, "detail": "Backend did not return JSON"}
+    version = payload.get("version")
+    if not version:
+        # A non-InvokeAI server happening to have /api/v1/app/version would
+        # almost certainly not return a version field.
+        return {"reachable": False, "detail": "Response missing version field"}
+    return {"reachable": True, "version": version}
+
+
+@invoke_router.get("/boards")
+async def invokeai_boards() -> list[dict]:
+    """Return the list of boards from the configured InvokeAI backend.
+
+    Uses the same auth-fallback pattern as the recall and upload endpoints.
+    Returns a flat ``[{"board_id": ..., "board_name": ...}]`` list — the
+    frontend populates its dropdown directly from this.  Any failure
+    (unreachable, auth, 5xx) raises 502; the frontend then renders a
+    disabled "Uncategorized" option.
+    """
+    settings = config_manager.get_invokeai_settings()
+    base_url = settings["url"]
+    if not base_url:
+        raise HTTPException(
+            status_code=400, detail="InvokeAI backend URL is not configured."
+        )
+
+    boards_url = f"{base_url.rstrip('/')}/api/v1/boards/"
+    username = settings["username"]
+    password = settings["password"]
+
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+
+            async def _do(headers: dict[str, str]) -> httpx.Response:
+                return await client.get(
+                    boards_url, params={"all": "true"}, headers=headers
+                )
+
+            response = await _request_with_auth_fallback(
+                base_url, username, password, _do
+            )
+    except httpx.RequestError as exc:
+        logger.warning("InvokeAI boards request failed: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Could not reach InvokeAI backend at {base_url}: {exc}",
+        ) from exc
+
+    if response.status_code >= 400:
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"InvokeAI backend returned {response.status_code}: "
+                f"{response.text[:200]}"
+            ),
+        )
+
+    try:
+        raw = response.json()
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=502, detail="Boards endpoint did not return JSON"
+        ) from exc
+
+    # ``?all=true`` returns a flat list; without it InvokeAI returns
+    # ``{"items": [...], "offset": ..., "total": ...}``.  Handle both shapes
+    # so an accidentally-paginated response doesn't blank out the dropdown.
+    items = raw if isinstance(raw, list) else raw.get("items", [])
+    return [
+        {
+            "board_id": item.get("board_id"),
+            "board_name": item.get("board_name") or "(unnamed board)",
+        }
+        for item in items
+        if isinstance(item, dict) and item.get("board_id")
+    ]
 
 
 def _load_raw_metadata(album_key: str, index: int) -> dict:
@@ -300,7 +414,7 @@ async def recall_parameters(request: RecallRequest) -> dict:
                     url, json=payload, params={"strict": "true"}, headers=headers
                 )
 
-            response = await _post_with_auth_fallback(
+            response = await _request_with_auth_fallback(
                 base_url, username, password, _do
             )
     except httpx.RequestError as exc:
@@ -339,25 +453,51 @@ async def _upload_image_to_invokeai(
     image_path: Path,
     username: str | None,
     password: str | None,
-) -> str:
-    """Upload ``image_path`` to InvokeAI and return the assigned ``image_name``.
+    board_id: str | None = None,
+) -> tuple[str, str | None]:
+    """Upload ``image_path`` to InvokeAI and return ``(image_name, warning)``.
+
+    If ``board_id`` is provided, the upload targets that board.  If that
+    attempt fails (board deleted, renamed, permission issue, etc.) the
+    upload is retried without the board so the file lands in Uncategorized
+    — that's the documented fallback behaviour.  When the fallback kicks in
+    a human-readable warning is returned alongside the image name so the
+    caller can surface it to the UI.
 
     Auth transitions (anonymous ↔ token) are handled transparently by
-    ``_post_with_auth_fallback``; the multipart stream is re-opened on each
-    retry since the previous one will have been consumed.
+    ``_request_with_auth_fallback``; the multipart stream is re-opened on
+    each retry since the previous one will have been consumed.
     """
     upload_url = f"{base_url.rstrip('/')}/api/v1/images/upload"
     mime_type = mimetypes.guess_type(image_path.name)[0] or "image/png"
-    params = {"image_category": "user", "is_intermediate": "false"}
+    base_params = {"image_category": "user", "is_intermediate": "false"}
 
-    async def _do(headers: dict[str, str]) -> httpx.Response:
-        with image_path.open("rb") as fh:
-            files = {"file": (image_path.name, fh, mime_type)}
-            return await client.post(
-                upload_url, files=files, params=params, headers=headers
+    async def _attempt(params: dict[str, str]) -> httpx.Response:
+        async def _do(headers: dict[str, str]) -> httpx.Response:
+            with image_path.open("rb") as fh:
+                files = {"file": (image_path.name, fh, mime_type)}
+                return await client.post(
+                    upload_url, files=files, params=params, headers=headers
+                )
+
+        return await _request_with_auth_fallback(base_url, username, password, _do)
+
+    warning: str | None = None
+    if board_id:
+        upload_resp = await _attempt({**base_params, "board_id": board_id})
+        if upload_resp.status_code >= 400:
+            logger.warning(
+                "InvokeAI upload to board %s failed (%s); falling back to Uncategorized",
+                board_id,
+                upload_resp.status_code,
             )
-
-    upload_resp = await _post_with_auth_fallback(base_url, username, password, _do)
+            warning = (
+                f"Upload to the selected board failed "
+                f"(HTTP {upload_resp.status_code}); image was placed in Uncategorized."
+            )
+            upload_resp = await _attempt(base_params)
+    else:
+        upload_resp = await _attempt(base_params)
 
     if upload_resp.status_code >= 400:
         raise HTTPException(
@@ -382,7 +522,7 @@ async def _upload_image_to_invokeai(
             status_code=502,
             detail="InvokeAI image upload response did not include image_name",
         )
-    return image_name
+    return image_name, warning
 
 
 @invoke_router.post("/use_ref_image")
@@ -413,13 +553,14 @@ async def use_ref_image(request: UseRefImageRequest) -> dict:
 
     username = settings["username"]
     password = settings["password"]
+    board_id = settings["board_id"]
 
     recall_url = f"{base_url.rstrip('/')}/api/v1/recall/{request.queue_id}"
 
     try:
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
-            image_name = await _upload_image_to_invokeai(
-                client, base_url, image_path, username, password
+            image_name, board_warning = await _upload_image_to_invokeai(
+                client, base_url, image_path, username, password, board_id=board_id
             )
 
             # Deliberately omit ``strict=true`` so that the recall only
@@ -431,7 +572,7 @@ async def use_ref_image(request: UseRefImageRequest) -> dict:
             async def _do_recall(headers: dict[str, str]) -> httpx.Response:
                 return await client.post(recall_url, json=payload, headers=headers)
 
-            response = await _post_with_auth_fallback(
+            response = await _request_with_auth_fallback(
                 base_url, username, password, _do_recall
             )
     except httpx.RequestError as exc:
@@ -460,9 +601,12 @@ async def use_ref_image(request: UseRefImageRequest) -> dict:
     except ValueError:
         remote = {"raw": response.text}
 
-    return {
+    result = {
         "success": True,
         "sent": payload,
         "uploaded_image_name": image_name,
         "response": remote,
     }
+    if board_warning:
+        result["warning"] = board_warning
+    return result

--- a/photomap/frontend/static/javascript/settings.js
+++ b/photomap/frontend/static/javascript/settings.js
@@ -14,7 +14,7 @@ const DELAY_CONFIG = {
 // Cache DOM elements to avoid repeated queries
 let elements = {};
 
-function cacheElements() {
+export function cacheElements() {
   elements = {
     settingsBtn: document.getElementById("settingsBtn"),
     settingsOverlay: document.getElementById("settingsOverlay"),
@@ -30,6 +30,9 @@ function cacheElements() {
     invokeaiUrlInput: document.getElementById("invokeaiUrlInput"),
     invokeaiUsernameInput: document.getElementById("invokeaiUsernameInput"),
     invokeaiPasswordInput: document.getElementById("invokeaiPasswordInput"),
+    invokeaiBoardSelect: document.getElementById("invokeaiBoardSelect"),
+    invokeaiAuthSection: document.getElementById("invokeaiAuthSection"),
+    invokeaiStatusHint: document.getElementById("invokeaiStatusHint"),
     showControlPanelTextCheckbox: document.getElementById("showControlPanelTextCheckbox"),
     confirmDeleteCheckbox: document.getElementById("confirmDeleteCheckbox"),
     gridThumbSizeFactor: document.getElementById("gridThumbSizeFactor"),
@@ -291,7 +294,11 @@ async function saveLocationIQApiKey(apiKey) {
   }
 }
 
-async function loadInvokeAISettings() {
+// Tracks the currently-selected board_id as returned by the backend so the
+// auth/url refresh flow can restore the dropdown selection after re-populating.
+let invokeaiSelectedBoardId = "";
+
+export async function loadInvokeAISettings() {
   if (!elements.invokeaiUrlInput) {
     return;
   }
@@ -310,11 +317,13 @@ async function loadInvokeAISettings() {
       elements.invokeaiPasswordInput.value = "";
       elements.invokeaiPasswordInput.placeholder = data.has_password
         ? "(password saved — leave blank to keep)"
-        : "(for future multi-user support)";
+        : "(optional, multi-user mode)";
     }
+    invokeaiSelectedBoardId = data.board_id || "";
   } catch (error) {
     console.error("Failed to load InvokeAI settings:", error);
   }
+  await refreshInvokeAIStatus();
 }
 
 async function saveInvokeAISettings() {
@@ -330,6 +339,9 @@ async function saveInvokeAISettings() {
   if (elements.invokeaiPasswordInput && elements.invokeaiPasswordInput.value) {
     body.password = elements.invokeaiPasswordInput.value;
   }
+  if (elements.invokeaiBoardSelect) {
+    body.board_id = elements.invokeaiBoardSelect.value || "";
+  }
   try {
     await fetch("invokeai/config", {
       method: "POST",
@@ -338,6 +350,88 @@ async function saveInvokeAISettings() {
     });
   } catch (error) {
     console.error("Failed to save InvokeAI settings:", error);
+  }
+}
+
+function setInvokeAIAuthSectionVisible(visible) {
+  if (!elements.invokeaiAuthSection) {
+    return;
+  }
+  elements.invokeaiAuthSection.hidden = !visible;
+}
+
+export async function refreshInvokeAIStatus() {
+  // Don't even try to probe when the URL is blank — keep the auth rows
+  // hidden so the UI stays calm for users who don't run InvokeAI.
+  if (!elements.invokeaiUrlInput || !elements.invokeaiUrlInput.value.trim()) {
+    setInvokeAIAuthSectionVisible(false);
+    return;
+  }
+  try {
+    const response = await fetch("invokeai/status");
+    if (!response.ok) {
+      setInvokeAIAuthSectionVisible(false);
+      return;
+    }
+    const data = await response.json();
+    const reachable = !!data.reachable;
+    setInvokeAIAuthSectionVisible(reachable);
+    if (reachable) {
+      await loadInvokeAIBoards();
+    }
+  } catch (error) {
+    console.error("Failed to probe InvokeAI status:", error);
+    setInvokeAIAuthSectionVisible(false);
+  }
+}
+
+function renderBoardOptions(boards, selectedId) {
+  const select = elements.invokeaiBoardSelect;
+  if (!select) {
+    return;
+  }
+  select.innerHTML = "";
+  // "Uncategorized" (no board_id) is always available as the default.
+  const uncategorized = document.createElement("option");
+  uncategorized.value = "";
+  uncategorized.textContent = "Uncategorized";
+  select.appendChild(uncategorized);
+
+  boards.forEach((board) => {
+    const option = document.createElement("option");
+    option.value = board.board_id;
+    option.textContent = board.board_name;
+    select.appendChild(option);
+  });
+  select.value = selectedId || "";
+  // If the saved selection isn't in the returned list (board was deleted),
+  // the value silently reverts to "" (Uncategorized) above — that's the
+  // right default given the runtime fallback behaviour.
+  select.disabled = false;
+}
+
+export async function loadInvokeAIBoards() {
+  if (!elements.invokeaiBoardSelect) {
+    return;
+  }
+  try {
+    const response = await fetch("invokeai/boards");
+    if (!response.ok) {
+      // Auth failure or upstream error — render a disabled dropdown so the
+      // user knows the list couldn't be fetched but can still see what the
+      // default (Uncategorized) will do.
+      elements.invokeaiBoardSelect.innerHTML = '<option value="">Uncategorized</option>';
+      elements.invokeaiBoardSelect.value = "";
+      elements.invokeaiBoardSelect.disabled = true;
+      return;
+    }
+    const boards = await response.json();
+    renderBoardOptions(boards, invokeaiSelectedBoardId);
+  } catch (error) {
+    console.error("Failed to load InvokeAI boards:", error);
+    elements.invokeaiBoardSelect.innerHTML = '<option value="">Uncategorized</option>';
+    elements.invokeaiBoardSelect.value = "";
+    elements.invokeaiBoardSelect.disabled = true;
   }
 }
 
@@ -352,13 +446,28 @@ function setupInvokeAISettingsControls() {
       timeout = setTimeout(fn, 600);
     };
   };
-  const debouncedSave = debounced(saveInvokeAISettings);
-  [elements.invokeaiUrlInput, elements.invokeaiUsernameInput, elements.invokeaiPasswordInput]
-    .filter(Boolean)
-    .forEach((input) => {
-      input.addEventListener("input", debouncedSave);
-      input.addEventListener("blur", saveInvokeAISettings);
+  // Every credential/URL edit has to save first and then probe status: the
+  // status endpoint reads the persisted config, not whatever's in the field.
+  const debouncedSaveAndRefresh = debounced(async () => {
+    await saveInvokeAISettings();
+    await refreshInvokeAIStatus();
+  });
+  const textInputs = [elements.invokeaiUrlInput, elements.invokeaiUsernameInput, elements.invokeaiPasswordInput].filter(
+    Boolean
+  );
+  textInputs.forEach((input) => {
+    input.addEventListener("input", debouncedSaveAndRefresh);
+    input.addEventListener("blur", async () => {
+      await saveInvokeAISettings();
+      await refreshInvokeAIStatus();
     });
+  });
+  if (elements.invokeaiBoardSelect) {
+    elements.invokeaiBoardSelect.addEventListener("change", async () => {
+      invokeaiSelectedBoardId = elements.invokeaiBoardSelect.value || "";
+      await saveInvokeAISettings();
+    });
+  }
 }
 
 function setupLocationIQApiKeyControl() {

--- a/photomap/frontend/templates/modules/settings.html
+++ b/photomap/frontend/templates/modules/settings.html
@@ -222,25 +222,8 @@
               placeholder="e.g. http://localhost:9090"
               autocomplete="off"
             />
-          </div>
-          <div class="setting-row">
-            <label for="invokeaiUsernameInput">InvokeAI Username:</label>
-            <input
-              type="text"
-              id="invokeaiUsernameInput"
-              placeholder="(optional)"
-              autocomplete="off"
-            />
-          </div>
-          <div class="setting-row">
-            <label for="invokeaiPasswordInput">InvokeAI Password:</label>
-            <input
-              type="password"
-              id="invokeaiPasswordInput"
-              placeholder="(optional)"
-              autocomplete="new-password"
-            />
             <small
+              id="invokeaiStatusHint"
               style="
                 color: #666;
                 font-size: 0.85em;
@@ -249,11 +232,48 @@
                 grid-column: 2 / 3;
               "
             >
-              Optional: URL of a running InvokeAI server to enable the
-              <em>Recall</em> / <em>Remix</em> buttons in the metadata drawer.
-              Add a username and password if the InvokeAI server requires
-              authentication.
+              URL of a running InvokeAI server to enable the
+              <em>Recall</em>, <em>Remix</em>, and <em>Use as Ref Image</em>
+              buttons in the metadata drawer.
             </small>
+          </div>
+          <div id="invokeaiAuthSection" hidden>
+            <div class="setting-row">
+              <label for="invokeaiUsernameInput">InvokeAI Username:</label>
+              <input
+                type="text"
+                id="invokeaiUsernameInput"
+                placeholder="(optional, multi-user mode)"
+                autocomplete="off"
+              />
+            </div>
+            <div class="setting-row">
+              <label for="invokeaiPasswordInput">InvokeAI Password:</label>
+              <input
+                type="password"
+                id="invokeaiPasswordInput"
+                placeholder="(optional, multi-user mode)"
+                autocomplete="new-password"
+              />
+            </div>
+            <div class="setting-row">
+              <label for="invokeaiBoardSelect">Upload to Image Board:</label>
+              <select id="invokeaiBoardSelect">
+                <option value="">Uncategorized</option>
+              </select>
+              <small
+                style="
+                  color: #666;
+                  font-size: 0.85em;
+                  display: block;
+                  margin-top: 4px;
+                  grid-column: 2 / 3;
+                "
+              >
+                Reference images uploaded via
+                <em>Use as Ref Image</em> are placed in this board.
+              </small>
+            </div>
           </div>
         </form>
       </div>

--- a/tests/backend/test_invoke_router.py
+++ b/tests/backend/test_invoke_router.py
@@ -40,7 +40,7 @@ def test_get_config_empty(client, clear_invokeai_config):
     response = client.get("/invokeai/config")
     assert response.status_code == 200
     body = response.json()
-    assert body == {"url": "", "username": "", "has_password": False}
+    assert body == {"url": "", "username": "", "has_password": False, "board_id": ""}
 
 
 def test_set_and_get_config(client, clear_invokeai_config):
@@ -415,10 +415,10 @@ def _install_recall_stub(monkeypatch):
 
 
 class _ScriptedClient:
-    """An httpx.AsyncClient stub whose ``post`` returns the next scripted response.
+    """An httpx.AsyncClient stub whose ``get``/``post`` return scripted responses.
 
-    Each call records the (url, headers) it saw so tests can assert on the
-    auth header progression across a retry cycle.
+    Each call records the (url, headers, method) it saw so tests can assert on
+    the auth header progression across a retry cycle.
     """
 
     def __init__(self, script):
@@ -437,10 +437,18 @@ class _ScriptedClient:
         return False
 
     async def post(self, url, **kwargs):
+        return await self._dispatch("POST", url, kwargs)
+
+    async def get(self, url, **kwargs):
+        return await self._dispatch("GET", url, kwargs)
+
+    async def _dispatch(self, method, url, kwargs):
         self.calls.append(
             {
+                "method": method,
                 "url": url,
                 "headers": dict(kwargs.get("headers") or {}),
+                "params": kwargs.get("params"),
                 "json": kwargs.get("json"),
             }
         )
@@ -738,3 +746,343 @@ def test_use_ref_image_403_with_token_retries_anonymously(
 
     # Cache cleared.
     assert invoke_module._cached_token is None
+
+
+# ── board_id round-trip + /invokeai/status + /invokeai/boards ──────────
+
+
+def test_config_round_trips_board_id(client, clear_invokeai_config):
+    client.post(
+        "/invokeai/config",
+        json={"url": "http://localhost:9090", "board_id": "board-uuid-1"},
+    )
+    body = client.get("/invokeai/config").json()
+    assert body["board_id"] == "board-uuid-1"
+
+
+def test_config_board_id_preserved_when_omitted(client, clear_invokeai_config):
+    client.post(
+        "/invokeai/config",
+        json={"url": "http://localhost:9090", "board_id": "keep-me"},
+    )
+    # Update another field without including board_id — it should survive.
+    client.post("/invokeai/config", json={"url": "http://localhost:9091"})
+    body = client.get("/invokeai/config").json()
+    assert body["board_id"] == "keep-me"
+
+
+def test_config_board_id_cleared_by_empty_string(client, clear_invokeai_config):
+    client.post(
+        "/invokeai/config",
+        json={"url": "http://localhost:9090", "board_id": "delete-me"},
+    )
+    client.post(
+        "/invokeai/config",
+        json={"url": "http://localhost:9090", "board_id": ""},
+    )
+    body = client.get("/invokeai/config").json()
+    assert body["board_id"] == ""
+
+
+def test_status_returns_unreachable_when_url_not_configured(
+    client, clear_invokeai_config
+):
+    response = client.get("/invokeai/status")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["reachable"] is False
+    assert "no invokeai url configured" in body["detail"].lower()
+
+
+def test_status_returns_version_on_reachable_backend(
+    client, clear_invokeai_config, monkeypatch
+):
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    def _route(url, kwargs):
+        assert url == "http://localhost:9090/api/v1/app/version"
+        return _Resp(200, json_body={"version": "5.6.0"})
+
+    stub = _ScriptedClient([_route])
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", stub)
+
+    body = client.get("/invokeai/status").json()
+    assert body["reachable"] is True
+    assert body["version"] == "5.6.0"
+
+
+def test_status_marks_network_failure_as_unreachable(
+    client, clear_invokeai_config, monkeypatch
+):
+    client.post("/invokeai/config", json={"url": "http://localhost:9999"})
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    class _ExplodingClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def get(self, url, **kwargs):
+            raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", _ExplodingClient)
+
+    body = client.get("/invokeai/status").json()
+    assert body["reachable"] is False
+    assert "could not reach" in body["detail"].lower()
+
+
+def test_status_rejects_non_invokeai_server(
+    client, clear_invokeai_config, monkeypatch
+):
+    """A random HTTP 200 without a ``version`` field should count as
+    unreachable so the settings UI doesn't reveal the auth rows."""
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    def _route(url, kwargs):
+        return _Resp(200, json_body={"hello": "world"})
+
+    stub = _ScriptedClient([_route])
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", stub)
+
+    body = client.get("/invokeai/status").json()
+    assert body["reachable"] is False
+
+
+def test_boards_returns_flat_list_on_success(
+    client, clear_invokeai_config, clear_token_cache, monkeypatch
+):
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    def _route(url, kwargs):
+        assert url == "http://localhost:9090/api/v1/boards/"
+        assert kwargs.get("params") == {"all": "true"}
+        return _Resp(
+            200,
+            json_body=[
+                {"board_id": "abc", "board_name": "Landscapes"},
+                {"board_id": "def", "board_name": "Portraits"},
+                # Entries missing board_id are filtered out — they're not
+                # addressable in the upload endpoint.
+                {"board_name": "Missing id"},
+            ],
+        )
+
+    stub = _ScriptedClient([_route])
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", stub)
+
+    body = client.get("/invokeai/boards").json()
+    assert body == [
+        {"board_id": "abc", "board_name": "Landscapes"},
+        {"board_id": "def", "board_name": "Portraits"},
+    ]
+
+
+def test_boards_unwraps_paginated_response(
+    client, clear_invokeai_config, clear_token_cache, monkeypatch
+):
+    """If the InvokeAI build ignores ?all=true we still want to use the items list."""
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    def _route(url, kwargs):
+        return _Resp(
+            200,
+            json_body={
+                "items": [{"board_id": "abc", "board_name": "Landscapes"}],
+                "offset": 0,
+                "total": 1,
+            },
+        )
+
+    stub = _ScriptedClient([_route])
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", stub)
+
+    body = client.get("/invokeai/boards").json()
+    assert body == [{"board_id": "abc", "board_name": "Landscapes"}]
+
+
+def test_boards_returns_502_on_upstream_failure(
+    client, clear_invokeai_config, clear_token_cache, monkeypatch
+):
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    def _route(url, kwargs):
+        return _Resp(500, json_body={"detail": "server exploded"}, text="boom")
+
+    stub = _ScriptedClient([_route])
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", stub)
+
+    response = client.get("/invokeai/boards")
+    assert response.status_code == 502
+
+
+def test_use_ref_image_passes_configured_board_id(
+    client, clear_invokeai_config, monkeypatch, tmp_path
+):
+    client.post(
+        "/invokeai/config",
+        json={"url": "http://localhost:9090", "board_id": "my-board"},
+    )
+
+    image_file = tmp_path / "pic.png"
+    image_file.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    monkeypatch.setattr(
+        invoke_module, "_load_image_path", lambda album_key, index: image_file
+    )
+
+    captured_upload_params: list[dict] = []
+
+    class _StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, **kwargs):
+            if "files" in kwargs:
+                captured_upload_params.append(kwargs.get("params"))
+                kwargs["files"]["file"][1].read()
+
+                class _Up:
+                    status_code = 200
+                    text = ""
+
+                    def json(self_inner):
+                        return {"image_name": "uploaded.png"}
+
+                return _Up()
+
+            class _Rec:
+                status_code = 200
+                text = "{}"
+
+                def json(self_inner):
+                    return {"status": "success"}
+
+            return _Rec()
+
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", _StubClient)
+
+    response = client.post(
+        "/invokeai/use_ref_image",
+        json={"album_key": "any", "index": 0},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert "warning" not in body
+
+    assert len(captured_upload_params) == 1
+    params = captured_upload_params[0]
+    assert params == {
+        "image_category": "user",
+        "is_intermediate": "false",
+        "board_id": "my-board",
+    }
+
+
+def test_use_ref_image_falls_back_to_uncategorized_when_board_upload_fails(
+    client, clear_invokeai_config, monkeypatch, tmp_path
+):
+    """When the configured board rejects the upload, retry without it so the
+    image lands in Uncategorized — and surface a warning so the UI can say so."""
+    client.post(
+        "/invokeai/config",
+        json={"url": "http://localhost:9090", "board_id": "ghost-board"},
+    )
+
+    image_file = tmp_path / "pic.png"
+    image_file.write_bytes(b"\x89PNG")
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    monkeypatch.setattr(
+        invoke_module, "_load_image_path", lambda album_key, index: image_file
+    )
+
+    upload_params_seen: list[dict] = []
+
+    class _StubClient:
+        def __init__(self, *a, **kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, **kwargs):
+            if "files" in kwargs:
+                params = kwargs.get("params") or {}
+                upload_params_seen.append(params)
+                kwargs["files"]["file"][1].read()
+
+                if params.get("board_id"):
+                    # First attempt — board-scoped upload fails.
+                    class _BadBoard:
+                        status_code = 404
+                        text = '{"detail":"Board not found"}'
+
+                        def json(self_inner):
+                            return {"detail": "Board not found"}
+
+                    return _BadBoard()
+
+                # Retry without board_id succeeds.
+                class _OK:
+                    status_code = 200
+                    text = ""
+
+                    def json(self_inner):
+                        return {"image_name": "uploaded.png"}
+
+                return _OK()
+
+            class _Rec:
+                status_code = 200
+                text = "{}"
+
+                def json(self_inner):
+                    return {"status": "success"}
+
+            return _Rec()
+
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", _StubClient)
+
+    response = client.post(
+        "/invokeai/use_ref_image",
+        json={"album_key": "any", "index": 0},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["uploaded_image_name"] == "uploaded.png"
+    assert "warning" in body
+    assert "uncategorized" in body["warning"].lower()
+
+    # Two upload attempts: one with the board, one without.
+    assert len(upload_params_seen) == 2
+    assert upload_params_seen[0].get("board_id") == "ghost-board"
+    assert "board_id" not in upload_params_seen[1]

--- a/tests/frontend/invokeai-settings.test.js
+++ b/tests/frontend/invokeai-settings.test.js
@@ -1,0 +1,185 @@
+// Unit tests for settings.js — the InvokeAI reachability / boards flow.
+// Scope is deliberately narrow: the settings UI is mostly plumbing, so these
+// cover the decision points that could silently regress (show/hide the auth
+// section, populate the boards dropdown, fall back to Uncategorized).
+
+import { jest, describe, it, expect, afterEach } from "@jest/globals";
+
+// settings.js pulls in several other modules; stub them so the module loads
+// cleanly under jsdom.
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/album-manager.js", () => ({
+  albumManager: { fetchAvailableAlbums: jest.fn(() => Promise.resolve([])) },
+  checkAlbumIndex: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/search-ui.js", () => ({
+  exitSearchMode: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/state.js", () => ({
+  saveSettingsToLocalStorage: jest.fn(),
+  setAlbum: jest.fn(),
+  setMaxSearchResults: jest.fn(),
+  setMinSearchScore: jest.fn(),
+  state: {
+    album: "test",
+    currentDelay: 5,
+    mode: "chronological",
+    showControlPanelText: true,
+    suppressDeleteConfirm: false,
+    gridThumbSizeFactor: 1,
+    minSearchScore: 0,
+    maxSearchResults: 10,
+    swiper: { params: { autoplay: { delay: 5000 } } },
+  },
+}));
+
+const { cacheElements, loadInvokeAISettings, loadInvokeAIBoards, refreshInvokeAIStatus } =
+  await import("../../photomap/frontend/static/javascript/settings.js");
+
+function buildSettingsDom({ url = "" } = {}) {
+  document.body.innerHTML = `
+    <input id="invokeaiUrlInput" value="${url}" />
+    <input id="invokeaiUsernameInput" />
+    <input id="invokeaiPasswordInput" />
+    <div id="invokeaiAuthSection" hidden>
+      <select id="invokeaiBoardSelect"><option value="">Uncategorized</option></select>
+    </div>
+    <small id="invokeaiStatusHint"></small>
+  `;
+  cacheElements();
+}
+
+function mockFetchSequence(responses) {
+  // Sequentially return queued responses for matching URLs.  Any call that
+  // doesn't find a response for its URL will throw so tests catch unexpected
+  // requests rather than silently returning undefined.
+  global.fetch = jest.fn((url) => {
+    const entry = responses.shift();
+    if (!entry) {
+      throw new Error(`Unexpected fetch call: ${url}`);
+    }
+    if (entry.match && !url.includes(entry.match)) {
+      throw new Error(`Expected ${entry.match} but got ${url}`);
+    }
+    return Promise.resolve({
+      ok: entry.ok !== false,
+      json: () => Promise.resolve(entry.body ?? {}),
+    });
+  });
+}
+
+describe("InvokeAI settings flow", () => {
+  afterEach(() => {
+    delete global.fetch;
+    document.body.innerHTML = "";
+  });
+
+  describe("refreshInvokeAIStatus", () => {
+    it("leaves the auth section hidden when URL is blank", async () => {
+      buildSettingsDom({ url: "" });
+      global.fetch = jest.fn(() => {
+        throw new Error("Status endpoint must not be called for blank URL");
+      });
+
+      await refreshInvokeAIStatus();
+
+      expect(document.getElementById("invokeaiAuthSection").hidden).toBe(true);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("reveals the auth section when the backend reports reachable", async () => {
+      buildSettingsDom({ url: "http://localhost:9090" });
+      mockFetchSequence([
+        { match: "invokeai/status", body: { reachable: true, version: "5.6.0" } },
+        { match: "invokeai/boards", body: [{ board_id: "b1", board_name: "Landscapes" }] },
+      ]);
+
+      await refreshInvokeAIStatus();
+
+      expect(document.getElementById("invokeaiAuthSection").hidden).toBe(false);
+      const select = document.getElementById("invokeaiBoardSelect");
+      const options = Array.from(select.options).map((o) => o.textContent);
+      expect(options).toContain("Uncategorized");
+      expect(options).toContain("Landscapes");
+    });
+
+    it("keeps the auth section hidden when the backend is unreachable", async () => {
+      buildSettingsDom({ url: "http://localhost:9999" });
+      mockFetchSequence([{ match: "invokeai/status", body: { reachable: false, detail: "unreachable" } }]);
+
+      await refreshInvokeAIStatus();
+
+      expect(document.getElementById("invokeaiAuthSection").hidden).toBe(true);
+    });
+  });
+
+  describe("loadInvokeAIBoards", () => {
+    it("disables the dropdown and falls back to Uncategorized on failure", async () => {
+      buildSettingsDom({ url: "http://localhost:9090" });
+      mockFetchSequence([{ match: "invokeai/boards", ok: false, body: { detail: "nope" } }]);
+
+      await loadInvokeAIBoards();
+
+      const select = document.getElementById("invokeaiBoardSelect");
+      expect(select.disabled).toBe(true);
+      expect(select.options).toHaveLength(1);
+      expect(select.options[0].textContent).toBe("Uncategorized");
+      expect(select.value).toBe("");
+    });
+
+    it("populates options from a successful boards response", async () => {
+      buildSettingsDom({ url: "http://localhost:9090" });
+      mockFetchSequence([
+        {
+          match: "invokeai/boards",
+          body: [
+            { board_id: "b1", board_name: "Landscapes" },
+            { board_id: "b2", board_name: "Portraits" },
+          ],
+        },
+      ]);
+
+      await loadInvokeAIBoards();
+
+      const select = document.getElementById("invokeaiBoardSelect");
+      expect(select.disabled).toBe(false);
+      const values = Array.from(select.options).map((o) => o.value);
+      expect(values).toEqual(["", "b1", "b2"]);
+    });
+  });
+
+  describe("loadInvokeAISettings", () => {
+    it("populates inputs and kicks off the status + boards refresh", async () => {
+      buildSettingsDom({ url: "" });
+      mockFetchSequence([
+        {
+          match: "invokeai/config",
+          body: {
+            url: "http://localhost:9090",
+            username: "alice",
+            has_password: true,
+            board_id: "b2",
+          },
+        },
+        { match: "invokeai/status", body: { reachable: true, version: "5.6.0" } },
+        {
+          match: "invokeai/boards",
+          body: [
+            { board_id: "b1", board_name: "Landscapes" },
+            { board_id: "b2", board_name: "Portraits" },
+          ],
+        },
+      ]);
+
+      await loadInvokeAISettings();
+
+      expect(document.getElementById("invokeaiUrlInput").value).toBe("http://localhost:9090");
+      expect(document.getElementById("invokeaiUsernameInput").value).toBe("alice");
+      // Password field is never populated from the server, but its placeholder
+      // should reflect that one is saved.
+      expect(document.getElementById("invokeaiPasswordInput").placeholder).toMatch(/saved/);
+      expect(document.getElementById("invokeaiAuthSection").hidden).toBe(false);
+      // The previously-persisted board_id is restored as the dropdown selection.
+      expect(document.getElementById("invokeaiBoardSelect").value).toBe("b2");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Reveals the InvokeAI username/password fields and a new "Upload to Image Board" dropdown in the settings dialog only after the configured URL probes as a working InvokeAI backend.
- Reference images uploaded via *Use as Ref Image* are placed in the selected board; if the board can't be fetched at settings-load time, or the configured board rejects the upload at runtime, the image lands in Uncategorized and the response carries a warning.
- Independent of #221 (no overlapping files) — branched off master so the two PRs can land in either order.

## Backend

- `Config.invokeai_board_id` field; `to_dict` / `load_config` / `get_invokeai_settings` / `set_invokeai_settings` round-trip it.
- `GET /invokeai/status` probes the unauthenticated `/api/v1/app/version`. Returns `{reachable, version, detail}`. Used by the settings UI to decide whether to reveal the auth section. Treats a 200 without a `version` field as not-InvokeAI.
- `GET /invokeai/boards` fetches `/api/v1/boards/?all=true` through the existing auth-fallback helper (renamed `_post_with_auth_fallback` → `_request_with_auth_fallback` since it's now used for GET as well). Returns a flat `[{board_id, board_name}]` list; handles paginated responses too. Any failure surfaces as 502.
- `GET /invokeai/config` adds `board_id` to the response. `POST /invokeai/config` round-trips it with the same preserve-on-null / clear-on-empty-string semantics as the password field.
- `_upload_image_to_invokeai` accepts `board_id` and retries without it on a 4xx, returning a warning string the caller surfaces. `/use_ref_image` includes `warning` in the response on fallback.

## Frontend

- `settings.html`: wraps username/password rows + new `<select id="invokeaiBoardSelect">` in `#invokeaiAuthSection` (hidden by default).
- `settings.js`: load → `/invokeai/status` → conditional reveal → `/invokeai/boards`. URL/user/pass autosave (debounced) and re-probe; board selection autosaves on change. On boards fetch failure the dropdown is disabled and shows only "Uncategorized".

## Test plan

- [x] `ruff check photomap tests` clean.
- [x] `pytest tests/backend` — 119 passed (+12 new: status reachable / unreachable / non-InvokeAI / paginated boards / board_id round-trip / preserve-on-null / clear-on-empty / boards 502 / upload uses board_id / fallback to Uncategorized + warning).
- [x] `npm test` — 239 passed (+6 new in `invokeai-settings.test.js` covering reveal/hide, board population, and fallback).
- [x] `npm run lint` and `npm run format:check` clean.
- [x] Manual: enter a valid InvokeAI URL → username/password/board fields appear, dropdown populates.
- [x] Manual: enter junk URL → fields stay hidden.
- [x] Manual: pick a board, click Use as Ref Image → image lands in that board in InvokeAI.
- [x] Manual: delete the board in InvokeAI without updating settings → next Use as Ref Image lands in Uncategorized and surfaces the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)