### PR TITLE
feat(back-nav): in-app Back button + browser back/forward for slide history

### DIFF
--- a/photomap/frontend/static/css/control-and-search-panels.css
+++ b/photomap/frontend/static/css/control-and-search-panels.css
@@ -55,6 +55,40 @@
   opacity: 1;
 }
 
+#controlPanel button.back-nav-disabled,
+#controlPanel button.back-nav-disabled:hover {
+  opacity: 0.25;
+  cursor: default;
+}
+
+#backNavFlyout {
+  position: fixed;
+  background: rgba(30, 30, 30, 0.95);
+  border: 1px solid #444;
+  padding: 8px;
+  border-radius: 6px;
+  z-index: 10000;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  max-width: 360px;
+}
+
+#backNavFlyout .back-nav-thumb {
+  width: 72px;
+  height: 72px;
+  object-fit: cover;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: border-color 0.15s;
+  background: #111;
+}
+
+#backNavFlyout .back-nav-thumb:hover {
+  border-color: #fff;
+}
+
 /* Drag-over highlight for search panel */
 #searchPanel.drag-over {
   border: 2px dashed #00ff99;

--- a/photomap/frontend/static/javascript/back-button.js
+++ b/photomap/frontend/static/javascript/back-button.js
@@ -1,0 +1,137 @@
+// back-button.js
+// UI wiring for the Back button in the control panel. Left-click pops one
+// step off the back stack; right-click (or long-press) opens a flyout of
+// recent positions as thumbnails the user can jump to directly.
+
+import { backStack } from "./back-stack.js";
+import { state } from "./state.js";
+
+const FLYOUT_LIMIT = 10;
+const DISABLED_CLASS = "back-nav-disabled";
+const FLYOUT_ID = "backNavFlyout";
+
+function updateButtonState(btn) {
+  // Back is possible only when there is something to back up to — i.e. at
+  // least two entries (current + previous).
+  if (backStack.size() >= 2) {
+    btn.classList.remove(DISABLED_CLASS);
+  } else {
+    btn.classList.add(DISABLED_CLASS);
+  }
+}
+
+function removeFlyout() {
+  const existing = document.getElementById(FLYOUT_ID);
+  if (existing) {
+    if (existing._cleanup) {
+      existing._cleanup();
+    }
+    existing.remove();
+  }
+}
+
+function thumbnailUrl(globalIndex) {
+  if (!state.album) {
+    return "";
+  }
+  return `thumbnails/${encodeURIComponent(state.album)}/${globalIndex}?size=128`;
+}
+
+function buildFlyout(x, y) {
+  removeFlyout();
+
+  const entries = backStack.recent(FLYOUT_LIMIT);
+  if (entries.length === 0) {
+    return;
+  }
+
+  const flyout = document.createElement("div");
+  flyout.id = FLYOUT_ID;
+
+  for (const entry of entries) {
+    const img = document.createElement("img");
+    img.className = "back-nav-thumb";
+    img.src = thumbnailUrl(entry.globalIndex);
+    img.alt = `slide ${entry.globalIndex}`;
+    img.title = `Back to ${entry.kind === "step" ? "earlier slide" : entry.kind} #${entry.globalIndex}`;
+    img.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      removeFlyout();
+      backStack.popToEntry(entry.id);
+    });
+    flyout.appendChild(img);
+  }
+
+  document.body.appendChild(flyout);
+
+  // Position after appending so we can measure the flyout's actual size.
+  const rect = flyout.getBoundingClientRect();
+  const margin = 6;
+  let left = x;
+  let top = y;
+  if (left + rect.width > window.innerWidth - margin) {
+    left = Math.max(margin, window.innerWidth - rect.width - margin);
+  }
+  if (top + rect.height > window.innerHeight - margin) {
+    top = Math.max(margin, window.innerHeight - rect.height - margin);
+  }
+  flyout.style.left = `${left}px`;
+  flyout.style.top = `${top}px`;
+
+  const onDocClick = (ev) => {
+    if (!flyout.contains(ev.target)) {
+      removeFlyout();
+    }
+  };
+  const onKey = (ev) => {
+    if (ev.key === "Escape") {
+      removeFlyout();
+    }
+  };
+  // Defer so the same click that opened the flyout doesn't immediately close it.
+  setTimeout(() => {
+    document.addEventListener("click", onDocClick);
+    document.addEventListener("keydown", onKey);
+  }, 0);
+  flyout._cleanup = () => {
+    document.removeEventListener("click", onDocClick);
+    document.removeEventListener("keydown", onKey);
+  };
+}
+
+export function showBackFlyout(x, y) {
+  buildFlyout(x, y);
+}
+
+export function initializeBackButton() {
+  const btn = document.getElementById("backNavBtn");
+  if (!btn) {
+    return;
+  }
+
+  updateButtonState(btn);
+
+  btn.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (btn.classList.contains(DISABLED_CLASS)) {
+      return;
+    }
+    backStack.popOne();
+  });
+
+  btn.addEventListener("contextmenu", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (backStack.size() < 2) {
+      return;
+    }
+    buildFlyout(e.clientX + 6, e.clientY + 6);
+  });
+
+  // The back stack emits backStackChanged on every mutation. Listening for
+  // that (rather than slideChanged) keeps the button in sync even when the
+  // swiper suppresses its own slideChange event during an in-place restore.
+  window.addEventListener("backStackChanged", () => updateButtonState(btn));
+  window.addEventListener("albumChanged", () => removeFlyout());
+}

--- a/photomap/frontend/static/javascript/back-stack.js
+++ b/photomap/frontend/static/javascript/back-stack.js
@@ -4,10 +4,17 @@
 // UMAP cluster click, reference-thumbnail click). Slide-by-slide navigation
 // is recorded in memory only — only jumps are pushed onto the browser's
 // history stack, keeping the browser back button at a useful granularity.
+//
+// _entries is a timeline (NOT a stack): forward history is preserved when
+// the user backs up, so browser Forward can redo a jump that was undone.
+// _cursor points to the user's current position in the timeline. A new push
+// after a back-action truncates the forward portion of the timeline
+// (text-editor undo/redo semantics).
 
 const MAX_ENTRIES = 50;
 const HISTORY_MARKER = "photomap-nav";
 const STEP_KIND = "step";
