### PR TITLE
Polish metadata drawer and UMAP cluster hover popup

### DIFF
--- a/photomap/backend/metadata_modules/invoke_formatter.py
+++ b/photomap/backend/metadata_modules/invoke_formatter.py
@@ -78,7 +78,7 @@ _USE_REF_SVG = (
 _USE_REF_BUTTON_HTML = (
     '<button type="button" class="invoke-recall-btn" data-recall-mode="use_ref" '
     'title="Upload this image to InvokeAI and use it as a reference image">'
-    f'{_USE_REF_SVG}<span class="invoke-recall-label">Use as Ref Image</span>'
+    f'{_USE_REF_SVG}<span class="invoke-recall-label">Send to InvokeAI</span>'
     '<span class="invoke-recall-status" aria-live="polite"></span>'
     "</button>"
 )

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -99,30 +99,24 @@
 }
 
 .exif-metadata table {
-  margin: 0 !important;
-  padding: 0 !important;
-  border-spacing: 0;
   border-collapse: collapse;
+  border: 1px solid #bbb;
+  width: 100%;
+  margin: 0;
 }
 
 .exif-metadata th,
 .exif-metadata td {
-  padding: 2px 6px !important;
-  margin: 0 !important;
-  font-size: 0.98em;
+  border: 1px solid #555;
+  padding: 6px 10px;
   vertical-align: top;
-}
-
-.exif-metadata tr {
-  margin: 0 !important;
-  padding: 0 !important;
 }
 
 .metadata-link {
   color: #faea0e;
   text-decoration: none;
   font-weight: bold;
-  font-size: 1em;
+  font-size: 14px;
 }
 
 .cluster-info-badge {
@@ -155,6 +149,10 @@
   padding: 6px 10px;
 }
 
+.details-link-cell {
+  text-align: right;
+}
+
 /* ===== Recall / Remix buttons (pinned outside scrollable area) ===== */
 #recallButtonsContainer:empty {
   display: none;
@@ -166,6 +164,7 @@
 
 #metadataLinkContainer {
   padding: 0.4em 2em 0.8em;
+  text-align: right;
 }
 
 .invoke-recall-controls {
@@ -394,6 +393,26 @@
 .image-label-row {
   margin-top: 0.35em;
   font-size: 0.9em;
-  opacity: 0.85;
+  font-weight: bold;
+}
+
+.tag-value {
   font-style: italic;
+  font-weight: normal;
+}
+
+.image-label-row .tag-value:first-of-type {
+  font-weight: bold;
+}
+
+/* Visual frame mirrors .settings-accordion from settings.css but without
+   the class — settings.js setupAccordions() binds a competing click handler
+   to anything matching `.settings-accordion .accordion-header`, which
+   cancelled this drawer's own toggle. */
+.metadata-fields-accordion {
+  margin-top: 1em;
+  width: 100%;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  overflow: hidden;
 }

--- a/photomap/frontend/static/css/umap-floating-window.css
+++ b/photomap/frontend/static/css/umap-floating-window.css
@@ -23,7 +23,6 @@
   padding-bottom: 20px;
 }
 
-
 .icon-btn {
   background: none;
   border: none;
@@ -40,7 +39,9 @@
 }
 
 .icon-btn.active {
-  box-shadow: 0 0 8px 2px #4caf50, 0 0 16px 4px #2196f3;
+  box-shadow:
+    0 0 8px 2px #4caf50,
+    0 0 16px 4px #2196f3;
   background: rgba(76, 175, 80, 0.1);
   border: 2px solid #4caf50;
   z-index: 2;
@@ -110,6 +111,18 @@
   margin-top: 2px;
 }
 
+.umap-thumbnail-tags {
+  font-size: 1.05em;
+  font-weight: bold;
+  width: 100%;
+  text-align: center;
+  padding: 4px 8px 6px 8px;
+}
+
+.umap-thumbnail-tags .tag-value:first-of-type {
+  font-weight: bold;
+}
+
 #umapEpsContainer,
 #umapColorModeContainer {
   font-size: 0.85em;
@@ -134,7 +147,9 @@
   align-items: center;
   justify-content: center;
   vertical-align: middle;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .umap-info-btn:hover,
