### PR TITLE
feat(metadata-drawer): clickable thumbnails for in-album reference images

### DIFF
--- a/photomap/backend/metadata_modules/invoke/invoke_metadata_view.py
+++ b/photomap/backend/metadata_modules/invoke/invoke_metadata_view.py
@@ -164,10 +164,19 @@ class InvokeMetadataView:
     def _refimage_to_tuple(ref: RefImage) -> ReferenceImageTuple:
         cfg = ref.config
         model_name = cfg.model.name if cfg.model else ""
+        # Weight is only meaningful for IP-adapter references. Reference
+        # images that attach directly to the model (Flux2, Qwen, etc.) have
+        # no IP adapter — ``cfg.model`` is None — and any ``weight`` value
+        # InvokeAI serializes for them is an internal default rather than
+        # a user-set value, so suppress it.
+        if cfg.model is None:
+            weight: float | str | None = None
+        else:
+            weight = _effective_weight(cfg.weight, cfg.image_influence)
         return ReferenceImageTuple(
             model_name=model_name,
             image_name=_image_name(cfg.image),
-            weight=_effective_weight(cfg.weight, cfg.image_influence),
+            weight=weight,
         )
 
     @staticmethod

--- a/photomap/backend/metadata_modules/invoke_formatter.py
+++ b/photomap/backend/metadata_modules/invoke_formatter.py
@@ -236,10 +236,11 @@ def _tuple_table(
     * **Column** — a column that is empty across *all* surviving rows is
       dropped entirely, so a table of reference images with no IP adapter
       model names, for example, renders without a model column at all.
-    * **Weight fallback** — when the ``weight`` column survives because at
-      least one row carries a weight, rows that are missing a weight are
-      rendered as ``1.0`` (the effective default InvokeAI uses when the
-      field is absent) rather than as a ragged empty cell.
+
+    Rows missing a value in a surviving column render an empty cell. (We
+    used to substitute ``1.0`` for missing weights on the theory it matched
+    InvokeAI's default, but v5 Flux reference images legitimately carry no
+    weight, so the fallback was misleading rather than helpful.)
     """
     rows_data = [
         tup
@@ -258,13 +259,11 @@ def _tuple_table(
     html_rows: list[str] = []
     for tup in rows_data:
         cells: list[str] = []
-        for idx, field_name in enumerate(fields):
+        for idx in range(len(fields)):
             if not keep_column[idx]:
                 continue
             value = tup[idx]
-            if field_name == "weight" and (value is None or value == ""):
-                value = 1.0
-            elif value is None:
+            if value is None:
                 value = ""
             cells.append(f"<td>{value}</td>")
         html_rows.append(f"<tr>{''.join(cells)}</tr>")

--- a/photomap/backend/routers/search.py
+++ b/photomap/backend/routers/search.py
@@ -367,6 +367,46 @@ async def get_image_path(album_key: str, index: int) -> str:
         ) from e
 
 
+class ImageIndexLookupRequest(BaseModel):
+    filenames: list[str]
+
+
+class ImageIndexLookupResponse(BaseModel):
+    # Maps each requested filename to its album index, or null if not present.
+    indices: dict[str, int | None]
+
+
+@search_router.post(
+    "/image_indices/{album_key}",
+    response_model=ImageIndexLookupResponse,
+    tags=["Search"],
+)
+async def lookup_image_indices(
+    album_key: str,
+    req: ImageIndexLookupRequest,
+) -> ImageIndexLookupResponse:
+    """Resolve album indices for a batch of filenames (by basename).
+
+    Used by the metadata drawer to decide which reference-image filenames
+    correspond to images present in the current album, so they can be rendered
+    as clickable thumbnails. Filenames not found in the album map to ``null``.
+    Duplicate basenames in the album resolve to the first matching index.
+    """
+    embeddings = get_embeddings_for_album(album_key)
+    if not embeddings:
+        raise HTTPException(status_code=404, detail="Album not found")
+
+    sorted_filenames = embeddings.indexes["sorted_filenames"]
+    basename_to_index: dict[str, int] = {}
+    for idx, full_path in enumerate(sorted_filenames):
+        basename = Path(full_path).name
+        basename_to_index.setdefault(basename, idx)
+
+    return ImageIndexLookupResponse(
+        indices={name: basename_to_index.get(name) for name in req.filenames}
+    )
+
+
 @search_router.get(
     "/image_by_name/{album_key}/{filename:path}",
     response_class=FileResponse,

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -149,8 +149,53 @@
   padding: 6px 10px;
 }
 
+.ref-image-thumb {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  max-width: 140px;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.ref-image-thumb img {
+  display: block;
+  width: 96px;
+  height: 96px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid #555;
+  background: #1a1a1a;
+}
+
+.ref-image-thumb:hover img {
+  border-color: #faea0e;
+}
+
+.ref-image-thumb-caption {
+  font-size: 0.78em;
+  color: #ccc;
+  text-align: center;
+  word-break: break-all;
+  max-width: 100%;
+  line-height: 1.2;
+}
+
+.ref-image-thumb:hover .ref-image-thumb-caption {
+  color: #faea0e;
+}
+
 .details-link-cell {
   text-align: right;
+  /* Pin the link to the bottom of the scrollable description area so it
+     remains visible even when reference-image thumbnails push the table
+     past the 40vh scroll cap. Solid background keeps preceding rows from
+     showing through as they scroll under the sticky cell. */
+  position: sticky;
+  bottom: 0;
+  background: #1a1a1a;
 }
 
 /* ===== Recall / Remix buttons (pinned outside scrollable area) ===== */

--- a/photomap/frontend/static/javascript/grid-view.js
+++ b/photomap/frontend/static/javascript/grid-view.js
@@ -1,7 +1,7 @@
 import { addBookmarkIconToSlide } from "./bookmarks.js";
 import { toggleGridSwiperView } from "./events.js";
 import {
-  replaceReferenceImagesWithLinks,
+  enhanceReferenceImageThumbnails,
   updateClusterInfo,
   updateCurrentImageScore,
   updateImageLabel,
@@ -674,6 +674,13 @@ class GridViewManager {
   }
 
   updateMetadataOverlay() {
+    // When grid view isn't the active mode, the swiper view owns the shared
+    // descriptionText element. Touching it from here would wipe the details
+    // table the swiper just installed.
+    if (!state.gridViewActive) {
+      return;
+    }
+
     const globalIndex = slideState.getCurrentSlide().globalIndex;
     const data = this.slideData[globalIndex];
     if (!data) {
@@ -682,9 +689,10 @@ class GridViewManager {
 
     const rawDescription = data["description"] || "";
     const referenceImages = data["reference_images"] || [];
-    const processedDescription = replaceReferenceImagesWithLinks(rawDescription, referenceImages, state.album);
 
-    document.getElementById("descriptionText").innerHTML = processedDescription;
+    const descriptionText = document.getElementById("descriptionText");
+    descriptionText.innerHTML = rawDescription;
+    enhanceReferenceImageThumbnails(descriptionText, referenceImages, state.album);
 
     // Inject filepath as first row of the metadata table
     const filepath = data["filepath"] || "";
@@ -710,7 +718,17 @@ class GridViewManager {
     }
 
     document.getElementById("filenameText").textContent = data["filename"] || "";
-    document.getElementById("metadataLink").href = data["metadata_url"] || "#";
+    const masterLink = document.getElementById("metadataLink");
+    if (masterLink) {
+      masterLink.href = data["metadata_url"] || "#";
+    }
+    // Make sure the link is visible — a prior swiper render may have set
+    // linkContainer.style.display = "none" when it cloned the link into
+    // its details table.
+    const linkContainer = document.getElementById("metadataLinkContainer");
+    if (linkContainer) {
+      linkContainer.style.display = "";
+    }
 
     // Update cluster information display
     updateClusterInfo(data);

--- a/photomap/frontend/static/javascript/metadata-drawer.js
+++ b/photomap/frontend/static/javascript/metadata-drawer.js
@@ -13,6 +13,9 @@ import {
   getImageLabelInfo,
   SHOW_CLUSTER_LABELS_IN_BADGES,
 } from "./cluster-utils.js";
+import { enhanceReferenceImageThumbnails, registerReferenceThumbnailClickHandler } from "./reference-thumbnails.js";
+
+export { enhanceReferenceImageThumbnails };
 
 // Set up the bookmark toggle callback for the star icon
 scoreDisplay.setToggleBookmarkCallback((globalIndex) => {
@@ -47,62 +50,19 @@ export function toggleMetadataOverlay() {
   }
 }
 
-// Function to replace reference image filenames with clickable links
-export function replaceReferenceImagesWithLinks(description, referenceImages, albumKey) {
-  if (!description || !referenceImages || !albumKey) {
-    return description || "";
-  }
-
-  let processedDescription = description;
-
-  // Parse reference_images if it's a JSON string
-  let imageList = [];
-  try {
-    if (typeof referenceImages === "string") {
-      imageList = JSON.parse(referenceImages);
-    } else if (Array.isArray(referenceImages)) {
-      imageList = referenceImages;
-    }
-  } catch (e) {
-    console.warn("Failed to parse reference_images:", e);
-    return description;
-  }
-
-  // Replace each reference image filename with a link
-  imageList.forEach((imageName) => {
-    if (imageName && typeof imageName === "string") {
-      // Create a case-insensitive global regex to find all instances
-      const regex = new RegExp(imageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "gi");
-      const link = `<a href="image_by_name/${encodeURIComponent(albumKey)}/${encodeURIComponent(
-        imageName
-      )}" target="_blank" style="color: #faea0e;">${imageName}</a>`;
-      processedDescription = processedDescription.replace(regex, link);
-    }
-  });
-
-  return processedDescription;
-}
-
 // Update banner with current slide's metadata
 export function updateMetadataOverlay(slide) {
   if (!slide) {
     return;
   }
 
-  // Process description with reference image links
   const rawDescription = slide.dataset.description || "";
   const referenceImages = slide.dataset.reference_images || [];
-  const processedDescription = replaceReferenceImagesWithLinks(rawDescription, referenceImages, state.album);
+  const metadataUrl = slide.dataset.metadata_url || "#";
 
-  // Park the View Metadata (JSON) link in its standalone container before
-  // the innerHTML rewrite below — on the previous slide it may have been
-  // moved into the table, where rewriting descriptionText would destroy it
-  // (and its click listener) along with the table.
-  const metadataLink = document.getElementById("metadataLink");
-  const linkContainer = document.getElementById("metadataLinkContainer");
-  linkContainer.appendChild(metadataLink);
-
-  document.getElementById("descriptionText").innerHTML = processedDescription;
+  const descriptionText = document.getElementById("descriptionText");
+  descriptionText.innerHTML = rawDescription;
+  enhanceReferenceImageThumbnails(descriptionText, referenceImages, state.album);
 
   // Inject filepath as first row of the metadata table
   const filepath = slide.dataset.filepath || "";
@@ -128,25 +88,40 @@ export function updateMetadataOverlay(slide) {
   }
 
   document.getElementById("filenameText").textContent = slide.dataset.filename || "";
-  metadataLink.href = slide.dataset.metadata_url || "#";
 
-  // When a details table is present (Invoke's .invoke-metadata or EXIF's
-  // .exif-metadata table), tuck the View Metadata link into a full-width
-  // cell at the bottom. Otherwise leave it in the standalone container so
-  // it's still reachable for no-metadata images.
+  // Two metadata-link slots: the master sits in #metadataLinkContainer below
+  // the scrollable description and never moves; a clone is inserted into the
+  // bottom of the details table. The clone shares the .metadata-link class so
+  // the document-level delegated click handler activates it. Cloning instead
+  // of moving the master means an innerHTML wipe of descriptionText (by this
+  // function or by grid-view's equivalent) can never destroy the only
+  // metadata link in the page.
+  const masterLink = document.getElementById("metadataLink");
+  if (masterLink) {
+    masterLink.href = metadataUrl;
+  }
   const detailsTable =
     document.querySelector("#descriptionText .invoke-metadata") ||
     document.querySelector("#descriptionText .exif-metadata table");
+  const linkContainer = document.getElementById("metadataLinkContainer");
   if (detailsTable) {
+    const cloneLink = document.createElement("a");
+    cloneLink.className = "metadata-link";
+    cloneLink.href = metadataUrl;
+    cloneLink.target = "_blank";
+    cloneLink.rel = "noopener noreferrer";
+    cloneLink.textContent = "View Metadata (JSON)";
     const row = document.createElement("tr");
     const cell = document.createElement("td");
     cell.colSpan = 2;
     cell.className = "details-link-cell";
-    cell.appendChild(metadataLink);
+    cell.appendChild(cloneLink);
     row.appendChild(cell);
     (detailsTable.tBodies[0] || detailsTable).appendChild(row);
-    linkContainer.style.display = "none";
-  } else {
+    if (linkContainer) {
+      linkContainer.style.display = "none";
+    }
+  } else if (linkContainer) {
     linkContainer.style.display = "";
   }
 
@@ -340,19 +315,24 @@ export async function updateCurrentImageScore(metadata) {
 const metadataModal = document.getElementById("metadataModal");
 const metadataTextArea = document.getElementById("metadataTextArea");
 const closeMetadataModalBtn = document.getElementById("closeMetadataModalBtn");
-const metadataLink = document.getElementById("metadataLink");
 
-// Show modal and fetch metadata
-metadataLink.addEventListener("click", async (e) => {
+// Delegated click on any .metadata-link (the master in #metadataLinkContainer
+// and any per-table clone) — using delegation rather than binding to a single
+// element lets updateMetadataOverlay clone the link into the details table
+// without losing the handler if the table is later wiped by innerHTML.
+document.addEventListener("click", async (e) => {
+  const link = e.target.closest(".metadata-link");
+  if (!link) {
+    return;
+  }
   e.preventDefault();
   if (!metadataModal || !metadataTextArea) {
     return;
   }
   metadataModal.classList.add("visible");
 
-  // Fetch JSON metadata from the link's href
   try {
-    const resp = await fetch(metadataLink.href);
+    const resp = await fetch(link.href);
     if (resp.ok) {
       const text = await resp.text();
       metadataTextArea.value = text;
@@ -600,6 +580,7 @@ function setupOverlayButtons() {
 // Initialize metadata drawer - sets up all event listeners
 export function initializeMetadataDrawer() {
   setupOverlayButtons();
+  registerReferenceThumbnailClickHandler();
 
   // Metadata-fields accordion: mirrors the open/closed pattern used by the
   // Settings dialog accordions, with the open state persisted in

--- a/photomap/frontend/static/javascript/reference-thumbnails.js
+++ b/photomap/frontend/static/javascript/reference-thumbnails.js
@@ -1,0 +1,153 @@
+// reference-thumbnails.js
+// Enhances the metadata drawer's rendered InvokeAI table by replacing
+// reference-image filenames with clickable thumbnails for images that are
+// present in the current album. Filenames not in the album are left as the
+// plain text the formatter already rendered.
+
+import { slideState } from "./slide-state.js";
+
+// Parse the slide dataset's reference_images attribute (a JSON-stringified
+// list of filenames as written by the slide loader) into an array.
+// Returns [] for anything missing or malformed.
+export function parseReferenceImages(referenceImages) {
+  if (!referenceImages) {
+    return [];
+  }
+  if (Array.isArray(referenceImages)) {
+    return referenceImages.filter((s) => typeof s === "string" && s);
+  }
+  if (typeof referenceImages !== "string") {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(referenceImages);
+    return Array.isArray(parsed) ? parsed.filter((s) => typeof s === "string" && s) : [];
+  } catch (e) {
+    console.warn("Failed to parse reference_images:", e);
+    return [];
+  }
+}
+
+// Tracks the most recent enhancement request so stale fetches whose slide
+// has since changed are discarded rather than mutating the new slide's DOM.
+let _refThumbsFetchToken = 0;
+
+// Walk a rendered metadata description and turn every reference-image
+// filename cell into a clickable thumbnail block when that filename is
+// present in the current album. Filenames not in the album are left as
+// plain text. Safe to call without awaiting; race protection is built in.
+export async function enhanceReferenceImageThumbnails(container, referenceImages, albumKey, { fetchImpl } = {}) {
+  if (!container || !albumKey) {
+    return;
+  }
+  const imageList = parseReferenceImages(referenceImages);
+  if (imageList.length === 0) {
+    return;
+  }
+
+  const wanted = new Set(imageList);
+  const matches = collectReferenceFilenameNodes(container, wanted);
+  if (matches.length === 0) {
+    return;
+  }
+
+  _refThumbsFetchToken += 1;
+  const myToken = _refThumbsFetchToken;
+
+  const doFetch = fetchImpl || globalThis.fetch;
+  let indices;
+  try {
+    const resp = await doFetch(`image_indices/${encodeURIComponent(albumKey)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filenames: Array.from(wanted) }),
+    });
+    if (!resp.ok) {
+      return;
+    }
+    const body = await resp.json();
+    indices = body.indices || {};
+  } catch (e) {
+    console.warn("Reference-image index lookup failed:", e);
+    return;
+  }
+
+  // Slide changed mid-fetch: bail out so we don't graft thumbnails onto a
+  // DOM that has been rewritten for a different image.
+  if (myToken !== _refThumbsFetchToken) {
+    return;
+  }
+
+  for (const { node, filename } of matches) {
+    const index = indices[filename];
+    if (typeof index !== "number") {
+      continue;
+    }
+    const thumb = buildReferenceThumbnail(albumKey, index, filename);
+    const cell = node.parentNode;
+    if (cell) {
+      cell.replaceChild(thumb, node);
+    }
+  }
+}
+
+// Find text nodes inside the InvokeAI metadata sub-tables (`.invoke-tuples`)
+// whose trimmed value exactly equals one of the wanted filenames. The full
+// trimmed-match constraint keeps us from rewriting prompt or note cells
+// that happen to mention the same string.
+export function collectReferenceFilenameNodes(container, wanted) {
+  const cells = container.querySelectorAll(".invoke-tuples td");
+  const results = [];
+  cells.forEach((cell) => {
+    if (cell.childNodes.length !== 1) {
+      return;
+    }
+    const node = cell.firstChild;
+    if (node.nodeType !== 3 /* Node.TEXT_NODE */) {
+      return;
+    }
+    const filename = node.nodeValue.trim();
+    if (wanted.has(filename)) {
+      results.push({ node, filename });
+    }
+  });
+  return results;
+}
+
+export function buildReferenceThumbnail(albumKey, index, filename) {
+  const link = document.createElement("a");
+  link.href = "#";
+  link.className = "ref-image-thumb";
+  link.dataset.globalIndex = String(index);
+  link.title = `Show ${filename}`;
+
+  const img = document.createElement("img");
+  img.src = `thumbnails/${encodeURIComponent(albumKey)}/${index}?size=128`;
+  img.alt = filename;
+  img.loading = "lazy";
+
+  const caption = document.createElement("div");
+  caption.className = "ref-image-thumb-caption";
+  caption.textContent = filename;
+
+  link.appendChild(img);
+  link.appendChild(caption);
+  return link;
+}
+
+// Document-level delegated click handler. Activates a thumbnail click no
+// matter where it sits in the page, so the rewritten innerHTML in
+// updateMetadataOverlay does not require re-binding listeners per slide.
+export function registerReferenceThumbnailClickHandler() {
+  document.addEventListener("click", (e) => {
+    const thumb = e.target.closest(".ref-image-thumb");
+    if (!thumb) {
+      return;
+    }
+    e.preventDefault();
+    const index = parseInt(thumb.dataset.globalIndex, 10);
+    if (Number.isFinite(index)) {
+      slideState.navigateToIndex(index, false);
+    }
+  });
+}

--- a/tests/backend/test_invoke_metadata.py
+++ b/tests/backend/test_invoke_metadata.py
@@ -672,11 +672,10 @@ class TestFormatInvokeMetadataEmptyFields:
         assert "<td>0.6</td>" in html
         assert "Medium" not in html
 
-    def test_mixed_weight_column_defaults_missing_weights_to_1_0(self):
-        """Regression for the ragged-row bug: when some ref_images have an
-        explicit weight and others don't, every row renders with a weight
-        cell and missing weights default to 1.0 instead of leaving a blank
-        column on the first row.
+    def test_mixed_weight_column_leaves_missing_weights_blank(self):
+        """When some IP-adapter refs carry an explicit weight and others do
+        not, the column survives (one row has data) and rows without a
+        weight render as an empty cell rather than a synthesized 1.0.
         """
         metadata = {
             "metadata_version": 5,
@@ -690,8 +689,9 @@ class TestFormatInvokeMetadataEmptyFields:
                     "isEnabled": True,
                     "config": {
                         "type": "ipAdapter",
+                        "model": {"name": "ipa"},
                         "image": {"image_name": "first.png"},
-                        # no weight — should render as 1.0 in a surviving column
+                        # no weight — column survives, this cell stays empty
                     },
                 },
                 {
@@ -699,6 +699,7 @@ class TestFormatInvokeMetadataEmptyFields:
                     "isEnabled": True,
                     "config": {
                         "type": "ipAdapter",
+                        "model": {"name": "ipa"},
                         "image": {"image_name": "second.png"},
                         "weight": 0.7,
                     },
@@ -709,14 +710,62 @@ class TestFormatInvokeMetadataEmptyFields:
         start = html.index("<table class='invoke-tuples'>")
         end = html.index("</table>", start)
         tuple_table = html[start:end]
-        # model_name column is empty on every row → dropped.
-        # Two surviving columns (image, weight) × two rows → 4 <td>s total.
+        # All three columns survive (model, image, weight) × 2 rows → 6 <td>s.
         assert tuple_table.count("<tr>") == 2
-        assert tuple_table.count("<td>") == 4
+        assert tuple_table.count("<td>") == 6
         assert "<td>first.png</td>" in tuple_table
         assert "<td>second.png</td>" in tuple_table
-        assert "<td>1.0</td>" in tuple_table
+        # First row has an empty weight cell — no synthesized 1.0.
         assert "<td>0.7</td>" in tuple_table
+        assert "<td>1.0</td>" not in tuple_table
+        assert "<td></td>" in tuple_table
+
+    def test_refs_without_ip_adapter_suppress_weight_column(self):
+        """Reference images that attach directly to the model (Flux2, Qwen,
+        etc.) have no IP adapter — ``cfg.model`` is None — and any weight
+        InvokeAI serializes for them is an internal default, not a user
+        value. The column should drop entirely so a stray serialized 1.0
+        on one row doesn't make the user think the other ref has no weight
+        while this one does.
+        """
+        metadata = {
+            "metadata_version": 5,
+            "app_version": "6.12.0",
+            "positive_prompt": "x",
+            "seed": 1,
+            "model": {"name": "m"},
+            "ref_images": [
+                {
+                    "id": "r1",
+                    "isEnabled": True,
+                    "config": {
+                        "type": "flux2_reference_image",
+                        "image": {"image_name": "first.png"},
+                        # no weight at all
+                    },
+                },
+                {
+                    "id": "r2",
+                    "isEnabled": True,
+                    "config": {
+                        "type": "flux2_reference_image",
+                        "image": {"image_name": "second.png"},
+                        "model": None,
+                        "weight": 1,  # serialized internal default
+                    },
+                },
+            ],
+        }
+        html = format_invoke_metadata(_slide(), metadata).description
+        start = html.index("<table class='invoke-tuples'>")
+        end = html.index("</table>", start)
+        tuple_table = html[start:end]
+        # Only the image-name column survives → 1 cell per row.
+        assert tuple_table.count("<tr>") == 2
+        assert tuple_table.count("<td>") == 2
+        assert "<td>first.png</td>" in tuple_table
+        assert "<td>second.png</td>" in tuple_table
+        assert "1" not in tuple_table.replace("first.png", "").replace("second.png", "")
 
     def test_ref_images_list_of_lists_is_flattened(self):
         """Some legacy metadata wraps ref_images in an outer list. The v5

--- a/tests/backend/test_search.py
+++ b/tests/backend/test_search.py
@@ -188,6 +188,64 @@ def test_text_search(client, new_album, monkeypatch):
     ), "Text search returned unexpected image"
 
 
+def test_image_indices_lookup(client, new_album, monkeypatch):
+    """The batch /image_indices endpoint resolves album basenames to their
+    indices and returns null for filenames not present in the album. Powers
+    the metadata drawer's reference-image-thumbnail enhancement.
+    """
+    from photomap.backend.embeddings import Embeddings
+
+    monkeypatch.setattr(Embeddings, "minimum_image_size", 10 * 1024)
+
+    response = client.post("/update_index_async", json={"album_key": new_album["key"]})
+    assert response.status_code == 202
+    try:
+        poll_during_indexing(client, new_album["key"])
+    except TimeoutError as e:
+        pytest.fail(f"Indexing did not complete: {str(e)}")
+
+    known = fetch_filename(client, new_album["key"], 0)
+    response = client.post(
+        f"/image_indices/{quote(new_album['key'])}",
+        json={"filenames": [known, "definitely-not-in-album.png", "another-missing.jpg"]},
+    )
+    assert response.status_code == 200
+    indices = response.json()["indices"]
+    assert indices[known] == 0
+    assert indices["definitely-not-in-album.png"] is None
+    assert indices["another-missing.jpg"] is None
+
+
+def test_image_indices_empty_request(client, new_album, monkeypatch):
+    """An empty filenames list returns an empty mapping (not an error)."""
+    from photomap.backend.embeddings import Embeddings
+
+    monkeypatch.setattr(Embeddings, "minimum_image_size", 10 * 1024)
+
+    response = client.post("/update_index_async", json={"album_key": new_album["key"]})
+    assert response.status_code == 202
+    try:
+        poll_during_indexing(client, new_album["key"])
+    except TimeoutError as e:
+        pytest.fail(f"Indexing did not complete: {str(e)}")
+
+    response = client.post(
+        f"/image_indices/{quote(new_album['key'])}",
+        json={"filenames": []},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"indices": {}}
+
+
+def test_image_indices_unknown_album(client):
+    """Unknown album keys yield a 404 rather than an empty success."""
+    response = client.post(
+        "/image_indices/nonexistent_album",
+        json={"filenames": ["any.png"]},
+    )
+    assert response.status_code == 404
+
+
 def test_calibration_skipped_for_image_queries(tmp_path, monkeypatch):
     """SigLIP's sigmoid calibration was crushing every image-image cosine to
     1.0, returning 100 saturated matches. Calibration must only apply to

--- a/tests/frontend/grid-view-deletion.test.js
+++ b/tests/frontend/grid-view-deletion.test.js
@@ -56,7 +56,7 @@ jest.unstable_mockModule("../../photomap/frontend/static/javascript/search.js", 
 
 // Mock metadata-drawer.js
 jest.unstable_mockModule("../../photomap/frontend/static/javascript/metadata-drawer.js", () => ({
-  replaceReferenceImagesWithLinks: jest.fn(() => ""),
+  enhanceReferenceImageThumbnails: jest.fn(),
   updateCurrentImageScore: jest.fn(),
   updateClusterInfo: jest.fn(),
   updateImageLabel: jest.fn(),

--- a/tests/frontend/grid-view.test.js
+++ b/tests/frontend/grid-view.test.js
@@ -67,7 +67,7 @@ jest.unstable_mockModule("../../photomap/frontend/static/javascript/search.js", 
 
 // Mock metadata-drawer.js
 jest.unstable_mockModule("../../photomap/frontend/static/javascript/metadata-drawer.js", () => ({
-  replaceReferenceImagesWithLinks: jest.fn(() => ""),
+  enhanceReferenceImageThumbnails: jest.fn(),
   updateCurrentImageScore: jest.fn(),
   updateClusterInfo: jest.fn(),
   updateImageLabel: jest.fn(),

--- a/tests/frontend/reference-thumbnails.test.js
+++ b/tests/frontend/reference-thumbnails.test.js
@@ -1,0 +1,188 @@
+// Unit tests for reference-thumbnails.js
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+// Mock slide-state.js so its transitive imports (state.js → album-manager.js
+// → settings.js → umap.js) don't pull DOM-side-effect modules into the
+// import graph for this unit test.
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/slide-state.js", () => ({
+  slideState: {
+    navigateToIndex: jest.fn(),
+  },
+}));
+
+const {
+  buildReferenceThumbnail,
+  collectReferenceFilenameNodes,
+  enhanceReferenceImageThumbnails,
+  parseReferenceImages,
+} = await import("../../photomap/frontend/static/javascript/reference-thumbnails.js");
+
+describe("parseReferenceImages", () => {
+  it("returns [] for empty inputs", () => {
+    expect(parseReferenceImages(null)).toEqual([]);
+    expect(parseReferenceImages(undefined)).toEqual([]);
+    expect(parseReferenceImages("")).toEqual([]);
+    expect(parseReferenceImages([])).toEqual([]);
+  });
+
+  it("parses JSON string input", () => {
+    expect(parseReferenceImages('["a.png","b.jpg"]')).toEqual(["a.png", "b.jpg"]);
+  });
+
+  it("passes through array input", () => {
+    expect(parseReferenceImages(["a.png", "b.jpg"])).toEqual(["a.png", "b.jpg"]);
+  });
+
+  it("filters non-string entries", () => {
+    expect(parseReferenceImages(["a.png", 42, null, "b.jpg", ""])).toEqual(["a.png", "b.jpg"]);
+  });
+
+  it("returns [] for malformed JSON without throwing", () => {
+    const spy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    expect(parseReferenceImages("{not json")).toEqual([]);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("returns [] when JSON parses to a non-array", () => {
+    expect(parseReferenceImages('{"x":1}')).toEqual([]);
+  });
+});
+
+describe("collectReferenceFilenameNodes", () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+  });
+
+  it("matches single-text-node cells whose trimmed text equals a wanted filename", () => {
+    container.innerHTML = `
+      <table class="invoke-tuples">
+        <tr><td>ip-adapter</td><td>ref-1.png</td><td>0.7</td></tr>
+        <tr><td>ip-adapter</td><td>  ref-2.png  </td><td>0.5</td></tr>
+      </table>
+    `;
+    const matches = collectReferenceFilenameNodes(container, new Set(["ref-1.png", "ref-2.png", "not-present.png"]));
+    expect(matches.map((m) => m.filename)).toEqual(["ref-1.png", "ref-2.png"]);
+  });
+
+  it("ignores cells with multiple child nodes", () => {
+    container.innerHTML = `
+      <table class="invoke-tuples">
+        <tr><td>ref-1.png<span> extra</span></td></tr>
+      </table>
+    `;
+    expect(collectReferenceFilenameNodes(container, new Set(["ref-1.png"]))).toEqual([]);
+  });
+
+  it("ignores cells outside .invoke-tuples tables (e.g. prompt cells)", () => {
+    container.innerHTML = `
+      <table class="invoke-metadata">
+        <tr><th>Prompt</th><td class="copyme">ref-1.png</td></tr>
+      </table>
+    `;
+    expect(collectReferenceFilenameNodes(container, new Set(["ref-1.png"]))).toEqual([]);
+  });
+});
+
+describe("buildReferenceThumbnail", () => {
+  it("creates a clickable anchor with thumbnail and caption", () => {
+    const link = buildReferenceThumbnail("my album", 42, "ref-1.png");
+    expect(link.tagName).toBe("A");
+    expect(link.classList.contains("ref-image-thumb")).toBe(true);
+    expect(link.dataset.globalIndex).toBe("42");
+    expect(link.title).toBe("Show ref-1.png");
+
+    const img = link.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img.alt).toBe("ref-1.png");
+    // Album key must be URL-encoded so spaces don't break the URL.
+    expect(img.src).toContain("/thumbnails/my%20album/42");
+    expect(img.src).toContain("size=128");
+    expect(img.loading).toBe("lazy");
+
+    const caption = link.querySelector(".ref-image-thumb-caption");
+    expect(caption).not.toBeNull();
+    expect(caption.textContent).toBe("ref-1.png");
+  });
+});
+
+describe("enhanceReferenceImageThumbnails", () => {
+  let container;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    container.innerHTML = `
+      <table class="invoke-metadata">
+        <tr><th>Reference Images</th><td>
+          <table class="invoke-tuples">
+            <tr><td>ip-adapter</td><td>in-album.png</td><td>0.7</td></tr>
+            <tr><td>ip-adapter</td><td>missing.png</td><td>0.5</td></tr>
+          </table>
+        </td></tr>
+      </table>
+    `;
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  it("replaces in-album filename cells with clickable thumbnails", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ indices: { "in-album.png": 7, "missing.png": null } }),
+    });
+
+    await enhanceReferenceImageThumbnails(container, ["in-album.png", "missing.png"], "test_album", { fetchImpl });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "image_indices/test_album",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const body = JSON.parse(fetchImpl.mock.calls[0][1].body);
+    expect(body.filenames.sort()).toEqual(["in-album.png", "missing.png"]);
+
+    const thumbs = container.querySelectorAll("a.ref-image-thumb");
+    expect(thumbs.length).toBe(1);
+    expect(thumbs[0].dataset.globalIndex).toBe("7");
+
+    // The missing entry remains as the original text node.
+    const cells = container.querySelectorAll(".invoke-tuples td");
+    const missingCell = Array.from(cells).find((c) => c.textContent.trim() === "missing.png");
+    expect(missingCell).not.toBeUndefined();
+    expect(missingCell.querySelector("a.ref-image-thumb")).toBeNull();
+  });
+
+  it("skips the network call when none of the wanted filenames are rendered", async () => {
+    const fetchImpl = jest.fn();
+    await enhanceReferenceImageThumbnails(container, ["nothing-here.png"], "test_album", { fetchImpl });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(container.querySelectorAll("a.ref-image-thumb").length).toBe(0);
+  });
+
+  it("returns silently when the request fails", async () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchImpl = jest.fn().mockRejectedValue(new Error("network"));
+    await enhanceReferenceImageThumbnails(container, ["in-album.png"], "test_album", { fetchImpl });
+    expect(container.querySelectorAll("a.ref-image-thumb").length).toBe(0);
+  });
+
+  it("does nothing when albumKey is missing", async () => {
+    const fetchImpl = jest.fn();
+    await enhanceReferenceImageThumbnails(container, ["in-album.png"], "", { fetchImpl });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when referenceImages is empty", async () => {
+    const fetchImpl = jest.fn();
+    await enhanceReferenceImageThumbnails(container, [], "test_album", { fetchImpl });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- When the metadata drawer shows an InvokeAI reference image whose filename is present in the current album, it's now rendered as a clickable 96px thumbnail captioned with the filename. Clicking navigates the active view (swiper or grid) to that image; refs not in the album stay as plain text.
- New `POST /image_indices/{album_key}` endpoint batches filename → album-index lookups for the drawer.
- A standalone `reference-thumbnails.js` module owns the lookup, DOM walk, thumbnail construction, and click delegation; covered by 15 new Jest tests.

## Adjacent metadata-drawer fixes surfaced while testing

- **Weight column suppressed for refs without an IP adapter.** For Flux2, Qwen, and other direct-attach reference images, `cfg.model` is `None` and the `weight` value InvokeAI sometimes serializes is an internal default — not a user-set weight. Suppressing it drops the column cleanly when no rows carry meaningful weights and stops the misleading "1.0" cell.
- **No more synthesized 1.0 fallback.** When the weight column survives because one row has a weight, rows without one now render as an empty cell instead of `1.0`.
- **Fix `appendChild ... parameter 1 is not of type 'Node'` mid-navigation.** Concurrent grid-view + swiper handlers were both touching the shared `#descriptionText`. The grid's wipe destroyed the `#metadataLink` element the swiper had tucked into its details table; the next swiper `slideChange` then `appendChild(null)`'d and threw. The link is now a fresh `<a class="metadata-link">` clone in the table row, with the master element pinned in `#metadataLinkContainer` and the click handler delegated on `.metadata-link`. The grid-view's `updateMetadataOverlay` also early-returns when grid view isn't the active mode.
- **Details-link row stays visible.** Added `position: sticky; bottom: 0;` to `.details-link-cell` so the "View Metadata (JSON)" link stays pinned at the bottom of the description's scroll area even when thumbnails grow the table past the 40vh cap.

## Test plan

- [x] `make lint` — clean
- [x] `pytest tests/backend` — 257 passed (3 new for `/image_indices`, 1 new for weight suppression)
- [x] `npm test` — 248 passed (15 new for `reference-thumbnails.js`)
- [x] Manual: reference image present in album renders a thumbnail; clicking it navigates to that image in swiper view
- [x] Manual: reference image not in album stays as plain text
- [x] Manual: Flux2 image (no IP adapter on either ref) — no weight column
- [x] Manual: mixed IP-adapter refs with one weight set — weight column shown, missing-weight cell empty
- [x] Manual: clicking a reference thumbnail no longer throws the appendChild Node error
- [x] Manual: "View Metadata (JSON)" link visible at bottom of details table, stays put while scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)