### PR TITLE
fix(frontend): suppress slide animation when entering grid view

### DIFF
--- a/photomap/frontend/static/javascript/grid-view.js
+++ b/photomap/frontend/static/javascript/grid-view.js
@@ -364,7 +364,7 @@ class GridViewManager {
       // add some context slides before and after
       await this.loadBatch(targetIndex + this.slidesPerBatch, true);
       if (targetIndex > 0) {
-        await this.loadBatch(targetIndex - this.slidesPerBatch, false);
+        await this.loadBatch(targetIndex - this.slidesPerBatch, false, false);
       }
     } catch (err) {
       console.warn(err);
@@ -374,7 +374,7 @@ class GridViewManager {
     this.resetInProgress = false;
   }
 
-  async loadBatch(startIndex = null, append = true) {
+  async loadBatch(startIndex = null, append = true, animatePrepend = true) {
     const topLeftIndex = Math.floor(startIndex / this.slidesPerBatch) * this.slidesPerBatch;
 
     const placeholderSlides = [];
@@ -411,12 +411,14 @@ class GridViewManager {
         // Use a microtask (Promise) to ensure prepend DOM changes are committed
         Promise.resolve().then(() => {
           if (this.swiper && !this.swiper.destroyed) {
-            // Use default speed (300ms) for smooth animation, but suppress slide change event
-            this.swiper.slideTo(this.currentColumns, 300, false);
-            // Reset suppressSlideChange after transition completes
-            setTimeout(() => {
-              this.suppressSlideChange = false;
-            }, 350); // Slightly longer than animation duration
+            const speed = animatePrepend ? 300 : 0;
+            this.swiper.slideTo(this.currentColumns, speed, false);
+            setTimeout(
+              () => {
+                this.suppressSlideChange = false;
+              },
+              animatePrepend ? 350 : 0
+            );
           }
         });
       }


### PR DESCRIPTION
## Summary
- Switching from swiper view to grid view caused an unwanted horizontal scroll right after the grid faded in.
- Cause: `resetAllSlides()` prepends a context batch before the target slide, and `loadBatch()` then runs `swiper.slideTo(currentColumns, 300, false)` to compensate — that 300 ms animation is what was visible.
- Threaded an `animatePrepend` flag through `loadBatch()`. The initial-reset prepend now passes `false` (0 ms slideTo); runtime back-scrolling keeps the 300 ms animation.

## Test plan
- [ ] In swiper view, navigate several slides forward, then toggle to grid view — grid appears in place with no horizontal scroll.
- [ ] In grid view, scroll backward past the start of the loaded batch — prepend still animates smoothly.
- [ ] Toggle grid ↔ swiper repeatedly; confirm no regression in fade or current-slide highlighting.
- [ ] `npm test` and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)