@@ -157,4 +172,3 @@
 #umapClickBehaviorContainer input[type="radio"] {
   cursor: pointer;
 }
-

--- a/photomap/frontend/static/javascript/metadata-drawer.js
+++ b/photomap/frontend/static/javascript/metadata-drawer.js
@@ -3,7 +3,7 @@
 import { bookmarkManager } from "./bookmarks.js";
 import { scoreDisplay } from "./score-display.js";
 import { slideState } from "./slide-state.js";
-import { state } from "./state.js";
+import { state, setShowMetadataFields } from "./state.js";
 import { setSearchResults } from "./search.js";
 import { isColorLight } from "./utils.js";
 import {
@@ -94,6 +94,14 @@ export function updateMetadataOverlay(slide) {
   const referenceImages = slide.dataset.reference_images || [];
   const processedDescription = replaceReferenceImagesWithLinks(rawDescription, referenceImages, state.album);
 
+  // Park the View Metadata (JSON) link in its standalone container before
+  // the innerHTML rewrite below — on the previous slide it may have been
+  // moved into the table, where rewriting descriptionText would destroy it
+  // (and its click listener) along with the table.
+  const metadataLink = document.getElementById("metadataLink");
+  const linkContainer = document.getElementById("metadataLinkContainer");
+  linkContainer.appendChild(metadataLink);
+
   document.getElementById("descriptionText").innerHTML = processedDescription;
 
   // Inject filepath as first row of the metadata table
@@ -120,7 +128,27 @@ export function updateMetadataOverlay(slide) {
   }
 
   document.getElementById("filenameText").textContent = slide.dataset.filename || "";
-  document.getElementById("metadataLink").href = slide.dataset.metadata_url || "#";
+  metadataLink.href = slide.dataset.metadata_url || "#";
+
+  // When a details table is present (Invoke's .invoke-metadata or EXIF's
+  // .exif-metadata table), tuck the View Metadata link into a full-width
+  // cell at the bottom. Otherwise leave it in the standalone container so
+  // it's still reachable for no-metadata images.
+  const detailsTable =
+    document.querySelector("#descriptionText .invoke-metadata") ||
+    document.querySelector("#descriptionText .exif-metadata table");
+  if (detailsTable) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 2;
+    cell.className = "details-link-cell";
+    cell.appendChild(metadataLink);
+    row.appendChild(cell);
+    (detailsTable.tBodies[0] || detailsTable).appendChild(row);
+    linkContainer.style.display = "none";
+  } else {
+    linkContainer.style.display = "";
+  }
 
   // Update cluster information display
   updateClusterInfo(slide.dataset);
@@ -144,23 +172,34 @@ export function updateClusterInfo(metadata) {
   if (clusterInfo && clusterInfo.cluster !== null && clusterInfo.cluster !== undefined) {
     const { cluster, color, size } = clusterInfo;
 
-    // Create label. When the vocabulary endpoint has supplied a phrase for
-    // this cluster, splice it in. Gated by SHOW_CLUSTER_LABELS_IN_BADGES so
-    // the whole addition can be backed out with one flag flip.
-    let clusterLabel = cluster === -1 ? `Unclustered (size=${size})` : `Cluster ${cluster} (size=${size})`;
+    // Build badge contents. When the vocabulary endpoint has supplied a phrase
+    // for this cluster, splice it in as an italicized tag value. Gated by
+    // SHOW_CLUSTER_LABELS_IN_BADGES so the whole addition can be backed out
+    // with one flag flip.
     let titleAttr = null;
+    let labelInfo = null;
     if (SHOW_CLUSTER_LABELS_IN_BADGES && cluster !== -1) {
-      const labelInfo = getClusterLabelInfo(cluster);
-      if (labelInfo) {
-        clusterLabel = `Cluster ${cluster} · ${labelInfo.label} (size=${size})`;
-        if (labelInfo.alternates?.length) {
-          titleAttr = `also: ${labelInfo.alternates.join(", ")}`;
-        }
+      labelInfo = getClusterLabelInfo(cluster);
+      if (labelInfo?.alternates?.length) {
+        titleAttr = `also: ${labelInfo.alternates.join(", ")}`;
       }
     }
 
-    // Set badge text and colors
-    clusterInfoBadge.textContent = clusterLabel;
+    clusterInfoBadge.replaceChildren();
+    if (cluster === -1) {
+      clusterInfoBadge.appendChild(document.createTextNode(`Unclustered (size=${size})`));
+    } else if (labelInfo) {
+      clusterInfoBadge.appendChild(document.createTextNode(`Cluster ${cluster} · `));
+      const valSpan = document.createElement("span");
+      valSpan.className = "tag-value";
+      valSpan.textContent = labelInfo.label;
+      clusterInfoBadge.appendChild(valSpan);
+      clusterInfoBadge.appendChild(document.createTextNode(` (size=${size})`));
+    } else {
+      clusterInfoBadge.appendChild(document.createTextNode(`Cluster ${cluster} (size=${size})`));
+    }
+
+    // Set badge colors
     clusterInfoBadge.style.backgroundColor = color;
     clusterInfoBadge.style.color = isColorLight(color) ? "#222" : "#fff";
     if (titleAttr) {
@@ -244,8 +283,17 @@ export async function updateImageLabel(metadata) {
     container.style.display = "none";
     return;
   }
-  const altSuffix = info.alternates?.length ? ` (also: ${info.alternates.join(", ")})` : "";
-  textSpan.textContent = `image: ${info.label}${altSuffix}`;
+  textSpan.replaceChildren();
+  const tags = [info.label, ...(info.alternates || [])].slice(0, 3);
+  tags.forEach((tag, idx) => {
+    if (idx > 0) {
+      textSpan.appendChild(document.createTextNode(", "));
+    }
+    const span = document.createElement("span");
+    span.className = "tag-value";
+    span.textContent = tag;
+    textSpan.appendChild(span);
+  });
   container.style.display = "block";
 }
 
@@ -552,6 +600,24 @@ function setupOverlayButtons() {
 // Initialize metadata drawer - sets up all event listeners
 export function initializeMetadataDrawer() {
   setupOverlayButtons();
+
+  // Metadata-fields accordion: mirrors the open/closed pattern used by the
+  // Settings dialog accordions, with the open state persisted in
+  // state.showMetadataFields (and therefore in localStorage).
+  const header = document.getElementById("metadataFieldsHeader");
+  const body = document.getElementById("metadataFieldsBody");
+  if (header && body) {
+    const setOpen = (open) => {
+      header.setAttribute("aria-expanded", String(open));
+      body.classList.toggle("open", open);
+    };
+    setOpen(state.showMetadataFields);
+    header.addEventListener("click", () => {
+      const open = header.getAttribute("aria-expanded") !== "true";
+      setOpen(open);
+      setShowMetadataFields(open);
+    });
+  }
 
   // Listen for UMAP data loaded event to refresh cluster info for the current slide
   window.addEventListener("umapDataLoaded", () => {

--- a/photomap/frontend/static/javascript/state.js
+++ b/photomap/frontend/static/javascript/state.js
@@ -34,6 +34,7 @@ export const state = {
   umapExitFullscreenOnSelection: true, // Exit fullscreen when cluster is selected
   umapClickSelectsCluster: true, // Whether click selects cluster or single image
   umapControlsVisible: true, // Whether the UMAP controls panel is visible
+  showMetadataFields: true, // Whether the metadata-drawer fields table is shown
 };
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -139,6 +140,11 @@ export async function restoreFromLocalStorage() {
   if (storedUmapControlsVisible !== null) {
     state.umapControlsVisible = storedUmapControlsVisible === "true";
   }
+
+  const storedShowMetadataFields = localStorage.getItem("showMetadataFields");
+  if (storedShowMetadataFields !== null) {
+    state.showMetadataFields = storedShowMetadataFields === "true";
+  }
 }
 
 // Save state to local storage
@@ -156,6 +162,7 @@ export function saveSettingsToLocalStorage() {
   localStorage.setItem("umapExitFullscreenOnSelection", state.umapExitFullscreenOnSelection ? "true" : "false");
   localStorage.setItem("umapClickSelectsCluster", state.umapClickSelectsCluster ? "true" : "false");
   localStorage.setItem("umapControlsVisible", state.umapControlsVisible ? "true" : "false");
+  localStorage.setItem("showMetadataFields", state.showMetadataFields ? "true" : "false");
 }
 
 export async function setAlbum(newAlbumKey, force = false) {
@@ -368,5 +375,14 @@ export function setUmapControlsVisible(visible) {
     state.umapControlsVisible = visible;
     saveSettingsToLocalStorage();
     window.dispatchEvent(new CustomEvent("settingsUpdated", { detail: { umapControlsVisible: visible } }));
+  }
+}
+
+export function setShowMetadataFields(visible) {
+  const bool = !!visible;
+  if (state.showMetadataFields !== bool) {
+    state.showMetadataFields = bool;
+    saveSettingsToLocalStorage();
+    window.dispatchEvent(new CustomEvent("settingsUpdated", { detail: { showMetadataFields: bool } }));
   }
 }

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -887,7 +887,6 @@ async function createUmapThumbnail({ x, y, index, cluster }) {
   // Falls back gracefully when the labels endpoint hasn't populated this
   // cluster (or is unavailable).
   const labelInfo = getClusterLabelInfo(cluster);
-  const clusterLabel = labelInfo ? `${labelInfo.label} — ${sizeStr}` : sizeStr;
   const textIsDark = isColorLight(clusterColor) ? "#222" : "#fff";
   const textShadow = isColorLight(clusterColor) ? "0 1px 2px #fff, 0 0px 8px #fff" : "0 1px 2px #000, 0 0px 8px #000";
 
@@ -913,25 +912,33 @@ async function createUmapThumbnail({ x, y, index, cluster }) {
   fnameDiv.style.textShadow = textShadow;
   umapThumbnailDiv.appendChild(fnameDiv);
 
-  // Cluster label
+  // Cluster line: identifier + size only. Tag phrases moved to their own row.
   const clusterDiv = document.createElement("div");
   clusterDiv.className = "umap-thumbnail-cluster";
-  clusterDiv.textContent = clusterLabel;
+  clusterDiv.textContent = sizeStr;
   clusterDiv.style.color = textIsDark;
   clusterDiv.style.textShadow = textShadow;
   umapThumbnailDiv.appendChild(clusterDiv);
 
-  // Alternates row, only when present. Inline rather than title=
-  // since the popup disappears on mouse move (no chance to hover it).
-  if (labelInfo?.alternates?.length) {
-    const altDiv = document.createElement("div");
-    altDiv.className = "umap-thumbnail-cluster-alternates";
-    altDiv.textContent = `also: ${labelInfo.alternates.join(", ")}`;
-    altDiv.style.color = textIsDark;
-    altDiv.style.textShadow = textShadow;
-    altDiv.style.fontSize = "0.85em";
-    altDiv.style.opacity = "0.75";
-    umapThumbnailDiv.appendChild(altDiv);
+  // Tags row, only when the labels endpoint has populated this cluster.
+  // Inline rather than title= since the popup disappears on mouse move.
+  if (labelInfo) {
+    const tags = [labelInfo.label, ...(labelInfo.alternates || [])].slice(0, 3);
+    const tagsDiv = document.createElement("div");
+    tagsDiv.className = "umap-thumbnail-tags";
+    tagsDiv.style.color = textIsDark;
+    tagsDiv.style.textShadow = textShadow;
+    tagsDiv.appendChild(document.createTextNode("Tags for this cluster: "));
+    tags.forEach((tag, idx) => {
+      if (idx > 0) {
+        tagsDiv.appendChild(document.createTextNode(", "));
+      }
+      const span = document.createElement("span");
+      span.className = "tag-value";
+      span.textContent = tag;
+      tagsDiv.appendChild(span);
+    });
+    umapThumbnailDiv.appendChild(tagsDiv);
   }
 
   document.body.appendChild(umapThumbnailDiv);

--- a/photomap/frontend/templates/modules/metadata-drawer.html
+++ b/photomap/frontend/templates/modules/metadata-drawer.html
@@ -24,24 +24,27 @@
     </div>
     <!-- Scrollable Content Area -->
     <div class="filenameDescContainer">
-      <div id="clusterInfoContainer" style="display: none; margin-top: 0.5em;">
-        <span id="clusterInfoBadge" class="cluster-info-badge" style="cursor: pointer;"></span>
+      <div id="clusterInfoContainer" style="display: none; margin-top: 0.5em">
+        <span id="clusterInfoBadge" class="cluster-info-badge" style="cursor: pointer"></span>
       </div>
-      <div id="imageLabelContainer" class="image-label-row" style="display: none;">
-        <span id="imageLabelText"></span>
+      <div id="imageLabelContainer" class="image-label-row" style="display: none">
+        Tags for this image: <span id="imageLabelText"></span>
       </div>
-      <div id="descriptionText"></div>
+      <div class="metadata-fields-accordion">
+        <button id="metadataFieldsHeader" class="accordion-header" type="button" aria-expanded="false">
+          <span class="accordion-chevron">&#9654;</span>
+          Image Details
+        </button>
+        <div id="metadataFieldsBody" class="accordion-body">
+          <div id="descriptionText"></div>
+        </div>
+      </div>
     </div>
     <!-- Recall/Remix buttons (below scrollable area, always visible) -->
     <div id="recallButtonsContainer"></div>
     <!-- Metadata link (below buttons, always visible) -->
     <div id="metadataLinkContainer">
-      <a
-        id="metadataLink"
-        href="#"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="metadata-link"
+      <a id="metadataLink" href="#" target="_blank" rel="noopener noreferrer" class="metadata-link"
         >View Metadata (JSON)</a
       >
     </div>

--- a/tests/backend/test_invoke_metadata.py
+++ b/tests/backend/test_invoke_metadata.py
@@ -896,7 +896,7 @@ class TestFormatInvokeRecallButtons:
         assert 'data-recall-mode="recall"' in html
         assert 'data-recall-mode="remix"' in html
         assert 'data-recall-mode="use_ref"' in html
-        assert "Use as Ref Image" in html
+        assert "Send to InvokeAI" in html
         assert html.count('class="invoke-recall-btn"') == 3
 
     def test_scalar_only_metadata_appends_use_ref_button_when_enabled(self):
@@ -943,5 +943,5 @@ class TestFormatInvokeRecallButtons:
         html = use_ref_button_html()
         assert 'class="invoke-recall-controls"' in html
         assert 'data-recall-mode="use_ref"' in html
-        assert "Use as Ref Image" in html
+        assert "Send to InvokeAI" in html
         assert html.count('class="invoke-recall-btn"') == 1


### PR DESCRIPTION
## Summary
- Unify cluster-badge / image-tag typography in the metadata drawer; render the per-image tag row as up to three tags (first bold italic, rest italic).
- Restructure the UMAP cluster hover popup: cluster line is `Cluster N (size=K)` only, with tags in a new "Tags for this cluster:" row using the same bold/italic pattern at a slightly larger font.
- Replace the always-visible metadata block with a persistent "Image Details" accordion modeled on the Settings dialog (open state stored in `localStorage` via `state.showMetadataFields`).
- Normalize the EXIF table styling to match the Invoke table and pull the "View Metadata (JSON)" link into a right-aligned, full-width bottom row of whichever details table is present. Standalone fallback link is right-aligned and matches the recall-button font size.
- Rename "Use as Ref Image" → "Send to InvokeAI".

## Test plan
- [x] Open an InvokeAI-generated image → confirm `Image Details` accordion appears, opens/closes, and the View Metadata (JSON) link sits in the bottom-right of the table.
- [x] Open a photographic / EXIF-only image → confirm the EXIF table has matching borders, padding, and width, with the View Metadata link in its bottom row.
- [x] Open an image with no metadata → confirm the View Metadata link still appears in the standalone container.
- [x] Reload the page after collapsing the accordion → confirm the closed state persists across browser sessions.
- [x] Hover an image in the UMAP map → confirm the cluster line reads `Cluster N (size=K)` with a separate `Tags for this cluster: a, b, c` row below it.
- [x] Confirm the image-label row in the drawer shows up to three tags with the first bold italic and the rest italic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)