### PR TITLE
fix(security): close XSS, path-traversal, and partial-write risks

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,11 @@ export default {
   setupFilesAfterEnv: ['./tests/frontend/setup.js'],
   moduleFileExtensions: ['js'],
   transform: {},
-  verbose: true
+  verbose: true,
+  // Native ESM has no Istanbul instrumentation, so use V8's built-in
+  // coverage. Only collect over the production frontend modules — tests
+  // and node_modules would skew the numbers.
+  coverageProvider: 'v8',
+  collectCoverageFrom: ['photomap/frontend/static/javascript/**/*.js'],
+  coverageReporters: ['text-summary', 'text']
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "PhotoMapAI Frontend JavaScript Tests",
   "type": "module",
   "scripts": {
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest --coverage",
     "lint": "eslint photomap/frontend/static/javascript/**/*.js tests/frontend/**/*.js",
     "lint:fix": "eslint --fix photomap/frontend/static/javascript/**/*.js tests/frontend/**/*.js",
     "format": "prettier --write 'photomap/frontend/static/javascript/**/*.js' 'tests/frontend/**/*.js'",

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -15,6 +15,7 @@ from platformdirs import user_config_dir
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .encoders import DEFAULT_ENCODER_SPEC, LEGACY_ENCODER_SPEC
+from .util import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -336,12 +337,10 @@ class ConfigManager:
             raise RuntimeError("No configuration loaded")
 
         try:
-            self.config_path.parent.mkdir(parents=True, exist_ok=True)
-
-            with open(self.config_path, "w") as f:
-                yaml.safe_dump(
-                    self._config.to_dict(), f, default_flow_style=False, indent=2
-                )
+            payload = yaml.safe_dump(
+                self._config.to_dict(), default_flow_style=False, indent=2
+            )
+            atomic_write_text(self.config_path, payload)
         except Exception as e:
             raise RuntimeError(
                 f"Failed to save configuration to {self.config_path}: {e}"

--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -44,6 +44,7 @@ from .metadata_extraction import MetadataExtractor
 from .metadata_formatting import format_metadata
 from .metadata_modules import SlideSummary
 from .progress import progress_tracker
+from .util import atomic_savez
 
 logger = logging.getLogger(__name__)
 
@@ -675,10 +676,8 @@ class Embeddings(BaseModel):
 
     def _save_embeddings(self, index_result: IndexResult) -> None:
         """Save embeddings to disk and clear cache."""
-        # Ensure directory exists
         logger.info(f"Saving embeddings to {self.embeddings_path}")
-        self.embeddings_path.parent.mkdir(parents=True, exist_ok=True)
-        np.savez(
+        atomic_savez(
             self.embeddings_path,
             embeddings=index_result.embeddings,
             filenames=index_result.filenames,
@@ -1150,7 +1149,7 @@ class Embeddings(BaseModel):
 
         cache_file = self.embeddings_path.parent / "umap.npz"
         umap_embeddings = np.asarray(umap_embeddings)
-        np.savez(cache_file, umap=umap_embeddings)
+        atomic_savez(cache_file, umap=umap_embeddings)
         logger.info(f"UMAP embeddings shape: {umap_embeddings.shape}")
         return umap_embeddings
 
@@ -1440,18 +1439,11 @@ class Embeddings(BaseModel):
             # 4. Clear Cache immediately (Before touching disk)
             _open_npz_file.cache_clear()
 
-            # 5. Force Delete the old file to prevent Windows locking issues
-            if self.embeddings_path.exists():
-                try:
-                    self.embeddings_path.unlink()
-                except PermissionError:
-                    logger.warning(
-                        f"File locked, attempting overwrite: {self.embeddings_path}"
-                    )
-
-            # 6. Save updated data
-            self.embeddings_path.parent.mkdir(parents=True, exist_ok=True)
-            np.savez(
+            # 5. Atomically replace the on-disk index. The previous version
+            # unlinked first and then wrote, which lost the entire index if
+            # the subsequent write failed; ``atomic_savez`` writes to a
+            # ``.tmp`` and renames into place instead.
+            atomic_savez(
                 self.embeddings_path,
                 embeddings=embeddings,
                 filenames=filenames,
@@ -1459,7 +1451,7 @@ class Embeddings(BaseModel):
                 metadata=metadata,
             )
 
-            # 7. Re-prime the cache immediately to verify the write
+            # 6. Re-prime the cache immediately to verify the write
             _open_npz_file(self.embeddings_path)
 
         except Exception as e:
@@ -1506,9 +1498,9 @@ class Embeddings(BaseModel):
             # Update the filename in the original array
             filenames[original_idx] = new_path_str
 
-            # Save updated data
-            self.embeddings_path.parent.mkdir(parents=True, exist_ok=True)
-            np.savez(
+            # Save updated data atomically so a partial write never leaves
+            # the index unloadable.
+            atomic_savez(
                 self.embeddings_path,
                 embeddings=embeddings,
                 filenames=filenames,

--- a/photomap/backend/metadata_modules/exif_formatter.py
+++ b/photomap/backend/metadata_modules/exif_formatter.py
@@ -5,6 +5,7 @@ Format EXIF metadata for images, including human-readable tags.
 Returns an HTML representation of the EXIF data.
 """
 
+import html
 from logging import getLogger
 
 import requests
@@ -12,6 +13,17 @@ import requests
 from .slide_summary import SlideSummary
 
 logger = getLogger(__name__)
+
+
+def _esc(value: object) -> str:
+    """Escape ``value`` for safe interpolation into HTML.
+
+    EXIF and LocationIQ payloads are not trusted — every value crossing into
+    the rendered drawer table must pass through here.
+    """
+    if value is None:
+        return ""
+    return html.escape(str(value), quote=True)
 
 
 def format_exif_metadata(
@@ -37,7 +49,7 @@ def format_exif_metadata(
     gps_lon = metadata.get("GPSLongitudeDecimal")
 
     # Build HTML table
-    html = """
+    html_doc = """
     <div class='exif-metadata' style="display: flex; align-items: flex-start; gap: 18px; margin: 0; padding: 0;">
     """
 
@@ -70,26 +82,26 @@ def format_exif_metadata(
             </div>
             """
         elif locationiq_api_key and not api_key_valid:
-            map_html = f'<div style="font-size:0.9em; color:#888; font-style:italic;">Map unavailable ({error_msg})</div>'
+            map_html = f'<div style="font-size:0.9em; color:#888; font-style:italic;">Map unavailable ({_esc(error_msg)})</div>'
         else:
             map_html = '<div style="font-size:0.9em; color:#888; font-style:italic;">Map unavailable (no API key)</div>'
 
-        html += f"""
+        html_doc += f"""
         <div class='gps-info' style="min-width:180px; max-width:220px; margin:0; padding:0; text-align:left; vertical-align:top;">
             <div style="font-weight: bold; margin-bottom: 4px;">📍 Location</div>
             <div style="display: flex; flex-direction: column; align-items: flex-end; font-size: 0.98em; margin-bottom: 6px;">
                     <a href="{google_maps_link}" target="_blank" style="color: white; text-decoration: none"
-                       onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'" style="text-align: left;">{coord_str}</a>
+                       onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'" style="text-align: left;">{_esc(coord_str)}</a>
             </div>
             {map_html}
         </div>
         """
     else:
         # Still need a left column for alignment, even if empty
-        html += "<div class='gps-info' style='min-width:0px;'></div>"
+        html_doc += "<div class='gps-info' style='min-width:0px;'></div>"
 
     # Right column: EXIF table
-    html += "<div style='flex:1;'><table class='exif-table'>"
+    html_doc += "<div style='flex:1;'><table class='exif-table'>"
 
     # Prioritize important fields
     priority_fields = {
@@ -111,15 +123,17 @@ def format_exif_metadata(
         "GPSTimeStamp": "GPS Time",
     }
 
-    # Add priority fields first
+    # Add priority fields first. display_name comes from the hardcoded
+    # priority_fields dict above, so it's already trusted; value comes from
+    # the image's EXIF and must be escaped.
     for field, display_name in priority_fields.items():
         if field in metadata:
             value = _format_field_value(field, metadata[field])
-            html += f"<tr><th>{display_name}</th><td>{value}</td></tr>"
+            html_doc += f"<tr><th>{display_name}</th><td>{_esc(value)}</td></tr>"
 
-    html += "</table></div></div>"  # Close right column and flex container
+    html_doc += "</table></div></div>"  # Close right column and flex container
 
-    slide_data.description = html
+    slide_data.description = html_doc
     return slide_data
 
 

--- a/photomap/backend/metadata_modules/invoke_formatter.py
+++ b/photomap/backend/metadata_modules/invoke_formatter.py
@@ -9,6 +9,7 @@ v2 / v3 / v5 InvokeAI metadata. The formatter itself does not know anything
 about the underlying metadata version layout.
 """
 
+import html
 import logging
 from collections.abc import Iterable
 from datetime import datetime
@@ -26,6 +27,17 @@ from .invokemetadata import GenerationMetadataAdapter
 from .slide_summary import SlideSummary
 
 logger = logging.getLogger(__name__)
+
+
+def _esc(value: object) -> str:
+    """Escape ``value`` for safe interpolation into HTML.
+
+    PNG tEXt chunks are attacker-controllable, so every metadata-derived
+    string crossing into the rendered drawer table must pass through here.
+    """
+    if value is None:
+        return ""
+    return html.escape(str(value), quote=True)
 
 
 _COPY_SVG = (
@@ -167,27 +179,28 @@ def format_invoke_metadata(
 
     rows: list[str] = []
     if modification_time:
-        rows.append(f"<tr><th>Date</th><td>{modification_time}</td></tr>")
+        rows.append(f"<tr><th>Date</th><td>{_esc(modification_time)}</td></tr>")
     rows.append(
         f'<tr><th>Positive Prompt</th><td class="copyme">'
-        f"{positive_prompt}{_COPY_SVG if positive_prompt else ''}</td></tr>"
+        f"{_esc(positive_prompt)}{_COPY_SVG if positive_prompt else ''}</td></tr>"
     )
     if negative_prompt:
         rows.append(
             f'<tr><th>Negative Prompt</th><td class="copyme">'
-            f"{negative_prompt}{_COPY_SVG}</td></tr>"
+            f"{_esc(negative_prompt)}{_COPY_SVG}</td></tr>"
         )
     if model:
-        rows.append(f"<tr><th>Model</th><td>{model}</td></tr>")
+        rows.append(f"<tr><th>Model</th><td>{_esc(model)}</td></tr>")
     if seed is not None:
         rows.append(
-            f'<tr><th>Seed</th><td class="copyme">{seed}{_COPY_SVG}</td></tr>'
+            f'<tr><th>Seed</th><td class="copyme">{_esc(seed)}{_COPY_SVG}</td></tr>'
         )
     if loras and (lora_html := _tuple_table(loras)):
         rows.append(f"<tr><th>Loras</th><td>{lora_html}</td></tr>")
     if raster_images:
         rows.append(
-            f"<tr><th>Raster Images</th><td>{', '.join(raster_images)}</td></tr>"
+            "<tr><th>Raster Images</th><td>"
+            f"{', '.join(_esc(name) for name in raster_images)}</td></tr>"
         )
     if reference_images and (ref_html := _tuple_table(reference_images)):
         rows.append(f"<tr><th>Reference Images</th><td>{ref_html}</td></tr>")
@@ -210,7 +223,8 @@ def format_invoke_metadata(
 
 def _scalar_table(metadata: dict) -> str:
     rows = "".join(
-        f"<tr><th>{key}</th><td>{value}</td></tr>" for key, value in metadata.items()
+        f"<tr><th>{_esc(key)}</th><td>{_esc(value)}</td></tr>"
+        for key, value in metadata.items()
     )
     return f"<table class='invoke-metadata'>{rows}</table>"
 
@@ -262,10 +276,7 @@ def _tuple_table(
         for idx in range(len(fields)):
             if not keep_column[idx]:
                 continue
-            value = tup[idx]
-            if value is None:
-                value = ""
-            cells.append(f"<td>{value}</td>")
+            cells.append(f"<td>{_esc(tup[idx])}</td>")
         html_rows.append(f"<tr>{''.join(cells)}</tr>")
 
     return "<table class='invoke-tuples'>" + "".join(html_rows) + "</table>"

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -291,6 +291,18 @@ def validate_image_access(album_config, image_path: Path) -> bool:
     # The resolve() calls shouldn't really be necessary here, but they fix problems arising
     # on mapped Windows network drive paths.
     check_album_lock(album_config.key)  # May raise a 403 exception
+
+    # Reject symlinks outright. ``resolve()`` + ``is_relative_to`` already
+    # blocks symlinks whose target lives outside the album, but a flat reject
+    # also closes a TOCTOU window between this check and the eventual file
+    # open, and shields against attacks that swap a regular file for a
+    # symlink after indexing.
+    try:
+        if image_path.is_symlink():
+            return False
+    except OSError:
+        return False
+
     return any(
         [
             image_path.resolve().is_relative_to(Path(p).resolve())

--- a/photomap/backend/routers/curation.py
+++ b/photomap/backend/routers/curation.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from ..config import get_config_manager
 from ..embeddings import _open_npz_file, get_fps_indices_global, get_kmeans_indices_global
 from ..progress import IndexStatus, progress_tracker
+from .album import validate_album_exists, validate_image_access
 from .index import check_album_lock
 
 router = APIRouter()
@@ -35,6 +36,7 @@ class ExportRequest(BaseModel):
     """
     Request model for the export endpoint.
     """
+    album: str
     filenames: list[str]
     output_folder: str
 
@@ -355,6 +357,12 @@ async def export_dataset(request: ExportRequest):
     if not is_within_base_dir(output_dir, base_dir):
         raise HTTPException(status_code=400, detail="Output folder is outside the allowed export directory")
 
+    # Resolve the album so we can verify each source path lives inside it —
+    # otherwise a caller could ask us to copy /etc/passwd into their export
+    # dir. Validated after the output-folder checks so cheap input errors
+    # surface as 400 even when the album key is bogus.
+    album_config = validate_album_exists(request.album)
+
     if not output_dir.exists():
         try:
             output_dir.mkdir(parents=True, exist_ok=True)
@@ -366,11 +374,21 @@ async def export_dataset(request: ExportRequest):
 
     for img_path in request.filenames:
         try:
-            if not os.path.exists(img_path):
+            src_path = Path(img_path)
+            if not src_path.exists():
                 continue
 
-            original_filename = os.path.basename(img_path)
-            parent_folder = os.path.basename(os.path.dirname(img_path))
+            # Reject any source that doesn't live inside one of the album's
+            # configured image_paths. ``validate_image_access`` resolves both
+            # sides and uses ``is_relative_to``, which blocks ``..``-style
+            # escapes; the explicit ``is_symlink`` guard blocks a symlink
+            # planted inside the album from pointing at an arbitrary file.
+            if src_path.is_symlink() or not validate_image_access(album_config, src_path):
+                errors.append(f"Access denied: {img_path}")
+                continue
+
+            original_filename = src_path.name
+            parent_folder = src_path.parent.name
             name_stem, name_ext = os.path.splitext(original_filename)
 
             candidate_name = original_filename
@@ -386,14 +404,14 @@ async def export_dataset(request: ExportRequest):
                 dest_path = output_dir / candidate_name
                 counter += 1
 
-            shutil.copy2(img_path, dest_path)
+            shutil.copy2(src_path, dest_path)
 
-            base_src = os.path.splitext(img_path)[0]
-            base_dest = os.path.splitext(str(dest_path))[0]
+            base_src = src_path.with_suffix("")
+            base_dest = dest_path.with_suffix("")
             for ext in ['.txt', '.caption', '.json']:
-                txt_src = base_src + ext
-                if os.path.exists(txt_src):
-                    shutil.copy2(txt_src, base_dest + ext)
+                sidecar_src = base_src.with_name(base_src.name + ext)
+                if sidecar_src.exists() and not sidecar_src.is_symlink():
+                    shutil.copy2(sidecar_src, base_dest.with_name(base_dest.name + ext))
             success_count += 1
         except Exception as e:
             errors.append(f"Copy failed: {e}")

--- a/photomap/backend/routers/filetree.py
+++ b/photomap/backend/routers/filetree.py
@@ -44,7 +44,12 @@ def get_windows_drives():
 
 
 def is_path_safe(path_str: str) -> bool:
-    """Check if path is safe to access"""
+    """Check if path is safe to access.
+
+    On Unix, the path must resolve inside ``ROOT_DIR`` (default ``/``).
+    Operators who tighten ``PHOTOMAP_ALBUM_ROOT`` to a subdirectory rely on
+    this check to keep the file-tree browser fenced in.
+    """
     if platform.system() == "Windows":
         # On Windows, allow any valid drive path
         try:
@@ -54,18 +59,15 @@ def is_path_safe(path_str: str) -> bool:
         except Exception:
             return False
     else:
-        # On Unix, check if it's within ROOT_DIR or if it's an absolute path we want to allow
         try:
             path = Path(path_str).resolve()
 
-            # If ROOT_DIR is set, check if path is within it
-            if ROOT_DIR:
-                root_path = Path(ROOT_DIR).resolve()
-                # Allow paths within ROOT_DIR or absolute paths for browsing
-                return path.is_relative_to(root_path) or path.exists()
-            else:
-                # If no ROOT_DIR restriction, allow any existing absolute path
+            # If ROOT_DIR is unset/empty, allow any existing absolute path.
+            if not ROOT_DIR:
                 return path.exists()
+
+            root_path = Path(ROOT_DIR).resolve()
+            return path.is_relative_to(root_path)
         except Exception:
             return False
 

--- a/photomap/backend/util.py
+++ b/photomap/backend/util.py
@@ -1,7 +1,56 @@
 """
 This module provides utility functions for the PhotoMap application."""
 
+import os
 import socket
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def atomic_savez(path: Path, **arrays: Any) -> None:
+    """Write a ``.npz`` archive to ``path`` atomically.
+
+    Writes to a sibling ``<name>.tmp`` and then ``Path.replace``s into place,
+    so a crash or concurrent reader never sees a half-written file. Callers
+    that previously called ``np.savez(path, ...)`` directly risked leaving a
+    truncated index that the next read would fail to load.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    try:
+        with tmp_path.open("wb") as fh:
+            np.savez(fh, **arrays)
+        os.replace(tmp_path, path)
+    except BaseException:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        raise
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Write ``text`` to ``path`` atomically via a ``.tmp`` rename.
+
+    Used for long-lived config files where a partial write would leave the
+    user unable to reload the app.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(path.name + ".tmp")
+    try:
+        with tmp_path.open("w", encoding=encoding) as fh:
+            fh.write(text)
+        os.replace(tmp_path, path)
+    except BaseException:
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        raise
 
 
 def get_public_ip_and_hostname():

--- a/photomap/frontend/static/javascript/curation.js
+++ b/photomap/frontend/static/javascript/curation.js
@@ -578,7 +578,11 @@ function setupEventListeners() {
       const response = await fetch("api/curation/export", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ filenames: filesToExport, output_folder: path }),
+        body: JSON.stringify({
+          album: state.album,
+          filenames: filesToExport,
+          output_folder: path,
+        }),
       });
       const data = await response.json();
       alert(`Exported ${data.exported} files.`);

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 testpaths = tests
+addopts = --cov=photomap --cov-report=term-missing:skip-covered
 markers =
     slow: tests that load real ML weights or otherwise take many seconds; excluded from CI via `-m "not slow"`

--- a/tests/backend/test_album_lock.py
+++ b/tests/backend/test_album_lock.py
@@ -110,6 +110,7 @@ def test_filetree_create_directory_locked(client, setup_album_lock):
 def test_curation_export_locked(client, setup_album_lock):
     """Test that /api/curation/export is disabled when album is locked."""
     response = client.post("/api/curation/export", json={
+        "album": "any-key",
         "filenames": ["test.jpg"],
         "output_folder": "/tmp/export"
     })

--- a/tests/backend/test_curation.py
+++ b/tests/backend/test_curation.py
@@ -277,6 +277,7 @@ def test_export_endpoint(client, new_album, monkeypatch, tmp_path):
         response = client.post(
             "/api/curation/export",
             json={
+                "album": new_album["key"],
                 "filenames": selected_files,
                 "output_folder": str(export_folder)
             }
@@ -295,10 +296,13 @@ def test_export_endpoint(client, new_album, monkeypatch, tmp_path):
 
 def test_export_validation(client, tmp_path):
     """Test validation of export parameters."""
+    # Output-folder validation runs before album resolution, so a dummy
+    # album key is fine here.
     # Test empty output folder
     response = client.post(
         "/api/curation/export",
         json={
+            "album": "any-key",
             "filenames": ["some_file.jpg"],
             "output_folder": ""
         }
@@ -309,6 +313,7 @@ def test_export_validation(client, tmp_path):
     response = client.post(
         "/api/curation/export",
         json={
+            "album": "any-key",
             "filenames": ["some_file.jpg"],
             "output_folder": "/\x00invalid"
         }
@@ -318,10 +323,11 @@ def test_export_validation(client, tmp_path):
 
 def test_export_path_traversal_protection(client):
     """Test that export prevents path traversal attacks."""
-    # Try to export to system directory outside user home
+    # Output-folder validation runs before album resolution.
     response = client.post(
         "/api/curation/export",
         json={
+            "album": "any-key",
             "filenames": ["some_file.jpg"],
             "output_folder": "/etc"
         }
@@ -329,7 +335,7 @@ def test_export_path_traversal_protection(client):
     assert response.status_code == 400
 
 
-def test_export_nonexistent_files(client):
+def test_export_nonexistent_files(client, new_album):
     """Test export with nonexistent files."""
     with tempfile.TemporaryDirectory(dir=Path.home()) as temp_dir:
         export_folder = Path(temp_dir) / "export_test"
@@ -337,6 +343,7 @@ def test_export_nonexistent_files(client):
         response = client.post(
             "/api/curation/export",
             json={
+                "album": new_album["key"],
                 "filenames": ["/nonexistent/file1.jpg", "/nonexistent/file2.jpg"],
                 "output_folder": str(export_folder)
             }


### PR DESCRIPTION
## Summary

Hardens the issues from the security-critical group of last week's code review:

- **XSS via PNG tEXt metadata.** Every metadata-derived string the drawer interpolates (prompts, model names, LoRA names, raster image names, EXIF values, LocationIQ place names) is now passed through `html.escape(..., quote=True)`. New `_esc` helpers in `invoke_formatter.py` and `exif_formatter.py`.
- **Path traversal in the file-tree browser.** Removed the `or path.exists()` fallback in `filetree.is_path_safe` that was nullifying the `ROOT_DIR` boundary check.
- **Arbitrary file copy via `/api/curation/export`.** The endpoint now requires an `album` field and validates every source path against that album's configured `image_paths` via `validate_image_access`. Symlinked sources and sidecars (`.txt`/`.caption`/`.json`) are rejected.
- **Symlink-based access in served images.** Centralized in `validate_image_access` so served images, thumbnails, zip downloads, and the indexing endpoints all refuse symlink files (also closes a TOCTOU window between validation and file open).
- **Non-atomic writes for `config.yaml` and `.npz`.** New `atomic_write_text` / `atomic_savez` helpers in `util.py` (`.tmp` + `os.replace`). All four `np.savez` sites in `embeddings.py` and `config.save_config` use them. `remove_image_from_embeddings` no longer unlinks the old index before writing the new one.

Piggyback commit adds **coverage reporting** to both test suites (no new deps — `pytest-cov` was already in the `testing` extras; Jest uses the V8 provider).

## Test plan

- [x] `ruff check photomap tests` — clean
- [x] `npm run lint` + `npm run format:check` — clean
- [x] `pytest tests/backend` — 257 passed (with coverage)
- [x] `npm test` — 288 passed across 18 suites (with coverage)
- [ ] Manual: open the metadata drawer on an InvokeAI-generated PNG with `<script>alert(1)</script>` injected into the prompt and confirm it renders as text
- [ ] Manual: try `/api/curation/export` with an `img_path` outside the album, confirm 403/access-denied
- [ ] Manual: tighten `PHOTOMAP_ALBUM_ROOT=/some/subdir`, confirm `/filetree/directories?path=/etc` is rejected
- [ ] Manual: kill the server mid-`update_index` and confirm the album reopens cleanly (atomic write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)