### PR TITLE
fix(ci): repair v1.0.5 release artifact pipeline

### DIFF
--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile

--- a/.github/workflows/deploy-dockerhub.yml
+++ b/.github/workflows/deploy-dockerhub.yml
@@ -9,6 +9,9 @@ on:
         required: true
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   dockerhub-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pyinstaller.yml
+++ b/.github/workflows/deploy-pyinstaller.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/deploy-pyinstaller.yml
+++ b/.github/workflows/deploy-pyinstaller.yml
@@ -169,10 +169,12 @@ jobs:
 
       - name: Create archive (Windows)
         if: runner.os == 'Windows'
+        # Use 7z instead of Compress-Archive: the latter throws
+        # "Stream was too long" on archives above ~2 GB, which the cu129 build hits.
         run: |
           $version = "${{ steps.get_version_win.outputs.version }}"
           $archiveName = "photomap-${{ matrix.platform }}-${{ matrix.torch_variant }}-v$version"
-          Compress-Archive -Path "dist\$archiveName" -DestinationPath "dist\$archiveName.zip" -Force
+          7z a -tzip "dist\$archiveName.zip" "dist\$archiveName"
         shell: pwsh
 
       - name: Debug - List dist contents

--- a/.github/workflows/deploy-pyinstaller.yml
+++ b/.github/workflows/deploy-pyinstaller.yml
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -186,7 +186,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: photomap-${{ matrix.platform }}-${{ matrix.torch_variant }}-v${{ steps.get_version_unix.outputs.version || steps.get_version_win.outputs.version }}
           path: dist/photomap-${{ matrix.platform }}-${{ matrix.torch_variant }}-v${{ steps.get_version_unix.outputs.version || steps.get_version_win.outputs.version }}${{ matrix.archive_ext }}

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -7,6 +7,9 @@ on:
         required: true
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   pypi-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -46,7 +46,7 @@ jobs:
           python -m build
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.get_version.outputs.version }}
           generate_release_notes: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,10 +13,10 @@ jobs:
       tag:  ${{ steps.get_version.outputs.tag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with: 
           python-version: '3.12'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,13 @@ name: Deploy Release
 
 on:
   workflow_dispatch:
-  release: 
+  release:
     types: [published]
+
+env:
+  # Force JS actions to run under Node 24; the v4/v5 majors of the
+  # actions/* family still ship Node 20 entrypoints as of mid-2026.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   tag-release: 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   backend-lint:
     name: Backend Linting (Ruff)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/run_js_tests.yml
+++ b/.github/workflows/run_js_tests.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/run_js_tests.yml
+++ b/.github/workflows/run_js_tests.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test_frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ master, main ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   run_tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download CPU installer package artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with: 
           pattern: "*-cpu-*"
           path: artifacts
@@ -21,7 +21,7 @@ jobs:
         run: ls -lR artifacts
 
       - name: Upload artifacts to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
           files: artifacts/*-cpu-*/*

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -1,11 +1,14 @@
 name: Upload Release Artifacts
 
 on:
-  workflow_call: 
+  workflow_call:
     inputs:
-      tag_name: 
+      tag_name:
         required: true
         type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   upload-release: 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "requests",
     "scikit-learn",
     "setuptools<67",  # Avoid deprecation warning from CLIP dependency
-    "torch ~= 2.9.0",
+    "torch",
     "tqdm",
     "transformers",  # SigLIP encoder backend
     "umap-learn",


### PR DESCRIPTION
## Summary

The v1.0.5 release ([run 25994273288](https://github.com/lstein/PhotoMapAI/actions/runs/25994273288)) shipped broken artifacts:
- `photomap-linux-x64-cpu-v1.0.5` came out at **5 GB** (should be ~800 MB) — it was actually a CUDA build
- `photomap-windows-x64-cu129-v1.0.5` came out at **648 MB** (should be ~4 GB) — it was actually a CPU build
- The release-asset upload failed because the 5 GB linux-cpu zip exceeded GitHub's 2 GiB per-asset cap

Root cause: the encoder PR (#226) tightened the torch constraint in `pyproject.toml` to `~= 2.9.0`. The PyInstaller build script installed the correct variant from `pytorch.org/whl/<variant>` (cpu→2.12.0, cu129→2.8.0), but the subsequent `pip install .` rejected those versions and re-resolved torch from default PyPI — which serves the CUDA wheel on Linux and the CPU wheel on Windows, silently flipping every variant.

This PR contains three fixes:

- **`5b9bac0`** — Unpin torch back to `"torch"` (matches v1.0.4) so the variant install isn't clobbered. Also bump 8 workflows to the latest action majors (checkout v5, setup-python v6, setup-node v5, upload-artifact v5, download-artifact v5, action-gh-release v3, docker/build-push-action v6).
- **`7af0ee0`** — Switch the Windows zip step from `Compress-Archive` to `7z`. PowerShell's built-in cmdlet throws `Stream was too long` on archives above ~2 GB; the cu129 build is ~4 GB.
- **`6cc847f`** — Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow level. The action majors above still ship Node 20 entrypoints as of mid-2026, so the runner kept warning; this opts into Node 24 ahead of the June 2nd, 2026 forced cutover.

## Test plan

- [x] Confirmed via dispatched build [run 25996560245](https://github.com/lstein/PhotoMapAI/actions/runs/25996560245) that the linux-cpu artifact is back to **796 MB** and the linux-cu129 artifact is **6.7 GB** (matches v1.0.4 sizes)
- [x] Windows cu129 archive step succeeds with 7z (verified locally that the step parses; awaiting full run)
- [ ] Re-run `Deploy PyInstaller Executables` on this branch after merge and confirm all five artifacts come through with the right sizes and no Node 20 deprecation warnings
- [ ] On the next tagged release, confirm `upload-release` successfully attaches the three CPU zips to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)