+const ANCHOR_ID = "anchor";
 
 function isJumpKind(kind) {
   return !!kind && kind !== STEP_KIND;
@@ -16,6 +23,13 @@ function isJumpKind(kind) {
 class BackStack {
   constructor() {
     this._entries = [];
+    this._cursor = -1;
+    // Parallel to the browser's history stack: each entry mirrors one
+    // history.pushState call (plus the anchor from init's replaceState).
+    // anchor's entryIdx is null; jump entries point at the _entries index
+    // where that jump landed the user.
+    this._historyStates = [{ id: ANCHOR_ID, entryIdx: null }];
+    this._currentHistoryIdx = 0;
     this._pendingJumpKind = null;
     this._navigator = null;
     this._anchored = false;
@@ -46,15 +60,13 @@ class BackStack {
     this._anchored = true;
     if (typeof window !== "undefined" && window.history?.replaceState) {
       try {
-        window.history.replaceState({ [HISTORY_MARKER]: "anchor" }, "");
+        window.history.replaceState({ [HISTORY_MARKER]: ANCHOR_ID }, "");
       } catch {
         // ignore — non-fatal
       }
     }
   }
 
-  // Wire the actual slide navigator. Called once during app startup.
-  // The function receives an entry and should move the swiper to that position.
   setNavigator(fn) {
     this._navigator = fn;
   }
@@ -66,67 +78,55 @@ class BackStack {
     this._pendingJumpKind = kind;
   }
 
+  // Number of entries up to and including the current cursor — i.e., how
+  // far back the user could pop. Forward history (entries above the cursor)
+  // is not counted.
   size() {
-    return this._entries.length;
+    return this._cursor + 1;
   }
 
-  // Latest entry is the user's current position. peek(1) returns that;
-  // peek(2) returns the slide before it (the "back" target), and so on.
+  // peek(1) is the user's current position, peek(2) the previous, etc.
   peek(n = 1) {
-    return this._entries[this._entries.length - n] || null;
+    const idx = this._cursor - (n - 1);
+    if (idx < 0) {
+      return null;
+    }
+    return this._entries[idx] || null;
   }
 
-  // Returns the most recent `limit` entries that the back button could pop to,
-  // newest first, excluding the user's current position.
+  // Up to `limit` entries the Back button could pop to, newest first,
+  // excluding the user's current position. Does NOT include forward history.
   recent(limit = 10) {
-    const end = this._entries.length - 1;
+    if (this._cursor <= 0) {
+      return [];
+    }
+    const end = this._cursor;
     const start = Math.max(0, end - limit);
     return this._entries.slice(start, end).reverse();
   }
 
-  // Pop the current position, navigate to the previous one. Returns true if
-  // a back navigation was performed.
+  // Move cursor one step back. Does not touch _entries (preserves forward
+  // history for browser Forward).
   popOne() {
-    if (this._entries.length < 2 || !this._navigator) {
+    if (this._cursor <= 0 || !this._navigator) {
       return false;
     }
-    this._entries.pop();
-    const target = this._entries[this._entries.length - 1];
+    this._cursor--;
+    const target = this._entries[this._cursor];
     this._notifyChanged();
     this._navigator(target);
     return true;
   }
 
-  // Truncate the stack so the entry with the given id becomes the top, then
-  // navigate to it. Used by the thumbnail flyout where the user selects a
-  // specific prior position to jump back to.
+  // Move cursor to the entry with the given id (must be at or below the
+  // current cursor — the flyout only surfaces back-able entries).
   popToEntry(entryId) {
     const idx = this._entries.findIndex((e) => e.id === entryId);
-    if (idx < 0 || !this._navigator) {
+    if (idx < 0 || idx > this._cursor || !this._navigator) {
       return false;
     }
-    this._entries.length = idx + 1;
+    this._cursor = idx;
     const target = this._entries[idx];
-    this._notifyChanged();
-    this._navigator(target);
-    return true;
-  }
-
-  // Pop the stack until just past the most recent jump entry, then navigate
-  // there. This is the browser-back semantic.
-  popToPreviousJump() {
-    let jumpIdx = -1;
-    for (let i = this._entries.length - 1; i >= 0; i--) {
-      if (isJumpKind(this._entries[i].kind)) {
-        jumpIdx = i;
-        break;
-      }
-    }
-    if (jumpIdx <= 0 || !this._navigator) {
-      return false;
-    }
-    this._entries.splice(jumpIdx);
-    const target = this._entries[this._entries.length - 1];
     this._notifyChanged();
     this._navigator(target);
     return true;
@@ -141,20 +141,23 @@ class BackStack {
     const kind = this._pendingJumpKind || STEP_KIND;
     this._pendingJumpKind = null;
 
-    const last = this._entries[this._entries.length - 1];
-    if (last && last.globalIndex === globalIndex && last.isSearchMode === !!isSearchMode) {
-      // Same position re-emitted — handles two cases:
-      // 1. Restore: a popOne/popToEntry just landed here and the swiper has
-      //    now reported the new active slide; dedup absorbs the re-push.
-      // 2. A jump-tagged event for the same slide upgrades kind to jump so
-      //    the browser-back boundary lands here.
-      if (isJumpKind(kind) && !isJumpKind(last.kind)) {
-        last.kind = kind;
-        this._pushHistory(last);
+    const current = this._cursor >= 0 ? this._entries[this._cursor] : null;
+    if (current && current.globalIndex === globalIndex && current.isSearchMode === !!isSearchMode) {
+      // Same position re-emitted — common after a restore (the swiper echoes
+      // a slideChanged when it actually moves) or when a jump-tagged event
+      // re-fires for the same slide. Upgrade kind to jump if needed so the
+      // browser-back boundary lands here.
+      if (isJumpKind(kind) && !isJumpKind(current.kind)) {
+        current.kind = kind;
+        this._pushHistory(current);
         this._notifyChanged();
       }
       return;
     }
+
+    // New entry: truncate the forward portion of the timeline and append.
+    this._entries.length = this._cursor + 1;
+    this._truncateHistoryStatesAboveCursor();
 
     const entry = {
       globalIndex,
@@ -164,8 +167,17 @@ class BackStack {
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     };
     this._entries.push(entry);
+    this._cursor = this._entries.length - 1;
+
     if (this._entries.length > MAX_ENTRIES) {
-      this._entries.splice(0, this._entries.length - MAX_ENTRIES);
+      const drop = this._entries.length - MAX_ENTRIES;
+      this._entries.splice(0, drop);
+      this._cursor -= drop;
+      // Shift entryIdx in _historyStates and drop any that fell off the front.
+      this._historyStates = this._historyStates
+        .map((s) => (s.entryIdx === null ? s : { ...s, entryIdx: s.entryIdx - drop }))
+        .filter((s) => s.entryIdx === null || s.entryIdx >= 0);
+      this._currentHistoryIdx = Math.min(this._currentHistoryIdx, this._historyStates.length - 1);
     }
 
     if (isJumpKind(kind)) {
@@ -175,13 +187,17 @@ class BackStack {
   }
 
   _onAlbumChanged(detail) {
-    // Deletion: filter entries pointing at deleted indices and shift the rest.
     if (detail && detail.changeType === "deletion" && Array.isArray(detail.deletedIndices)) {
       const deleted = new Set(detail.deletedIndices);
       const sorted = [...detail.deletedIndices].sort((a, b) => a - b);
       const filtered = [];
-      for (const e of this._entries) {
+      let newCursor = this._cursor;
+      for (let i = 0; i < this._entries.length; i++) {
+        const e = this._entries[i];
         if (deleted.has(e.globalIndex)) {
+          if (i <= this._cursor) {
+            newCursor--;
+          }
           continue;
         }
         let before = 0;
@@ -195,11 +211,21 @@ class BackStack {
         filtered.push({ ...e, globalIndex: e.globalIndex - before });
       }
       this._entries = filtered;
+      this._cursor = filtered.length === 0 ? -1 : Math.max(0, Math.min(newCursor, filtered.length - 1));
+      // Browser history entries with the old entryIdx mapping are now stale;
+      // dropping all of them is simpler than re-deriving — the user remains
+      // in the same album and only loses browser back/forward across
+      // pre-deletion jumps.
+      this._historyStates = [this._historyStates[0]];
+      this._currentHistoryIdx = 0;
       this._notifyChanged();
       return;
     }
     // Album switch / move / index change: cross-album back doesn't make sense.
     this._entries = [];
+    this._cursor = -1;
+    this._historyStates = [this._historyStates[0]];
+    this._currentHistoryIdx = 0;
     this._pendingJumpKind = "jump";
     this._notifyChanged();
   }
@@ -210,11 +236,48 @@ class BackStack {
       // Not one of ours — leave it alone.
       return;
     }
-    // Whether this is one of our jump entries or the anchor (the original
-    // entry created by replaceState on init), the user has moved one step
-    // back in browser history. Rewind the stack to the position before the
-    // most recent jump.
-    this.popToPreviousJump();
+    const stateId = st[HISTORY_MARKER];
+    const newHistIdx = stateId === ANCHOR_ID ? 0 : this._historyStates.findIndex((s) => s.id === stateId);
+    if (newHistIdx < 0) {
+      // Orphan: the matching entry was truncated when the user took a new
+      // action after backing up. Skip silently.
+      return;
+    }
+    if (newHistIdx === this._currentHistoryIdx) {
+      return;
+    }
+
+    let targetCursor;
+    if (newHistIdx < this._currentHistoryIdx) {
+      // Back: rewind to the slide just before the jump we're leaving.
+      const leaving = this._historyStates[this._currentHistoryIdx];
+      if (leaving.entryIdx === null) {
+        // Shouldn't happen — the anchor lives at index 0, you can't leave it
+        // by going backwards.
+        return;
+      }
+      targetCursor = leaving.entryIdx - 1;
+    } else {
+      // Forward: land at the jump we're arriving at.
+      const arriving = this._historyStates[newHistIdx];
+      if (arriving.entryIdx === null) {
+        return;
+      }
+      targetCursor = arriving.entryIdx;
+    }
+
+    this._currentHistoryIdx = newHistIdx;
+
+    if (targetCursor >= 0 && targetCursor < this._entries.length && this._navigator) {
+      this._cursor = targetCursor;
+      const target = this._entries[this._cursor];
+      this._notifyChanged();
+      this._navigator(target);
+    } else {
+      // Notify even when we don't navigate (e.g., backed to the anchor) so
+      // the UI can refresh its enabled/disabled state.
+      this._notifyChanged();
+    }
   }
 
   _pushHistory(entry) {
@@ -226,21 +289,46 @@ class BackStack {
     } catch {
       // ignore — non-fatal
     }
+    // Browser truncates forward history on pushState; mirror that in our
+    // parallel array.
+    this._historyStates.length = this._currentHistoryIdx + 1;
+    this._historyStates.push({ id: entry.id, entryIdx: this._cursor });
+    this._currentHistoryIdx = this._historyStates.length - 1;
+  }
+
+  _truncateHistoryStatesAboveCursor() {
+    // Drop _historyStates entries that reference entries beyond the cursor.
+    // The anchor (entryIdx === null) is always preserved.
+    for (let i = this._historyStates.length - 1; i > 0; i--) {
+      const s = this._historyStates[i];
+      if (s.entryIdx !== null && s.entryIdx > this._cursor) {
+        this._historyStates.splice(i, 1);
+        if (i <= this._currentHistoryIdx) {
+          this._currentHistoryIdx--;
+        }
+      }
+    }
+    if (this._currentHistoryIdx >= this._historyStates.length) {
+      this._currentHistoryIdx = this._historyStates.length - 1;
+    }
   }
 
   _notifyChanged() {
     if (typeof window === "undefined") {
       return;
     }
-    window.dispatchEvent(new CustomEvent("backStackChanged", { detail: { size: this._entries.length } }));
+    window.dispatchEvent(new CustomEvent("backStackChanged", { detail: { size: this.size() } }));
   }
 
   // Test hook.
   _reset() {
     this._entries = [];
+    this._cursor = -1;
+    this._historyStates = [{ id: ANCHOR_ID, entryIdx: null }];
+    this._currentHistoryIdx = 0;
     this._pendingJumpKind = null;
   }
 }
 
 export const backStack = new BackStack();
-export const __TEST__ = { MAX_ENTRIES, HISTORY_MARKER };
+export const __TEST__ = { MAX_ENTRIES, HISTORY_MARKER, ANCHOR_ID };

--- a/photomap/frontend/static/javascript/back-stack.js
+++ b/photomap/frontend/static/javascript/back-stack.js
@@ -222,11 +222,16 @@ class BackStack {
       return;
     }
     // Album switch / move / index change: cross-album back doesn't make sense.
+    // The next slideChanged is recorded as a plain step (NOT a jump), so the
+    // album load itself doesn't create a browser-history entry. If we did
+    // push it, browser-back from any post-album navigation would arrive at
+    // the anchor and try to navigate to "the slide before the album existed"
+    // — a non-position — and silently do nothing, leaving the user stuck.
     this._entries = [];
     this._cursor = -1;
     this._historyStates = [this._historyStates[0]];
     this._currentHistoryIdx = 0;
-    this._pendingJumpKind = "jump";
+    this._pendingJumpKind = null;
     this._notifyChanged();
   }
 
@@ -256,14 +261,28 @@ class BackStack {
         // by going backwards.
         return;
       }
+      // Record where the user was on this state so a future forward can
+      // restore them there (instead of the jump's original landing position,
+      // which may be behind their actual cursor if they took steps after
+      // the jump).
+      leaving.lastCursorBeforeLeaving = this._cursor;
       targetCursor = leaving.entryIdx - 1;
     } else {
-      // Forward: land at the jump we're arriving at.
+      // Forward: prefer the cursor the user was at when they last left this
+      // state (saved during the back-popstate that landed us here), so steps
+      // taken after the original jump are restored too. Fall back to the
+      // jump's original entryIdx if no leaving-cursor was recorded or if
+      // it's been invalidated by a truncation.
       const arriving = this._historyStates[newHistIdx];
       if (arriving.entryIdx === null) {
         return;
       }
-      targetCursor = arriving.entryIdx;
+      const restored = arriving.lastCursorBeforeLeaving;
+      if (typeof restored === "number" && restored >= 0 && restored < this._entries.length) {
+        targetCursor = restored;
+      } else {
+        targetCursor = arriving.entryIdx;
+      }
     }
 
     this._currentHistoryIdx = newHistIdx;

--- a/photomap/frontend/static/javascript/back-stack.js
+++ b/photomap/frontend/static/javascript/back-stack.js
@@ -1,0 +1,246 @@
+// back-stack.js
+// Tracks recent slide positions to power an in-app Back button and to wire
+// history.pushState for coarse-grained "jumps" (search submit, album switch,
+// UMAP cluster click, reference-thumbnail click). Slide-by-slide navigation
+// is recorded in memory only — only jumps are pushed onto the browser's
+// history stack, keeping the browser back button at a useful granularity.
+
+const MAX_ENTRIES = 50;
+const HISTORY_MARKER = "photomap-nav";
+const STEP_KIND = "step";
+
+function isJumpKind(kind) {
+  return !!kind && kind !== STEP_KIND;
+}
+
+class BackStack {
+  constructor() {
+    this._entries = [];
+    this._pendingJumpKind = null;
+    this._navigator = null;
+    this._anchored = false;
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("slideChanged", (e) => this._onSlideChanged(e.detail));
+      // seekToSlideIndex fires from slideState.navigateToIndex (seek slider,
+      // UMAP cluster click, reference-thumbnail click, our own back-restore).
+      // The swiper suppresses its own slideChange handler when seeking to a
+      // nearby slide, so listening here is the only way to track programmatic
+      // navigation reliably.
+      window.addEventListener("seekToSlideIndex", (e) => this._onSlideChanged(e.detail));
+      // These two must run before slide-state's listeners so that we can set
+      // pendingJumpKind / clear the stack before the resulting slideChanged
+      // fires. main.js imports back-stack first to make this true — the
+      // listener-registration order on window is what determines firing order
+      // (capture:true has no effect for window-dispatched events).
+      window.addEventListener("searchResultsChanged", () => this.markNextAsJump("search"));
+      window.addEventListener("albumChanged", (e) => this._onAlbumChanged(e.detail));
+      window.addEventListener("popstate", (e) => this._onPopState(e));
+    }
+  }
+
+  init() {
+    if (this._anchored) {
+      return;
+    }
+    this._anchored = true;
+    if (typeof window !== "undefined" && window.history?.replaceState) {
+      try {
+        window.history.replaceState({ [HISTORY_MARKER]: "anchor" }, "");
+      } catch {
+        // ignore — non-fatal
+      }
+    }
+  }
+
+  // Wire the actual slide navigator. Called once during app startup.
+  // The function receives an entry and should move the swiper to that position.
+  setNavigator(fn) {
+    this._navigator = fn;
+  }
+
+  // Called by code paths that perform a coarse-grained jump (UMAP cluster
+  // click, reference-thumbnail click). The next slideChanged event will be
+  // recorded as a jump and pushed onto the browser history stack.
+  markNextAsJump(kind = "jump") {
+    this._pendingJumpKind = kind;
+  }
+
+  size() {
+    return this._entries.length;
+  }
+
+  // Latest entry is the user's current position. peek(1) returns that;
+  // peek(2) returns the slide before it (the "back" target), and so on.
+  peek(n = 1) {
+    return this._entries[this._entries.length - n] || null;
+  }
+
+  // Returns the most recent `limit` entries that the back button could pop to,
+  // newest first, excluding the user's current position.
+  recent(limit = 10) {
+    const end = this._entries.length - 1;
+    const start = Math.max(0, end - limit);
+    return this._entries.slice(start, end).reverse();
+  }
+
+  // Pop the current position, navigate to the previous one. Returns true if
+  // a back navigation was performed.
+  popOne() {
+    if (this._entries.length < 2 || !this._navigator) {
+      return false;
+    }
+    this._entries.pop();
+    const target = this._entries[this._entries.length - 1];
+    this._notifyChanged();
+    this._navigator(target);
+    return true;
+  }
+
+  // Truncate the stack so the entry with the given id becomes the top, then
+  // navigate to it. Used by the thumbnail flyout where the user selects a
+  // specific prior position to jump back to.
+  popToEntry(entryId) {
+    const idx = this._entries.findIndex((e) => e.id === entryId);
+    if (idx < 0 || !this._navigator) {
+      return false;
+    }
+    this._entries.length = idx + 1;
+    const target = this._entries[idx];
+    this._notifyChanged();
+    this._navigator(target);
+    return true;
+  }
+
+  // Pop the stack until just past the most recent jump entry, then navigate
+  // there. This is the browser-back semantic.
+  popToPreviousJump() {
+    let jumpIdx = -1;
+    for (let i = this._entries.length - 1; i >= 0; i--) {
+      if (isJumpKind(this._entries[i].kind)) {
+        jumpIdx = i;
+        break;
+      }
+    }
+    if (jumpIdx <= 0 || !this._navigator) {
+      return false;
+    }
+    this._entries.splice(jumpIdx);
+    const target = this._entries[this._entries.length - 1];
+    this._notifyChanged();
+    this._navigator(target);
+    return true;
+  }
+
+  _onSlideChanged(detail) {
+    const { globalIndex, searchIndex, isSearchMode } = detail || {};
+    if (typeof globalIndex !== "number") {
+      return;
+    }
+
+    const kind = this._pendingJumpKind || STEP_KIND;
+    this._pendingJumpKind = null;
+
+    const last = this._entries[this._entries.length - 1];
+    if (last && last.globalIndex === globalIndex && last.isSearchMode === !!isSearchMode) {
+      // Same position re-emitted — handles two cases:
+      // 1. Restore: a popOne/popToEntry just landed here and the swiper has
+      //    now reported the new active slide; dedup absorbs the re-push.
+      // 2. A jump-tagged event for the same slide upgrades kind to jump so
+      //    the browser-back boundary lands here.
+      if (isJumpKind(kind) && !isJumpKind(last.kind)) {
+        last.kind = kind;
+        this._pushHistory(last);
+        this._notifyChanged();
+      }
+      return;
+    }
+
+    const entry = {
+      globalIndex,
+      searchIndex: typeof searchIndex === "number" ? searchIndex : null,
+      isSearchMode: !!isSearchMode,
+      kind,
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    };
+    this._entries.push(entry);
+    if (this._entries.length > MAX_ENTRIES) {
+      this._entries.splice(0, this._entries.length - MAX_ENTRIES);
+    }
+
+    if (isJumpKind(kind)) {
+      this._pushHistory(entry);
+    }
+    this._notifyChanged();
+  }
+
+  _onAlbumChanged(detail) {
+    // Deletion: filter entries pointing at deleted indices and shift the rest.
+    if (detail && detail.changeType === "deletion" && Array.isArray(detail.deletedIndices)) {
+      const deleted = new Set(detail.deletedIndices);
+      const sorted = [...detail.deletedIndices].sort((a, b) => a - b);
+      const filtered = [];
+      for (const e of this._entries) {
+        if (deleted.has(e.globalIndex)) {
+          continue;
+        }
+        let before = 0;
+        for (const d of sorted) {
+          if (d < e.globalIndex) {
+            before++;
+          } else {
+            break;
+          }
+        }
+        filtered.push({ ...e, globalIndex: e.globalIndex - before });
+      }
+      this._entries = filtered;
+      this._notifyChanged();
+      return;
+    }
+    // Album switch / move / index change: cross-album back doesn't make sense.
+    this._entries = [];
+    this._pendingJumpKind = "jump";
+    this._notifyChanged();
+  }
+
+  _onPopState(e) {
+    const st = e.state;
+    if (!st || !st[HISTORY_MARKER]) {
+      // Not one of ours — leave it alone.
+      return;
+    }
+    // Whether this is one of our jump entries or the anchor (the original
+    // entry created by replaceState on init), the user has moved one step
+    // back in browser history. Rewind the stack to the position before the
+    // most recent jump.
+    this.popToPreviousJump();
+  }
+
+  _pushHistory(entry) {
+    if (typeof window === "undefined" || !window.history?.pushState) {
+      return;
+    }
+    try {
+      window.history.pushState({ [HISTORY_MARKER]: entry.id, kind: entry.kind }, "");
+    } catch {
+      // ignore — non-fatal
+    }
+  }
+
+  _notifyChanged() {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.dispatchEvent(new CustomEvent("backStackChanged", { detail: { size: this._entries.length } }));
+  }
+
+  // Test hook.
+  _reset() {
+    this._entries = [];
+    this._pendingJumpKind = null;
+  }
+}
+
+export const backStack = new BackStack();
+export const __TEST__ = { MAX_ENTRIES, HISTORY_MARKER };

--- a/photomap/frontend/static/javascript/curation.js
+++ b/photomap/frontend/static/javascript/curation.js
@@ -1,3 +1,4 @@
+import { backStack } from "./back-stack.js";
 import { bookmarkManager } from "./bookmarks.js";
 import { createSimpleDirectoryPicker } from "./filetree.js";
 import { updateSearchCheckmarks } from "./search-ui.js";
@@ -32,6 +33,7 @@ window.toggleCurationPanel = function () {
     if (isOpen) {
       // When panel is open, clicking UMAP points should navigate to that image
       setUmapClickCallback((index) => {
+        backStack.markNextAsJump("curation");
         slideState.navigateToIndex(index, false);
       });
     } else {

--- a/photomap/frontend/static/javascript/events.js
+++ b/photomap/frontend/static/javascript/events.js
@@ -3,6 +3,8 @@
 // including keyboard shortcuts and cross-component coordination.
 import { aboutManager } from "./about.js";
 import { checkAlbumIndex } from "./album-manager.js";
+import { initializeBackButton } from "./back-button.js";
+import { backStack } from "./back-stack.js";
 import { toggleCurrentBookmark } from "./bookmarks.js";
 import { initializeControlPanel, toggleFullscreen } from "./control-panel.js";
 import { initializeGridSwiper } from "./grid-view.js";
@@ -33,6 +35,7 @@ async function initializeEvents() {
   initializeControlPanel(); // Initialize control panel buttons
   initializeMetadataDrawer(); // Initialize metadata drawer events
   initializeSlideshowControls(); // Initialize slideshow controls
+  initializeBackButton(); // Initialize Back button (in-app history)
   setupGlobalEventListeners();
   setupAccessibility();
   checkAlbumIndex(); // Check if the album index exists before proceeding
@@ -66,7 +69,14 @@ const KEYBOARD_SHORTCUTS = {
   b: () => toggleCurrentBookmark(),
   B: () => toggleCurrentBookmark(),
   " ": (e) => handleSpacebarToggle(e),
+  Backspace: (e) => handleBackKey(e),
 };
+
+function handleBackKey(e) {
+  e.preventDefault();
+  e.stopPropagation();
+  backStack.popOne();
+}
 
 // Toggle the play/pause state using the spacebar
 function handleSpacebarToggle(e) {

--- a/photomap/frontend/static/javascript/reference-thumbnails.js
+++ b/photomap/frontend/static/javascript/reference-thumbnails.js
@@ -4,6 +4,7 @@
 // present in the current album. Filenames not in the album are left as the
 // plain text the formatter already rendered.
 
+import { backStack } from "./back-stack.js";
 import { slideState } from "./slide-state.js";
 
 // Parse the slide dataset's reference_images attribute (a JSON-stringified
@@ -147,6 +148,7 @@ export function registerReferenceThumbnailClickHandler() {
     e.preventDefault();
     const index = parseInt(thumb.dataset.globalIndex, 10);
     if (Number.isFinite(index)) {
+      backStack.markNextAsJump("reference");
       slideState.navigateToIndex(index, false);
     }
   });

--- a/photomap/frontend/static/javascript/seek-slider.js
+++ b/photomap/frontend/static/javascript/seek-slider.js
@@ -1,3 +1,4 @@
+import { backStack } from "./back-stack.js";
 import { bookmarkManager } from "./bookmarks.js";
 import { ScoreDisplay } from "./score-display.js";
 import { getCurrentSlideIndex, slideState } from "./slide-state.js";
@@ -303,6 +304,7 @@ class SeekSlider {
     // Update hover strip with final slider position
     this.updateHoverStripProgress(targetIndex + 1);
     this.isUserSeeking = true;
+    backStack.markNextAsJump("seek");
     slideState.navigateToIndex(targetIndex, slideState.isSearchMode);
     setTimeout(() => {
       this.isUserSeeking = false;

--- a/photomap/frontend/static/javascript/slide-state.js
+++ b/photomap/frontend/static/javascript/slide-state.js
@@ -86,6 +86,12 @@ class SlideStateManager {
    */
   navigateToIndex(index, isSearchIndex = null) {
     this.setCurrentIndex(index, isSearchIndex);
+    // Announce the change so listeners (seek slider, UMAP marker, back stack)
+    // stay in sync, then issue the swiper command. The swiper suppresses its
+    // own slideChange handler when seeking to an already-loaded slide and
+    // during the rebuild path, so this is the only reliable signal that the
+    // active position changed via programmatic navigation.
+    this.notifySlideChanged();
     this.seekToSlideIndex();
   }
 

--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -601,38 +601,50 @@ class SwiperManager {
       }
     }
 
-    this.swiper.removeAllSlides();
+    // Suppress swiper.slideChange while the rebuild is in progress. Without
+    // this, the intermediate active-slide transitions during removeAllSlides /
+    // appendSlide / slideTo would each invoke updateFromExternal and dispatch
+    // slideChanged with transient globalIndex values — none of which represent
+    // a slide the user actually viewed. slideState was already set to the
+    // target by navigateToIndex's setCurrentIndex, so suppressing here is
+    // safe (and mirrors what the nearby branch already does).
+    this.isInternalSlideChange = true;
+    try {
+      this.swiper.removeAllSlides();
 
-    let origin = -2;
-    const slides_to_add = 5;
-    if (globalIndex + origin < 0) {
-      origin = 0;
-    }
-
-    const swiperContainer = document.getElementById("singleSwiper");
-    swiperContainer.style.visibility = "hidden";
-
-    for (let i = origin; i < slides_to_add; i++) {
-      if (searchIndex + i >= totalCount) {
-        break;
+      let origin = -2;
+      const slides_to_add = 5;
+      if (globalIndex + origin < 0) {
+        origin = 0;
       }
-      if (globalIndex + i < 0) {
-        continue;
-      }
-      if (globalIndex + i >= slideState.totalAlbumImages) {
-        break;
-      }
-      await this.addSlideByIndex(globalIndex + i, searchIndex + i, false, false);
-    }
 
-    slideEls = this.swiper.slides;
-    let targetSlideIdx = Array.from(slideEls).findIndex((el) => parseInt(el.dataset.globalIndex, 10) === globalIndex);
-    if (targetSlideIdx === -1) {
-      targetSlideIdx = 0;
-    }
-    this.swiper.slideTo(targetSlideIdx, 0);
+      const swiperContainer = document.getElementById("singleSwiper");
+      swiperContainer.style.visibility = "hidden";
 
-    swiperContainer.style.visibility = "visible";
-    updateMetadataOverlay(this.currentSlide());
+      for (let i = origin; i < slides_to_add; i++) {
+        if (searchIndex + i >= totalCount) {
+          break;
+        }
+        if (globalIndex + i < 0) {
+          continue;
+        }
+        if (globalIndex + i >= slideState.totalAlbumImages) {
+          break;
+        }
+        await this.addSlideByIndex(globalIndex + i, searchIndex + i, false, false);
+      }
+
+      slideEls = this.swiper.slides;
+      let targetSlideIdx = Array.from(slideEls).findIndex((el) => parseInt(el.dataset.globalIndex, 10) === globalIndex);
+      if (targetSlideIdx === -1) {
+        targetSlideIdx = 0;
+      }
+      this.swiper.slideTo(targetSlideIdx, 0);
+
+      swiperContainer.style.visibility = "visible";
+      updateMetadataOverlay(this.currentSlide());
+    } finally {
+      this.isInternalSlideChange = false;
+    }
   }
 }

--- a/photomap/frontend/static/javascript/touch.js
+++ b/photomap/frontend/static/javascript/touch.js
@@ -1,6 +1,8 @@
 // touch.js
 // This file handles touch events for the slideshow, allowing tap and swipe gestures to control navigation and overlays.
 
+import { showBackFlyout } from "./back-button.js";
+import { backStack } from "./back-stack.js";
 import { showSlideshowModeMenu, toggleSlideshowWithIndicator } from "./slideshow.js";
 import { state } from "./state.js";
 
@@ -166,6 +168,49 @@ if (slideshowBtn) {
   });
 
   slideshowBtn.addEventListener("touchcancel", () => {
+    clearTimeout(longTouchTimer);
+    touchStartPos = null;
+  });
+}
+
+// Long-touch handler for Back button — opens the recent-positions flyout.
+const backNavBtn = document.getElementById("backNavBtn");
+if (backNavBtn) {
+  let longTouchTimer = null;
+  let touchStartPos = null;
+
+  backNavBtn.addEventListener("touchstart", (e) => {
+    touchStartPos = {
+      x: e.touches[0].clientX,
+      y: e.touches[0].clientY,
+    };
+
+    longTouchTimer = setTimeout(() => {
+      if (touchStartPos && backStack.size() >= 2) {
+        e.preventDefault();
+        showBackFlyout(touchStartPos.x + 6, touchStartPos.y + 6);
+        touchStartPos = null;
+      }
+    }, 500);
+  });
+
+  backNavBtn.addEventListener("touchmove", (e) => {
+    if (touchStartPos) {
+      const dx = e.touches[0].clientX - touchStartPos.x;
+      const dy = e.touches[0].clientY - touchStartPos.y;
+      if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
+        clearTimeout(longTouchTimer);
+        touchStartPos = null;
+      }
+    }
+  });
+
+  backNavBtn.addEventListener("touchend", () => {
+    clearTimeout(longTouchTimer);
+    touchStartPos = null;
+  });
+
+  backNavBtn.addEventListener("touchcancel", () => {
     clearTimeout(longTouchTimer);
     touchStartPos = null;
   });

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -1,6 +1,7 @@
 // umap.js
 // This file handles the UMAP visualization and interaction logic.
 import { albumManager } from "./album-manager.js";
+import { backStack } from "./back-stack.js";
 import { CLUSTER_PALETTE, getClusterLabelInfo, setClusterLabels } from "./cluster-utils.js";
 import { exitSearchMode } from "./search-ui.js";
 import { getImagePath, setSearchResults } from "./search.js";
@@ -1387,6 +1388,7 @@ async function handleImageClick(clickedIndex) {
   exitSearchMode();
 
   // Navigate directly to the clicked image without entering search mode
+  backStack.markNextAsJump("cluster");
   slideState.navigateToIndex(clickedIndex, false);
 
   // Exit fullscreen mode if enabled

--- a/photomap/frontend/static/main.js
+++ b/photomap/frontend/static/main.js
@@ -25,6 +25,11 @@ import './javascript/utils.js';
 import './javascript/curation.js';
 
 backStack.setNavigator((entry) => {
-  slideState.navigateToIndex(entry.globalIndex, entry.isSearchMode);
+  // Always restore by global index. Passing isSearchIndex=true would make
+  // setCurrentIndex treat entry.globalIndex as a search-results index and
+  // clamp it to the search size (which would always land on the last result).
+  // With isSearchIndex=false, setCurrentIndex sets the global position and
+  // resolves the matching search index if one exists in the active search.
+  slideState.navigateToIndex(entry.globalIndex, false);
 });
 backStack.init();

--- a/photomap/frontend/static/main.js
+++ b/photomap/frontend/static/main.js
@@ -1,6 +1,11 @@
 // main.js
 // This file initializes the application by importing necessary modules and setting up event listeners.
 
+// IMPORTANT: back-stack must load before any module that registers an
+// albumChanged or searchResultsChanged listener — its handler must run first
+// so it can mark the upcoming slideChanged as a jump. window.dispatchEvent
+// listeners fire in registration order; there is no capture-phase shortcut.
+import { backStack } from './javascript/back-stack.js';
 import './javascript/album-manager.js';
 import './javascript/bookmarks.js';
 import './javascript/cluster-utils.js';
@@ -12,9 +17,14 @@ import './javascript/search-ui.js';
 import './javascript/search.js';
 import './javascript/seek-slider.js';
 import './javascript/settings.js';
+import { slideState } from './javascript/slide-state.js';
 import './javascript/state.js';
 import './javascript/swiper.js';
 import './javascript/umap.js';
 import './javascript/utils.js';
 import './javascript/curation.js';
 
+backStack.setNavigator((entry) => {
+  slideState.navigateToIndex(entry.globalIndex, entry.isSearchMode);
+});
+backStack.init();

--- a/photomap/frontend/templates/modules/control-panel.html
+++ b/photomap/frontend/templates/modules/control-panel.html
@@ -96,6 +96,28 @@
       <div class="button-label">Grid View</div>
     </div>
     <div class="control-icon-container">
+      <button
+        id="backNavBtn"
+        class="back-nav-disabled"
+        title="Back (right-click for recent)"
+      >
+        <svg
+          width="32"
+          height="32"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#fff"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M9 14 L4 9 L9 4" />
+          <path d="M4 9 H15 a5 5 0 0 1 5 5 v6" />
+        </svg>
+      </button>
+      <div class="button-label">Back</div>
+    </div>
+    <div class="control-icon-container">
       <button id="startStopSlideshowBtn" title="Start/Pause Slideshow">
         <span id="slideshowIcon">
           <svg

--- a/tests/frontend/back-button.test.js
+++ b/tests/frontend/back-button.test.js
@@ -1,0 +1,124 @@
+// Unit tests for back-button.js
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+// Mock state.js (transitively touches album-manager and others). We only need
+// state.album to build the thumbnail URL.
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/state.js", () => ({
+  state: { album: "test-album" },
+}));
+
+const { backStack } = await import("../../photomap/frontend/static/javascript/back-stack.js");
+const { initializeBackButton } = await import("../../photomap/frontend/static/javascript/back-button.js");
+
+function emitSlideChanged(globalIndex) {
+  window.dispatchEvent(
+    new CustomEvent("slideChanged", {
+      detail: { globalIndex, searchIndex: null, isSearchMode: false },
+    })
+  );
+}
+
+function setupDom() {
+  document.body.innerHTML = `
+    <button id="backNavBtn" class="back-nav-disabled" title="Back"></button>
+  `;
+}
+
+describe("back-button.js", () => {
+  let navigator;
+
+  beforeEach(() => {
+    setupDom();
+    backStack._reset();
+    navigator = jest.fn();
+    backStack.setNavigator(navigator);
+    initializeBackButton();
+  });
+
+  describe("enabled / disabled state", () => {
+    it("starts disabled when the stack is empty", () => {
+      const btn = document.getElementById("backNavBtn");
+      expect(btn.classList.contains("back-nav-disabled")).toBe(true);
+    });
+
+    it("remains disabled with only one entry", () => {
+      emitSlideChanged(0);
+      const btn = document.getElementById("backNavBtn");
+      expect(btn.classList.contains("back-nav-disabled")).toBe(true);
+    });
+
+    it("enables once two or more entries are pushed", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      const btn = document.getElementById("backNavBtn");
+      expect(btn.classList.contains("back-nav-disabled")).toBe(false);
+    });
+
+    it("re-disables after popping back down to a single entry", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      const btn = document.getElementById("backNavBtn");
+      btn.click();
+      // popOne emits backStackChanged synchronously — no need to wait for the
+      // swiper to echo slideChanged (which it suppresses for in-place jumps).
+      expect(btn.classList.contains("back-nav-disabled")).toBe(true);
+    });
+  });
+
+  describe("click behavior", () => {
+    it("pops one entry on left-click when enabled", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      document.getElementById("backNavBtn").click();
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
+    });
+
+    it("is a no-op while disabled", () => {
+      emitSlideChanged(0);
+      document.getElementById("backNavBtn").click();
+      expect(navigator).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("contextmenu flyout", () => {
+    function openFlyout(btn) {
+      const ev = new MouseEvent("contextmenu", { clientX: 100, clientY: 100, bubbles: true, cancelable: true });
+      btn.dispatchEvent(ev);
+    }
+
+    it("does not open a flyout when there's nothing to go back to", () => {
+      emitSlideChanged(0);
+      openFlyout(document.getElementById("backNavBtn"));
+      expect(document.getElementById("backNavFlyout")).toBeNull();
+    });
+
+    it("opens a flyout with up to 10 recent thumbnails on right-click", () => {
+      for (let i = 0; i < 12; i++) {
+        emitSlideChanged(i);
+      }
+      openFlyout(document.getElementById("backNavBtn"));
+      const flyout = document.getElementById("backNavFlyout");
+      expect(flyout).not.toBeNull();
+      const thumbs = flyout.querySelectorAll("img.back-nav-thumb");
+      expect(thumbs.length).toBe(10);
+      // Newest first: the entry just below the current one (globalIndex 10).
+      expect(thumbs[0].src).toContain("/test-album/10?");
+    });
+
+    it("clicking a thumbnail truncates the stack to that entry and navigates", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      emitSlideChanged(3);
+      openFlyout(document.getElementById("backNavBtn"));
+      const thumbs = document.querySelectorAll("#backNavFlyout img.back-nav-thumb");
+      // Click the thumbnail that maps to globalIndex 1 (oldest of the three shown).
+      const target = Array.from(thumbs).find((img) => img.src.includes("/test-album/1?"));
+      target.click();
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
+      expect(backStack.size()).toBe(2);
+      expect(document.getElementById("backNavFlyout")).toBeNull();
+    });
+  });
+});

--- a/tests/frontend/back-stack.test.js
+++ b/tests/frontend/back-stack.test.js
@@ -164,80 +164,122 @@ describe("back-stack.js", () => {
     });
   });
 
-  describe("popToPreviousJump (browser back)", () => {
-    it("returns false when there's no prior jump", () => {
+  describe("popstate handling (browser back / forward)", () => {
+    // Helper: read the most recent state object captured by the spy. Since
+    // back-stack calls window.history.pushState, the spy receives the same
+    // arguments the browser would persist in the history entry.
+    function lastPushedState() {
+      const calls = pushStateSpy.mock.calls;
+      return calls[calls.length - 1]?.[0] || null;
+    }
+
+    function fakePopState(state) {
+      window.dispatchEvent(new window.PopStateEvent("popstate", { state }));
+    }
+
+    it("ignores popstate events that aren't ours", () => {
       emitSlideChanged(0);
-      emitSlideChanged(1);
-      expect(backStack.popToPreviousJump()).toBe(false);
+      backStack.markNextAsJump("search");
+      emitSlideChanged(50);
+      navigator.mockClear();
+      fakePopState({ unrelated: true });
+      expect(navigator).not.toHaveBeenCalled();
     });
 
-    it("pops past the most recent jump and navigates to the step before it", () => {
+    it("ignores popstate with an orphan id (entry was truncated)", () => {
+      emitSlideChanged(0);
+      backStack.markNextAsJump("search");
+      emitSlideChanged(50);
+      navigator.mockClear();
+      fakePopState({ [HISTORY_MARKER]: "no-such-id" });
+      expect(navigator).not.toHaveBeenCalled();
+    });
+
+    it("back from a jump navigates to the slide just before it", () => {
       emitSlideChanged(0);
       emitSlideChanged(1);
       backStack.markNextAsJump("search");
       emitSlideChanged(50);
       emitSlideChanged(51);
       emitSlideChanged(52);
-      expect(backStack.popToPreviousJump()).toBe(true);
+      navigator.mockClear();
+      // Browser back from the search-pushed history entry lands on the anchor.
+      fakePopState({ [HISTORY_MARKER]: "anchor" });
       expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
       expect(backStack.size()).toBe(2);
     });
 
-    it("popstate triggers popToPreviousJump", () => {
-      emitSlideChanged(0);
-      emitSlideChanged(1);
-      backStack.markNextAsJump("search");
-      emitSlideChanged(99);
-      window.dispatchEvent(
-        new window.PopStateEvent("popstate", {
-          state: { [HISTORY_MARKER]: "some-id", kind: "jump" },
-        })
-      );
-      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
-    });
-
-    it("ignores popstate events that aren't ours", () => {
+    it("forward to a jump navigates AT the jump entry", () => {
       emitSlideChanged(0);
       emitSlideChanged(1);
       backStack.markNextAsJump("search");
       emitSlideChanged(50);
+      const searchState = lastPushedState();
+      // Back once.
+      fakePopState({ [HISTORY_MARKER]: "anchor" });
+      expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 1 }));
+      // Forward — we should land at the search target itself.
       navigator.mockClear();
-      window.dispatchEvent(new window.PopStateEvent("popstate", { state: { unrelated: true } }));
-      expect(navigator).not.toHaveBeenCalled();
+      fakePopState(searchState);
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 50 }));
+      expect(backStack.size()).toBe(3);
     });
 
-    it("treats an anchor popstate as a back-one-jump signal too", () => {
-      // Reaching the anchor means the user has hit back enough times to
-      // pop the last jump entry off the browser history; we should still
-      // rewind the in-memory stack.
-      emitSlideChanged(0);
-      backStack.markNextAsJump("search");
-      emitSlideChanged(10);
-      navigator.mockClear();
-      window.dispatchEvent(new window.PopStateEvent("popstate", { state: { [HISTORY_MARKER]: "anchor" } }));
-      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 0 }));
-    });
-
-    it("handles multiple browser-back hops through stacked jumps", () => {
-      // Mirrors the user-reported scenario: ref-image click then search,
-      // then two browser-backs should land back at the original slide.
+    it("multi-hop back through stacked jumps lands at the slide before the most recent jump", () => {
+      // Reference-click then search, then back twice.
       emitSlideChanged(1);
       backStack.markNextAsJump("reference");
       emitSlideChanged(2);
+      const refState = lastPushedState();
       backStack.markNextAsJump("search");
       emitSlideChanged(3);
 
-      // 1st browser back: state is the reference jump's entry.
-      window.dispatchEvent(
-        new window.PopStateEvent("popstate", {
-          state: { [HISTORY_MARKER]: "ref-id", kind: "reference" },
-        })
-      );
+      // 1st back: leave the search jump, land before it (at the reference jump).
+      fakePopState(refState);
       expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 2 }));
-
-      // 2nd browser back: state is the anchor.
-      window.dispatchEvent(new window.PopStateEvent("popstate", { state: { [HISTORY_MARKER]: "anchor" } }));
+      // 2nd back: leave the reference jump, land before it.
+      fakePopState({ [HISTORY_MARKER]: "anchor" });
       expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 1 }));
+    });
+
+    it("forward redoes a jump that was undone", () => {
+      // Mirror native browser back/forward symmetry.
+      emitSlideChanged(1);
+      backStack.markNextAsJump("reference");
+      emitSlideChanged(2);
+      const refState = lastPushedState();
+      backStack.markNextAsJump("search");
+      emitSlideChanged(3);
+      const searchState = lastPushedState();
+
+      fakePopState(refState); // back: leaves search jump, lands at 2.
+      fakePopState({ [HISTORY_MARKER]: "anchor" }); // back: leaves reference jump, lands at 1.
+      navigator.mockClear();
+      fakePopState(refState); // forward: arrives at reference jump (entry 2).
+      expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 2 }));
+      fakePopState(searchState); // forward: arrives at search jump (entry 3).
+      expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 3 }));
+    });
+
+    it("a new action after back truncates forward history", () => {
+      emitSlideChanged(1);
+      backStack.markNextAsJump("reference");
+      emitSlideChanged(2);
+      const refState = lastPushedState();
+      backStack.markNextAsJump("search");
+      emitSlideChanged(3);
+      // Back once.
+      fakePopState(refState);
+      expect(backStack.size()).toBe(2);
+      // New action while on entry 2: the search entry should be dropped.
+      emitSlideChanged(99);
+      expect(backStack.size()).toBe(3);
+      expect(backStack.peek(1).globalIndex).toBe(99);
+      // Old search state is now orphaned.
+      const previousSearchId = "id-no-longer-valid";
+      navigator.mockClear();
+      fakePopState({ [HISTORY_MARKER]: previousSearchId });
+      expect(navigator).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/frontend/back-stack.test.js
+++ b/tests/frontend/back-stack.test.js
@@ -1,0 +1,365 @@
+// Unit tests for back-stack.js
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+const { backStack, __TEST__ } = await import("../../photomap/frontend/static/javascript/back-stack.js");
+
+const HISTORY_MARKER = __TEST__.HISTORY_MARKER;
+
+function emitSlideChanged(globalIndex, { searchIndex = null, isSearchMode = false } = {}) {
+  window.dispatchEvent(
+    new CustomEvent("slideChanged", {
+      detail: { globalIndex, searchIndex, isSearchMode },
+    })
+  );
+}
+
+function emitAlbumChanged(detail) {
+  window.dispatchEvent(new CustomEvent("albumChanged", { detail }));
+}
+
+function emitSearchResultsChanged(detail = { results: [{ index: 1 }], searchType: "text" }) {
+  window.dispatchEvent(new CustomEvent("searchResultsChanged", { detail }));
+}
+
+function emitSeekToSlideIndex(globalIndex, { searchIndex = null, isSearchMode = false } = {}) {
+  window.dispatchEvent(
+    new CustomEvent("seekToSlideIndex", {
+      detail: { globalIndex, searchIndex, isSearchMode },
+    })
+  );
+}
+
+describe("back-stack.js", () => {
+  let navigator;
+  let pushStateSpy;
+  let replaceStateSpy;
+
+  beforeEach(() => {
+    backStack._reset();
+    navigator = jest.fn();
+    backStack.setNavigator(navigator);
+    pushStateSpy = jest.spyOn(window.history, "pushState").mockImplementation(() => {});
+    replaceStateSpy = jest.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  // Silence unused-var lint on replaceStateSpy — kept for clarity that init
+  // anchors via replaceState.
+  it("anchors history on init", () => {
+    backStack._anchored = false;
+    backStack.init();
+    expect(replaceStateSpy).toHaveBeenCalled();
+  });
+
+  describe("step pushes", () => {
+    it("appends each new slide as a step entry", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      expect(backStack.size()).toBe(3);
+      expect(backStack.peek(1).globalIndex).toBe(2);
+      expect(backStack.peek(1).kind).toBe("step");
+    });
+
+    it("dedupes consecutive identical positions", () => {
+      emitSlideChanged(5);
+      emitSlideChanged(5);
+      emitSlideChanged(5);
+      expect(backStack.size()).toBe(1);
+    });
+
+    it("does not call history.pushState for plain steps", () => {
+      pushStateSpy.mockClear();
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      expect(pushStateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("jump pushes", () => {
+    it("tags the next slide as jump after markNextAsJump()", () => {
+      emitSlideChanged(0);
+      backStack.markNextAsJump("cluster");
+      emitSlideChanged(42);
+      const top = backStack.peek(1);
+      expect(top.globalIndex).toBe(42);
+      expect(top.kind).toBe("cluster");
+    });
+
+    it("calls history.pushState with the jump marker", () => {
+      pushStateSpy.mockClear();
+      backStack.markNextAsJump("cluster");
+      emitSlideChanged(42);
+      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+      const [stateArg] = pushStateSpy.mock.calls[0];
+      expect(stateArg[HISTORY_MARKER]).toBeTruthy();
+      expect(stateArg.kind).toBe("cluster");
+    });
+
+    it("treats searchResultsChanged as a jump signal", () => {
+      emitSlideChanged(0);
+      emitSearchResultsChanged();
+      emitSlideChanged(7, { searchIndex: 0, isSearchMode: true });
+      expect(backStack.peek(1).kind).toBe("search");
+    });
+
+    it("upgrades a same-position step to a jump when re-emitted as jump", () => {
+      emitSlideChanged(3);
+      backStack.markNextAsJump("cluster");
+      pushStateSpy.mockClear();
+      emitSlideChanged(3);
+      expect(backStack.size()).toBe(1);
+      expect(backStack.peek(1).kind).toBe("cluster");
+      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("ring buffer cap", () => {
+    it("caps entries at MAX_ENTRIES", () => {
+      for (let i = 0; i < __TEST__.MAX_ENTRIES + 10; i++) {
+        emitSlideChanged(i);
+      }
+      expect(backStack.size()).toBe(__TEST__.MAX_ENTRIES);
+      // Oldest entries are dropped, newest kept.
+      expect(backStack.peek(1).globalIndex).toBe(__TEST__.MAX_ENTRIES + 9);
+    });
+  });
+
+  describe("popOne", () => {
+    it("returns false on an empty or single-entry stack", () => {
+      expect(backStack.popOne()).toBe(false);
+      emitSlideChanged(0);
+      expect(backStack.popOne()).toBe(false);
+    });
+
+    it("pops the top entry and navigates to the previous one", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      expect(backStack.popOne()).toBe(true);
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
+      expect(backStack.size()).toBe(2);
+    });
+
+    it("dedupes the slideChanged the swiper fires after navigating back", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      backStack.popOne();
+      // Simulate the swiper firing slideChanged for the restored position.
+      emitSlideChanged(1);
+      // Dedup absorbs the re-emit; no new entry pushed.
+      expect(backStack.size()).toBe(2);
+    });
+
+    it("emits backStackChanged after popOne so the UI can refresh even when slideChanged is suppressed", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      const listener = jest.fn();
+      window.addEventListener("backStackChanged", listener);
+      backStack.popOne();
+      // The pop itself fires backStackChanged synchronously — independent of
+      // whether the swiper subsequently emits slideChanged.
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ detail: { size: 1 } }));
+      window.removeEventListener("backStackChanged", listener);
+    });
+  });
+
+  describe("popToPreviousJump (browser back)", () => {
+    it("returns false when there's no prior jump", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      expect(backStack.popToPreviousJump()).toBe(false);
+    });
+
+    it("pops past the most recent jump and navigates to the step before it", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      backStack.markNextAsJump("search");
+      emitSlideChanged(50);
+      emitSlideChanged(51);
+      emitSlideChanged(52);
+      expect(backStack.popToPreviousJump()).toBe(true);
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
+      expect(backStack.size()).toBe(2);
+    });
+
+    it("popstate triggers popToPreviousJump", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      backStack.markNextAsJump("search");
+      emitSlideChanged(99);
+      window.dispatchEvent(
+        new window.PopStateEvent("popstate", {
+          state: { [HISTORY_MARKER]: "some-id", kind: "jump" },
+        })
+      );
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
+    });
+
+    it("ignores popstate events that aren't ours", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      backStack.markNextAsJump("search");
+      emitSlideChanged(50);
+      navigator.mockClear();
+      window.dispatchEvent(new window.PopStateEvent("popstate", { state: { unrelated: true } }));
+      expect(navigator).not.toHaveBeenCalled();
+    });
+
+    it("treats an anchor popstate as a back-one-jump signal too", () => {
+      // Reaching the anchor means the user has hit back enough times to
+      // pop the last jump entry off the browser history; we should still
+      // rewind the in-memory stack.
+      emitSlideChanged(0);
+      backStack.markNextAsJump("search");
+      emitSlideChanged(10);
+      navigator.mockClear();
+      window.dispatchEvent(new window.PopStateEvent("popstate", { state: { [HISTORY_MARKER]: "anchor" } }));
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 0 }));
+    });
+
+    it("handles multiple browser-back hops through stacked jumps", () => {
+      // Mirrors the user-reported scenario: ref-image click then search,
+      // then two browser-backs should land back at the original slide.
+      emitSlideChanged(1);
+      backStack.markNextAsJump("reference");
+      emitSlideChanged(2);
+      backStack.markNextAsJump("search");
+      emitSlideChanged(3);
+
+      // 1st browser back: state is the reference jump's entry.
+      window.dispatchEvent(
+        new window.PopStateEvent("popstate", {
+          state: { [HISTORY_MARKER]: "ref-id", kind: "reference" },
+        })
+      );
+      expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 2 }));
+
+      // 2nd browser back: state is the anchor.
+      window.dispatchEvent(new window.PopStateEvent("popstate", { state: { [HISTORY_MARKER]: "anchor" } }));
+      expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 1 }));
+    });
+  });
+
+  describe("album changes", () => {
+    it("clears the stack on album switch", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      emitAlbumChanged({ album: "other", totalImages: 100 });
+      expect(backStack.size()).toBe(0);
+    });
+
+    it("marks the post-switch first slide as a jump", () => {
+      emitSlideChanged(5);
+      emitAlbumChanged({ album: "other", totalImages: 100 });
+      pushStateSpy.mockClear();
+      emitSlideChanged(0);
+      expect(backStack.peek(1).kind).toBe("jump");
+      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("filters and reindexes entries on deletion", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(2);
+      emitSlideChanged(4);
+      emitSlideChanged(6);
+      emitAlbumChanged({
+        changeType: "deletion",
+        deletedIndices: [2, 4],
+        totalImages: 4,
+      });
+      // Entries pointing at 2 and 4 should be dropped; 6 should shift to 6 - 2 = 4.
+      // peek(1) returns the newest, peek(size()) the oldest — build oldest→newest.
+      const indices = [];
+      for (let i = backStack.size(); i >= 1; i--) {
+        indices.push(backStack.peek(i).globalIndex);
+      }
+      expect(indices).toEqual([0, 4]);
+    });
+  });
+
+  describe("seekToSlideIndex (programmatic navigation)", () => {
+    it("pushes when slideState.navigateToIndex dispatches seekToSlideIndex", () => {
+      // Mirrors what the seek slider does — emits seekToSlideIndex without
+      // also firing slideChanged (because the swiper suppresses its own
+      // slideChange for nearby slides).
+      emitSlideChanged(0);
+      emitSeekToSlideIndex(50);
+      expect(backStack.size()).toBe(2);
+      expect(backStack.peek(1).globalIndex).toBe(50);
+    });
+
+    it("dedupes when both seekToSlideIndex and a follow-up slideChanged fire for the same slide", () => {
+      // The far-seek path in the swiper does fire its own slideChange after
+      // rebuilding slides; the two events should collapse to one entry.
+      emitSlideChanged(0);
+      emitSeekToSlideIndex(50);
+      emitSlideChanged(50);
+      expect(backStack.size()).toBe(2);
+    });
+  });
+
+  describe("listener-order robustness", () => {
+    it("captures jump kind even when slide-state-style listeners run first", () => {
+      // Simulate the real-world load order: a bubble-phase listener that
+      // mimics slide-state's handler is registered first, dispatches
+      // slideChanged synchronously inside its searchResultsChanged handler.
+      const fakeSlideStateListener = (e) => {
+        if (e.detail?.results?.length) {
+          window.dispatchEvent(
+            new CustomEvent("slideChanged", {
+              detail: { globalIndex: 42, searchIndex: 0, isSearchMode: true },
+            })
+          );
+        }
+      };
+      window.addEventListener("searchResultsChanged", fakeSlideStateListener);
+      try {
+        emitSlideChanged(0);
+        emitSearchResultsChanged({ results: [{ index: 42 }], searchType: "text" });
+        // The push from the fake-slide-state-dispatched slideChanged should
+        // still be a jump, not a step.
+        expect(backStack.peek(1).kind).toBe("search");
+      } finally {
+        window.removeEventListener("searchResultsChanged", fakeSlideStateListener);
+      }
+    });
+  });
+
+  describe("popToEntry", () => {
+    it("navigates to a specific entry by id and truncates above it", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      emitSlideChanged(3);
+      const target = backStack.peek(3); // {globalIndex: 1}
+      expect(backStack.popToEntry(target.id)).toBe(true);
+      expect(navigator).toHaveBeenCalledWith(expect.objectContaining({ globalIndex: 1 }));
+      expect(backStack.size()).toBe(2);
+      expect(backStack.peek(1).globalIndex).toBe(1);
+    });
+
+    it("returns false for an unknown id", () => {
+      emitSlideChanged(0);
+      expect(backStack.popToEntry("bogus")).toBe(false);
+    });
+  });
+
+  describe("recent()", () => {
+    it("returns recent entries excluding the current position, newest first", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      emitSlideChanged(3);
+      const recent = backStack.recent(2);
+      expect(recent.map((e) => e.globalIndex)).toEqual([2, 1]);
+    });
+
+    it("returns [] when the stack has 1 or 0 entries", () => {
+      expect(backStack.recent()).toEqual([]);
+      emitSlideChanged(0);
+      expect(backStack.recent()).toEqual([]);
+    });
+  });
+});

