### PR TITLE
fix(cluster-labels): invalidate vocab cache when phrase set changes

### DIFF
--- a/photomap/backend/cluster_labels.py
+++ b/photomap/backend/cluster_labels.py
@@ -15,6 +15,7 @@ and DBSCAN parameter changes.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.resources
 import logging
 import threading
@@ -222,6 +223,23 @@ def _vocab_sources_max_mtime(vocab_path: Path) -> float:
     return max(mtimes)
 
 
+def vocab_fingerprint(phrases: list[str] | None = None) -> str:
+    """Stable hash of the loaded phrase set.
+
+    Why: mtime-only invalidation can't detect when the user extras file is
+    deleted or renamed — the bundled vocab's mtime is unchanged, so the cache
+    looks fresh while the phrase list has actually shrunk. Comparing a content
+    fingerprint catches add/remove/rename regardless of mtime direction.
+    """
+    if phrases is None:
+        phrases = load_vocab_phrases()
+    h = hashlib.sha256()
+    for p in sorted(set(phrases)):
+        h.update(p.encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
 def _read_cached_vocab(
     cache_path: Path,
     vocab_path: Path,
@@ -254,6 +272,19 @@ def _read_cached_vocab(
         )
         return None
     phrases = [str(p) for p in data["phrases"]]
+    # Mtime check above can miss two cases:
+    #   - User extras file deleted/renamed: bundled mtime stays the same, but
+    #     the phrase set just shrank.
+    #   - User extras file added back with an mtime older than the cache.
+    # Compare actual phrase sets to catch both.
+    current_phrases = load_vocab_phrases(vocab_path)
+    if set(phrases) != set(current_phrases):
+        logger.info(
+            "Vocab cache phrase set changed (cached=%d, current=%d); will rebuild",
+            len(phrases),
+            len(current_phrases),
+        )
+        return None
     embeddings = np.asarray(data["embeddings"], dtype=np.float32)
     return phrases, embeddings
 
@@ -269,7 +300,9 @@ def get_or_build_vocab_embeddings(
     L2-normalized after template-ensemble mean-pooling. The cache rebuilds when:
 
     - the file is missing,
-    - the bundled `cluster_vocab.txt` has been edited since the cache was written,
+    - either vocab source file has been edited since the cache was written,
+    - the stored phrase set differs from what's on disk now (catches user
+      extras file deletion/rename, which mtime alone misses),
     - the stamped encoder spec doesn't match (defensive against filename collisions),
     - `len(PROMPT_TEMPLATES)` has changed since the cache was written.
 
@@ -444,8 +477,20 @@ def _read_cached_labels(
         medoids = (
             [int(m) for m in data["medoids"]] if "medoids" in data.files else [None] * len(cluster_ids)
         )
+        # Vocab fingerprint was added to catch phrase-set changes the mtime
+        # check misses (e.g., the user extras file was deleted). Legacy caches
+        # written before the fingerprint existed could be silently stale, so
+        # we force a one-time rebuild on encounter — after that, all caches
+        # are stamped.
+        stored_fingerprint = str(data["vocab_fingerprint"]) if "vocab_fingerprint" in data.files else None
     except (OSError, KeyError, ValueError) as err:
         logger.warning("Labels cache at %s unreadable (%s); will rebuild", cache_path, err)
+        return None
+    if stored_fingerprint is None:
+        logger.info("Labels cache missing vocab fingerprint (pre-upgrade file); will rebuild")
+        return None
+    if stored_fingerprint != vocab_fingerprint():
+        logger.info("Labels cache vocab fingerprint changed; will rebuild")
         return None
 
     out: dict[int, dict] = {}
@@ -497,6 +542,7 @@ def _save_labels(cache_path: Path, labels_dict: dict[int, dict]) -> None:
             alternates=alternates_arr,
             scores=scores_arr,
             medoids=medoids_arr,
+            vocab_fingerprint=np.array(vocab_fingerprint()),
         )
     tmp_path.replace(cache_path)
 

--- a/tests/backend/test_cluster_labels.py
+++ b/tests/backend/test_cluster_labels.py
@@ -264,6 +264,63 @@ def test_vocab_cache_invalidates_on_user_file_edit(
     assert encoder.encode_calls == calls_before + 1
 
 
+def test_vocab_cache_invalidates_when_user_file_removed(
+    tiny_vocab, isolated_cache, fake_encoder, monkeypatch, tmp_path
+):
+    """Deleting the user extras file should rebuild — the phrase set shrank.
+
+    mtime-only invalidation would miss this: the bundled vocab's mtime doesn't
+    change, and the cache's own mtime is newer than that, so a naive check
+    would keep returning a stale cache that still has the user's extra phrases
+    baked in.
+    """
+    user = tmp_path / "extras.txt"
+    user.write_text("stadium\nlibrary\n", encoding="utf-8")
+    monkeypatch.setattr(cluster_labels, "user_vocab_file_path", lambda: user)
+
+    spec = "fake:user-removed"
+    phrases_before, _ = cluster_labels.get_or_build_vocab_embeddings(spec)
+    assert "stadium" in phrases_before
+    encoder = fake_encoder[spec]
+    calls_before = encoder.encode_calls
+
+    user.unlink()
+
+    phrases_after, _ = cluster_labels.get_or_build_vocab_embeddings(spec)
+    assert "stadium" not in phrases_after
+    assert "library" not in phrases_after
+    assert encoder.encode_calls == calls_before + 1  # rebuilt
+
+
+def test_vocab_cache_invalidates_when_user_file_added(
+    tiny_vocab, isolated_cache, fake_encoder, monkeypatch, tmp_path
+):
+    """Adding a user extras file later should rebuild even if its mtime is old.
+
+    A user may copy/restore an extras file with `cp -p` or `touch -r` such that
+    its mtime ends up older than the existing vocab cache. The fingerprint
+    check catches this where mtime alone would not.
+    """
+    import os
+
+    spec = "fake:user-added"
+    cluster_labels.get_or_build_vocab_embeddings(spec)  # build cache, no user file
+    encoder = fake_encoder[spec]
+    calls_before = encoder.encode_calls
+
+    # Create the user file but back-date it to before the cache was written.
+    user = tmp_path / "extras.txt"
+    user.write_text("stadium\n", encoding="utf-8")
+    cache_path = cluster_labels.vocab_cache_path(spec)
+    past = cache_path.stat().st_mtime - 60
+    os.utime(user, (past, past))
+    monkeypatch.setattr(cluster_labels, "user_vocab_file_path", lambda: user)
+
+    phrases, _ = cluster_labels.get_or_build_vocab_embeddings(spec)
+    assert "stadium" in phrases
+    assert encoder.encode_calls == calls_before + 1
+
+
 def test_load_vocab_phrases_lowercases():
     p = Path(__file__).parent / "fixtures_vocab.txt"
     p.write_text("UPPERCASE\nMixedCase Phrase\n", encoding="utf-8")
@@ -600,6 +657,82 @@ def test_get_or_build_invalidates_on_vocab_touch(synthetic_album, monkeypatch, t
     )
     future = time.time() + 5
     os.utime(vocab, (future, future))
+    cluster_labels.get_or_build_cluster_labels(
+        synthetic_album, cluster_eps=1.0, cluster_min_samples=3
+    )
+    assert call_count["n"] == 2
+
+
+def test_get_or_build_invalidates_when_user_vocab_removed(
+    synthetic_album, monkeypatch, tmp_path
+):
+    """Removing the user extras file should invalidate per-album labels caches.
+
+    Mtime-only invalidation misses this case (bundled vocab mtime is unchanged
+    and cache is newer than that), so the fingerprint check is what catches it.
+    """
+    call_count = {"n": 0}
+    real_compute = cluster_labels.compute_cluster_labels
+
+    def counting_compute(*args, **kwargs):
+        call_count["n"] += 1
+        return real_compute(*args, **kwargs)
+
+    monkeypatch.setattr(cluster_labels, "compute_cluster_labels", counting_compute)
+
+    # Point user_vocab_file_path at a real user file with extras.
+    user = tmp_path / "extras.txt"
+    user.write_text("stadium\nlibrary\n", encoding="utf-8")
+    monkeypatch.setattr(cluster_labels, "user_vocab_file_path", lambda: user)
+
+    cluster_labels.get_or_build_cluster_labels(
+        synthetic_album, cluster_eps=1.0, cluster_min_samples=3
+    )
+    assert call_count["n"] == 1
+
+    # Now remove the user file — phrase set shrinks, fingerprint changes.
+    user.unlink()
+
+    cluster_labels.get_or_build_cluster_labels(
+        synthetic_album, cluster_eps=1.0, cluster_min_samples=3
+    )
+    assert call_count["n"] == 2  # rebuilt
+
+
+def test_legacy_labels_cache_without_fingerprint_rebuilds(synthetic_album, monkeypatch):
+    """A cache file written before fingerprint support is force-rebuilt once.
+
+    Before the fingerprint stamp existed, the only invalidation signal was
+    mtime — which can't detect user-vocab file removal. We can't tell whether a
+    fingerprint-less cache was built under the buggy regime, so we always
+    rebuild to be safe. After this one rebuild the cache gets stamped and the
+    normal fingerprint path takes over.
+    """
+    import numpy as np
+
+    call_count = {"n": 0}
+    real_compute = cluster_labels.compute_cluster_labels
+
+    def counting_compute(*args, **kwargs):
+        call_count["n"] += 1
+        return real_compute(*args, **kwargs)
+
+    monkeypatch.setattr(cluster_labels, "compute_cluster_labels", counting_compute)
+
+    cluster_labels.get_or_build_cluster_labels(
+        synthetic_album, cluster_eps=1.0, cluster_min_samples=3
+    )
+    cache_path = cluster_labels.labels_cache_path(synthetic_album, 1.0, 3)
+    data = dict(np.load(cache_path, allow_pickle=False))
+    data.pop("vocab_fingerprint", None)
+    np.savez(cache_path, **data)
+
+    reloaded = cluster_labels.get_or_build_cluster_labels(
+        synthetic_album, cluster_eps=1.0, cluster_min_samples=3
+    )
+    assert call_count["n"] == 2  # legacy file forced a rebuild
+    assert set(reloaded.keys()) == {0, 1, 2}
+    # After rebuild the fingerprint is back, so a third call hits the cache.
     cluster_labels.get_or_build_cluster_labels(
         synthetic_album, cluster_eps=1.0, cluster_min_samples=3
     )


### PR DESCRIPTION
## Summary
- Vocab embedding cache and per-album labels cache used `max(mtime)` of vocab sources, which silently misses the case where a user removes or renames `~/.config/photomap/cluster_vocab_extra.txt` — the bundled vocab mtime is unchanged, the cache is newer than that, so a stale cache (still containing the user's old extra phrases) is returned forever.
- Vocab cache now compares the stored phrase set against the live one; mismatch triggers a rebuild regardless of mtime direction.
- Per-album labels cache stamps a SHA-256 fingerprint of the sorted phrase set into the npz. Legacy caches that predate the fingerprint are force-rebuilt once, then stamped going forward.

## Test plan
- [x] `pytest tests/backend/test_cluster_labels.py tests/backend/test_cluster_labels_router.py` — 45 passed
- [x] `pytest tests/backend` (rest of suite) — 208 passed
- [x] `ruff check photomap/backend/cluster_labels.py tests/backend/test_cluster_labels.py` — clean
- [ ] After merge, verify on a real album: rename `~/.config/photomap/cluster_vocab_extra.txt`, request cluster labels — vocab cache at `~/.cache/photomap/cluster_vocab/` rebuilds, and per-album `cluster_labels_eps*_ms*.npz` files rebuild on next request

🤖 Generated with [Claude Code](https://claude.com/claude-code)