### PR TITLE
fix(frontend): rebuild swiper after single-image delete

### DIFF
--- a/photomap/frontend/static/javascript/control-panel.js
+++ b/photomap/frontend/static/javascript/control-panel.js
@@ -161,39 +161,39 @@ async function confirmDelete(filepath, globalIndex) {
 }
 
 async function handleSuccessfulDelete(globalIndex, searchIndex) {
-  // synchronize the album information
   const metadata = await getIndexMetadata(state.album);
+  slideState.totalAlbumImages = metadata?.filename_count || 0;
 
-  // remove from search results, and adjust subsequent global indices downward by 1
+  // Drop the deleted entry from search results and decrement subsequent global indices.
+  // Stay on the same search position so the next result fills the slot; clamp at the end.
   if (slideState.isSearchMode && slideState.searchResults?.length > 0) {
     slideState.searchResults.splice(searchIndex, 1);
-    for (let i = 0; i < slideState.searchResults.length; i++) {
-      if (slideState.searchResults[i].index > globalIndex) {
-        slideState.searchResults[i].index -= 1;
+    for (const result of slideState.searchResults) {
+      if (result.index > globalIndex) {
+        result.index -= 1;
       }
+    }
+    if (slideState.searchResults.length === 0) {
+      slideState.exitSearchMode();
+    } else {
+      slideState.currentSearchIndex = Math.min(slideState.currentSearchIndex, slideState.searchResults.length - 1);
+      slideState.currentGlobalIndex = slideState.searchResults[slideState.currentSearchIndex].index;
     }
   }
 
-  // If the current globalIndex is after the deleted index, decrement it
-  if (slideState.currentGlobalIndex > globalIndex) {
-    slideState.currentGlobalIndex -= 1;
-  }
-
-  // Update total images
-  slideState.totalAlbumImages = metadata.filename_count || 0;
-
-  // TO DO: What happens when the last image is removed?!
-
-  // Update the current swiper.
-  const removedSlideIndex = state.swiper.slides.findIndex((slide) => {
-    return parseInt(slide.dataset.globalIndex, 10) === globalIndex;
-  });
-  if (removedSlideIndex === -1) {
-    console.warn("Deleted slide not found in swiper slides.");
+  // Backend re-indexes after deletion: the slide that was at globalIndex+1 is now at globalIndex,
+  // so keeping currentGlobalIndex unchanged naturally advances to the next image. Clamp so that
+  // deleting the last image lands on the new last image.
+  if (slideState.totalAlbumImages > 0) {
+    slideState.currentGlobalIndex = Math.min(slideState.currentGlobalIndex, slideState.totalAlbumImages - 1);
+  } else {
+    slideState.currentGlobalIndex = 0;
+    state.swiper.removeAllSlides();
     return;
   }
-  await state.swiper.removeSlide(removedSlideIndex);
-  slideState.navigateByOffset(0); // Stay on the same index, which is now the next image
+
+  // Full rebuild — neighbor slides' dataset.globalIndex values are now stale after backend reindexing.
+  await state.single_swiper.resetAllSlides();
 }
 
 // Setup button event listeners


### PR DESCRIPTION
## Summary

- Single-image delete (control panel trash button) patched one slide and adjusted `slideState` in place, leaving neighbor slides with stale `dataset.globalIndex` values after the backend re-indexed.
- After a few deletes, scrolling forward hit a slide whose stale index made `resolveOffset` wrap to 0 before the real last image was ever appended — the very last image of the album became unreachable.
- Replaces the surgical patching in `handleSuccessfulDelete` with a full `state.single_swiper.resetAllSlides()` rebuild (matching the bookmark-delete path), and clamps `currentGlobalIndex` so deleting the last image lands on the new last image.

Positioning behaviour after delete:
- Deleting the current image keeps `currentGlobalIndex` unchanged — the backend re-index slides the next image into that slot.
- Deleting the last image clamps down to the new last.
- Deleting the only image leaves an empty swiper.
- In search mode: splice the result, decrement subsequent `.index` values, clamp `currentSearchIndex` so the next result fills the slot; exit search mode if results become empty.

## Test plan

- [ ] Delete a middle image — current position stays, next image appears in its slot.
- [ ] Delete the last image (highest index) — lands on the new last image.
- [ ] Delete the only image in an album — swiper is empty.
- [ ] In search mode, delete the current result — advances to next result; on last result, falls back to the new last.
- [ ] After several deletes, scroll to the chronological end — the real last image is reachable.