--- a/tests/frontend/back-stack.test.js
+++ b/tests/frontend/back-stack.test.js
@@ -242,6 +242,30 @@ describe("back-stack.js", () => {
       expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 1 }));
     });
 
+    it("forward restores the cursor position the user was at when they pressed back", () => {
+      // User does: seek (#2), seek (#3), arrow-step (#4). Browser-back from
+      // slide #4 should land at slide #2 (before the second seek). Then
+      // browser-forward should return to slide #4 — the actual position
+      // when back was pressed — NOT slide #3 (the seek target).
+      emitSlideChanged(0); // slide #1
+      backStack.markNextAsJump("seek");
+      emitSlideChanged(1); // slide #2 (seek)
+      const seek2State = lastPushedState();
+      backStack.markNextAsJump("seek");
+      emitSlideChanged(2); // slide #3 (seek)
+      const seek3State = lastPushedState();
+      emitSlideChanged(3); // slide #4 (arrow-step)
+
+      // Browser back: leaving the seek-#3 state, land at slide #2.
+      fakePopState(seek2State);
+      expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 1 }));
+
+      // Browser forward: should restore slide #4, not slide #3.
+      navigator.mockClear();
+      fakePopState(seek3State);
+      expect(navigator).toHaveBeenLastCalledWith(expect.objectContaining({ globalIndex: 3 }));
+    });
+
     it("forward redoes a jump that was undone", () => {
       // Mirror native browser back/forward symmetry.
       emitSlideChanged(1);
@@ -292,13 +316,17 @@ describe("back-stack.js", () => {
       expect(backStack.size()).toBe(0);
     });
 
-    it("marks the post-switch first slide as a jump", () => {
+    it("does NOT mark the post-switch first slide as a jump", () => {
+      // Album-load isn't a user action that can be undone. If we pushed it
+      // to browser history, browser-back from any post-album navigation
+      // would arrive at the anchor with no slide to navigate to, leaving
+      // the user stuck.
       emitSlideChanged(5);
       emitAlbumChanged({ album: "other", totalImages: 100 });
       pushStateSpy.mockClear();
       emitSlideChanged(0);
-      expect(backStack.peek(1).kind).toBe("jump");
-      expect(pushStateSpy).toHaveBeenCalledTimes(1);
+      expect(backStack.peek(1).kind).toBe("step");
+      expect(pushStateSpy).not.toHaveBeenCalled();
     });
 
     it("filters and reindexes entries on deletion", () => {


### PR DESCRIPTION
## Summary

- Adds a U-turn **Back button** to the control panel (left-click pops one slide, right-click / long-press opens a flyout of up to 10 recent thumbnails, `Backspace` keyboard shortcut).
- Wires the **browser back/forward buttons** to coarse-grained "jump" events (search, album switch, UMAP cluster click, reference-thumbnail click, seek slider, curation-panel UMAP click). Slide-by-slide arrow nav stays out of browser history so the back button doesn't get flooded.
- `back-stack.js` uses a timeline-with-cursor model (à la text-editor undo/redo): backing up preserves forward history, new actions truncate it. Browser back navigates to the slide *before* the most recent jump; browser forward restores to the user's actual cursor when they pressed back (so steps taken after a jump aren't lost).
- Two underlying swiper/slide-state fixes were needed to make this work cleanly: `swiper.js`'s far-branch rebuild now sets `isInternalSlideChange` so transient slide-change events during the rebuild don't leak phantom entries; `slideState.navigateToIndex` now dispatches `slideChanged` so the seek slider and UMAP marker stay in sync regardless of swiper suppression.

## Test plan

- [x] Frontend unit tests: 288/288 passing (54 new tests for back-stack + back-button).
- [x] Lint + prettier clean.
- [x] Manual verification of: in-app Back button (single click and thumbnail flyout); browser back from a search jump; browser back/forward through multiple stacked jumps (search → ref-click → seek); browser forward restoring the cursor position the user was at when they pressed back.

## Known limitations (deferred)

- Album switch clears the stack (no cross-album back/forward).
- Orphaned browser-history entries from in-app pops followed by new actions become silent no-ops on browser-back (no clean way to delete arbitrary browser-history entries from JS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)