### PR TITLE
fix(concurrency): close race conditions from code review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ git worktree add -b lstein/{fix,feature,chore}/<branch-name> ../photomap-worktre
 cd ../photomap_worktrees/lstein-{fix,feature,chore}-<branch-name>
 python3 -mvenv .venv --prompt 'photomap-<branch-name>'
 source .venv/bin/activate
-pip install -e .[dev,test]
+pip install -e .[development,testing]
 ```
 
 Ruff is configured for line-length 120, target py310, rules E/W/F/I/UP/B (see pyproject.toml). Jest runs in jsdom with experimental ESM (the project is `"type": "module"`).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,7 @@ export default [
         Element: 'readonly',
         Node: 'readonly',
         NodeList: 'readonly',
+        AbortController: 'readonly',
         Blob: 'readonly',
         File: 'readonly',
         FileReader: 'readonly',

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -6,6 +6,7 @@ It uses a YAML file to store album details and provides methods to manipulate al
 """
 import logging
 import os
+import threading
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -211,6 +212,11 @@ class ConfigManager:
         """
         self.config_path = config_path or self._get_default_config_path()
         self._config: Config | None = None
+        # Re-entrant so a mutator can call load_config() and save_config()
+        # inside the same critical section. Without this lock, two concurrent
+        # API requests can clobber each other's writes when both read-modify-
+        # write the YAML config.
+        self._lock = threading.RLock()
 
     def _get_default_config_path(self) -> Path:
         """Get platform-specific default configuration file path."""
@@ -242,15 +248,16 @@ class ConfigManager:
             "PHOTOMAP_ALBUM_LOCKED"
         ):  # In locked-down environments, do not allow changing the locationIQ key
             raise PermissionError("Album configuration is locked.")
-        config = self.load_config()
-        # Strip whitespace and treat empty strings as None
-        config.locationiq_api_key = (
-            api_key.strip() if api_key and api_key.strip() else None
-        )
-        self._config = config
-        self.save_config()
-        # Clear cache after saving to ensure fresh reads
-        self._config = None
+        with self._lock:
+            config = self.load_config()
+            # Strip whitespace and treat empty strings as None
+            config.locationiq_api_key = (
+                api_key.strip() if api_key and api_key.strip() else None
+            )
+            self._config = config
+            self.save_config()
+            # Clear cache after saving to ensure fresh reads
+            self._config = None
 
     def get_invokeai_settings(self) -> dict[str, str | None]:
         """Return the configured InvokeAI connection settings."""
@@ -273,7 +280,6 @@ class ConfigManager:
 
         Empty strings are normalized to None so that the fields can be cleared.
         """
-        config = self.load_config()
 
         def _clean(value: str | None) -> str | None:
             if value is None:
@@ -281,70 +287,74 @@ class ConfigManager:
             value = value.strip()
             return value or None
 
-        config.invokeai_url = _clean(url)
-        config.invokeai_username = _clean(username)
-        config.invokeai_password = _clean(password)
-        config.invokeai_board_id = _clean(board_id)
-        self._config = config
-        self.save_config()
-        self._config = None
+        with self._lock:
+            config = self.load_config()
+            config.invokeai_url = _clean(url)
+            config.invokeai_username = _clean(username)
+            config.invokeai_password = _clean(password)
+            config.invokeai_board_id = _clean(board_id)
+            self._config = config
+            self.save_config()
+            self._config = None
 
     def load_config(self) -> Config:
         """Load configuration from YAML file."""
-        if self._config is None:
-            if not self.config_path.exists():
-                self._config = Config(
-                    config_version="1.0.0",
-                    albums={},
-                    locationiq_api_key=None,
-                )
-            else:
-                try:
-                    with open(self.config_path) as f:
-                        config_data = yaml.safe_load(f)
-
-                    # Convert album dictionaries to Album objects
-                    albums = {}
-                    for key, album_data in config_data.get("albums", {}).items():
-                        albums[key] = Album.from_dict(key, album_data)
-
-                    extra: dict[str, Any] = {}
-                    if "encoder_idle_timeout_seconds" in config_data:
-                        extra["encoder_idle_timeout_seconds"] = config_data[
-                            "encoder_idle_timeout_seconds"
-                        ]
+        with self._lock:
+            if self._config is None:
+                if not self.config_path.exists():
                     self._config = Config(
-                        config_version=config_data.get("config_version", "1.0.0"),
-                        albums=albums,
-                        locationiq_api_key=config_data.get("locationiq_api_key"),
-                        invokeai_url=config_data.get("invokeai_url"),
-                        invokeai_username=config_data.get("invokeai_username"),
-                        invokeai_password=config_data.get("invokeai_password"),
-                        invokeai_board_id=config_data.get("invokeai_board_id"),
-                        **extra,
+                        config_version="1.0.0",
+                        albums={},
+                        locationiq_api_key=None,
                     )
+                else:
+                    try:
+                        with open(self.config_path) as f:
+                            config_data = yaml.safe_load(f)
 
-                except Exception as e:
-                    raise RuntimeError(
-                        f"Failed to load configuration from {self.config_path}: {e}"
-                    ) from e
+                        # Convert album dictionaries to Album objects
+                        albums = {}
+                        for key, album_data in config_data.get("albums", {}).items():
+                            albums[key] = Album.from_dict(key, album_data)
 
-        return self._config
+                        extra: dict[str, Any] = {}
+                        if "encoder_idle_timeout_seconds" in config_data:
+                            extra["encoder_idle_timeout_seconds"] = config_data[
+                                "encoder_idle_timeout_seconds"
+                            ]
+                        self._config = Config(
+                            config_version=config_data.get("config_version", "1.0.0"),
+                            albums=albums,
+                            locationiq_api_key=config_data.get("locationiq_api_key"),
+                            invokeai_url=config_data.get("invokeai_url"),
+                            invokeai_username=config_data.get("invokeai_username"),
+                            invokeai_password=config_data.get("invokeai_password"),
+                            invokeai_board_id=config_data.get("invokeai_board_id"),
+                            **extra,
+                        )
+
+                    except Exception as e:
+                        raise RuntimeError(
+                            f"Failed to load configuration from {self.config_path}: {e}"
+                        ) from e
+
+            return self._config
 
     def save_config(self):
         """Save current configuration to file."""
-        if self._config is None:
-            raise RuntimeError("No configuration loaded")
+        with self._lock:
+            if self._config is None:
+                raise RuntimeError("No configuration loaded")
 
-        try:
-            payload = yaml.safe_dump(
-                self._config.to_dict(), default_flow_style=False, indent=2
-            )
-            atomic_write_text(self.config_path, payload)
-        except Exception as e:
-            raise RuntimeError(
-                f"Failed to save configuration to {self.config_path}: {e}"
-            ) from e
+            try:
+                payload = yaml.safe_dump(
+                    self._config.to_dict(), default_flow_style=False, indent=2
+                )
+                atomic_write_text(self.config_path, payload)
+            except Exception as e:
+                raise RuntimeError(
+                    f"Failed to save configuration to {self.config_path}: {e}"
+                ) from e
 
     def get_albums(self) -> dict[str, Album]:
         """Get all albums."""
@@ -365,16 +375,17 @@ class ConfigManager:
         Returns:
             True if added successfully, False if key already exists
         """
-        config = self.load_config()
+        with self._lock:
+            config = self.load_config()
 
-        if album.key in config.albums:
-            return False
+            if album.key in config.albums:
+                return False
 
-        config.albums[album.key] = album
-        self._config = config
-        self.save_config()
-        self._config = None  # Clear cache to ensure fresh reads
-        return True
+            config.albums[album.key] = album
+            self._config = config
+            self.save_config()
+            self._config = None  # Clear cache to ensure fresh reads
+            return True
 
     def update_album(self, album: Album) -> bool:
         """Update an existing album.
@@ -385,16 +396,17 @@ class ConfigManager:
         Returns:
             True if updated successfully, False if key doesn't exist
         """
-        config = self.load_config()
+        with self._lock:
+            config = self.load_config()
 
-        if album.key not in config.albums:
-            return False
+            if album.key not in config.albums:
+                return False
 
-        config.albums[album.key] = album
-        self._config = config
-        self.save_config()
-        self._config = None  # Clear cache to ensure fresh reads
-        return True
+            config.albums[album.key] = album
+            self._config = config
+            self.save_config()
+            self._config = None  # Clear cache to ensure fresh reads
+            return True
 
     def delete_album(self, key: str) -> bool:
         """Delete an album by key.
@@ -405,16 +417,17 @@ class ConfigManager:
         Returns:
             True if deleted successfully, False if key doesn't exist
         """
-        config = self.load_config()
+        with self._lock:
+            config = self.load_config()
 
-        if key not in config.albums:
-            return False
+            if key not in config.albums:
+                return False
 
-        del config.albums[key]
-        self._config = config
-        self.save_config()
-        self._config = None  # Clear cache to ensure fresh reads
-        return True
+            del config.albums[key]
+            self._config = config
+            self.save_config()
+            self._config = None  # Clear cache to ensure fresh reads
+            return True
 
     def get_photo_albums_dict(self) -> dict[str, str]:
         """Get albums in the old PHOTO_ALBUMS format for backward compatibility.

--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -53,6 +53,22 @@ logger = logging.getLogger(__name__)
 # keeps it fed without hitting the GIL-contention regression seen at 8.
 DEFAULT_BATCH_SIZE = 8
 DEFAULT_NUM_WORKERS = 4
+
+# Process-wide gate around the GPU-using portion of indexing. Two concurrent
+# albums each spinning up a CLIP/SigLIP encoder will OOM a typical 8-12 GiB
+# card; this serializes them so the second album waits its turn. Created
+# lazily on first use because asyncio.Semaphore wants a running event loop
+# (the module imports cleanly into CLI tools that never start one).
+_indexing_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_indexing_semaphore() -> asyncio.Semaphore:
+    global _indexing_semaphore
+    if _indexing_semaphore is None:
+        _indexing_semaphore = asyncio.Semaphore(1)
+    return _indexing_semaphore
+
+
 register_heif_opener()  # Register HEIF opener for PIL
 SUPPORTED_EXTENSIONS = {
     ".jpg",
@@ -661,18 +677,22 @@ class Embeddings(BaseModel):
         The sync :meth:`_process_images_batch` already overlaps CPU loading
         across threads, so delegating to it via ``asyncio.to_thread`` keeps
         the FastAPI event loop fully responsive while indexing runs.
+
+        Serialized by :data:`_indexing_semaphore` so two concurrent album
+        indexes don't both hold an encoder in VRAM at the same time.
         """
 
         def progress_cb(i: int, total: int, message: str) -> None:
             progress_tracker.update_progress(album_key, i, message)
 
-        return await asyncio.to_thread(
-            self._process_images_batch,
-            image_paths,
-            progress_cb,
-            batch_size,
-            num_workers,
-        )
+        async with _get_indexing_semaphore():
+            return await asyncio.to_thread(
+                self._process_images_batch,
+                image_paths,
+                progress_cb,
+                batch_size,
+                num_workers,
+            )
 
     def _save_embeddings(self, index_result: IndexResult) -> None:
         """Save embeddings to disk and clear cache."""
@@ -1467,15 +1487,17 @@ class Embeddings(BaseModel):
             new_path: The new path to the image file
         """
         try:
-            # Use optimized version for O(1) lookup
-            data = self.open_cached_embeddings(self.embeddings_path)
-
-            # Load the raw data for modification
-            sorted_filenames = data["sorted_filenames"]
-            filenames = data["filenames"]
-            embeddings = data["embeddings"]
-            modtimes = data["modification_times"]
-            metadata = data["metadata"]
+            # Load fresh copies of the raw arrays. We must NOT operate on the
+            # `_open_npz_file` cache here — concurrent readers share that dict,
+            # and mutating ``filenames`` in place would expose a half-edited
+            # array to anyone reading mid-update.
+            with np.load(self.embeddings_path, allow_pickle=True) as data:
+                filenames = data["filenames"].copy()
+                embeddings = data["embeddings"].copy()
+                modtimes = data["modification_times"].copy()
+                metadata = data["metadata"].copy()
+                sorted_indices = np.argsort(modtimes)
+                sorted_filenames = filenames[sorted_indices]
 
             current_filename = sorted_filenames[index]
 
@@ -1495,8 +1517,13 @@ class Embeddings(BaseModel):
                     new_max_len = max(len(new_path_str), max_len) + 50  # Add buffer
                     filenames = filenames.astype(f"<U{new_max_len}")
 
-            # Update the filename in the original array
+            # Update the filename in the now-private copy
             filenames[original_idx] = new_path_str
+
+            # Invalidate the shared cache BEFORE the write so any concurrent
+            # reader gets the on-disk version (old or new) rather than a stale
+            # cached object whose backing arrays we just rewrote.
+            _open_npz_file.cache_clear()
 
             # Save updated data atomically so a partial write never leaves
             # the index unloadable.
@@ -1513,7 +1540,8 @@ class Embeddings(BaseModel):
             logger.error(f"Failed to update image path in embeddings: {e}")
             raise
 
-        # Clear the LRU cache since the file has changed
+        # Re-clear after the write so any reader that primed the cache mid-flight
+        # is also invalidated.
         _open_npz_file.cache_clear()
 
     # This is not used in the current implementation, but can be useful for testing.

--- a/photomap/backend/encoders.py
+++ b/photomap/backend/encoders.py
@@ -523,20 +523,29 @@ def _idle_watcher_loop(timeout_seconds: float, poll_interval: float) -> None:
                 for key, ts in _search_encoder_last_access.items()
                 if key in _search_encoder_cache and now - ts >= timeout_seconds
             ]
-        for _key, encoder in stale:
-            if encoder.is_offloaded:
-                continue
-            # The cache-keyed timestamp only ticks on get_cached_encoder calls,
-            # but encoders also update their own `_last_use_monotonic` on every
-            # encode (via _ensure_on_device). A long encode loop holds the
-            # encoder hot via the latter even though the cache stamp is stale.
-            last_use = getattr(encoder, "_last_use_monotonic", 0.0)
-            if now - last_use < timeout_seconds:
-                continue
-            try:
-                encoder.offload()
-            except Exception:
-                logger.exception("Idle watcher failed to offload encoder")
+        for key, encoder in stale:
+            # Re-acquire the cache lock around the offload to keep
+            # ``clear_encoder_cache`` from concurrently calling ``encoder.close()``
+            # on a model the idle watcher is still moving off the GPU. If the
+            # encoder is no longer the live cache entry (e.g. the user reloaded
+            # an album with a new spec, evicting the old encoder), skip — closing
+            # an already-closed model would NPE on ``self._model``.
+            with _search_encoder_lock:
+                if _search_encoder_cache.get(key) is not encoder:
+                    continue
+                if encoder.is_offloaded:
+                    continue
+                # The cache-keyed timestamp only ticks on get_cached_encoder calls,
+                # but encoders also update their own `_last_use_monotonic` on every
+                # encode (via _ensure_on_device). A long encode loop holds the
+                # encoder hot via the latter even though the cache stamp is stale.
+                last_use = getattr(encoder, "_last_use_monotonic", 0.0)
+                if now - last_use < timeout_seconds:
+                    continue
+                try:
+                    encoder.offload()
+                except Exception:
+                    logger.exception("Idle watcher failed to offload encoder")
 
 
 def start_idle_watcher(timeout_seconds: float, poll_interval: float | None = None) -> None:

--- a/photomap/backend/progress.py
+++ b/photomap/backend/progress.py
@@ -5,6 +5,7 @@ allowing for tracking the status, progress, and estimated time remaining
 for each album being processed."""
 
 import logging
+import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
@@ -52,75 +53,91 @@ class ProgressInfo:
 
 
 class ProgressTracker:
-    """Global progress tracker for indexing operations."""
+    """Global progress tracker for indexing operations.
+
+    Mutators run on FastAPI background threads (one per active index/curation)
+    while readers come from the request thread, so every method that touches
+    ``self._progress`` takes ``self._lock`` to avoid torn reads of
+    ``ProgressInfo`` fields and lost writes when two batches update the same
+    album concurrently.
+    """
 
     def __init__(self):
         self._progress: dict[str, ProgressInfo] = {}
+        self._lock = threading.Lock()
 
     def start_operation(self, album_key: str, total_images: int, operation_type: str):
         """Start tracking progress for an album."""
-        self._progress[album_key] = ProgressInfo(
-            album_key=album_key,
-            status=IndexStatus(operation_type),
-            current_step=f"Starting {operation_type}",
-            images_processed=0,
-            total_images=total_images,
-            start_time=time.time(),
-        )
+        with self._lock:
+            self._progress[album_key] = ProgressInfo(
+                album_key=album_key,
+                status=IndexStatus(operation_type),
+                current_step=f"Starting {operation_type}",
+                images_processed=0,
+                total_images=total_images,
+                start_time=time.time(),
+            )
 
     def update_total_images(self, album_key: str, total_images: int):
         """Update the total number of images for an operation."""
-        if album_key in self._progress:
-            self._progress[album_key].total_images = total_images
+        with self._lock:
+            if album_key in self._progress:
+                self._progress[album_key].total_images = total_images
 
     def update_progress(
         self, album_key: str, images_processed: int, current_step: str = ""
     ):
         """Update progress for an album."""
-        if album_key in self._progress:
-            progress = self._progress[album_key]
-            progress.images_processed = images_processed
-            progress.current_step = current_step
-            if (
-                images_processed >= progress.total_images
-                and progress.status != IndexStatus.SCANNING
-            ):
-                progress.status = IndexStatus.COMPLETED
+        with self._lock:
+            if album_key in self._progress:
+                progress = self._progress[album_key]
+                progress.images_processed = images_processed
+                progress.current_step = current_step
+                if (
+                    images_processed >= progress.total_images
+                    and progress.status != IndexStatus.SCANNING
+                ):
+                    progress.status = IndexStatus.COMPLETED
 
     def set_error(self, album_key: str, error_message: str):
         """Set error status for an album."""
-        if album_key in self._progress:
-            progress = self._progress[album_key]
-            progress.status = IndexStatus.ERROR
-            progress.error_message = error_message
+        with self._lock:
+            if album_key in self._progress:
+                progress = self._progress[album_key]
+                progress.status = IndexStatus.ERROR
+                progress.error_message = error_message
 
     def get_progress(self, album_key: str) -> ProgressInfo | None:
         """Get progress info for an album."""
-        return self._progress.get(album_key)
+        with self._lock:
+            return self._progress.get(album_key)
 
     def remove_progress(self, album_key: str):
         """Remove progress tracking for an album."""
-        self._progress.pop(album_key, None)
+        with self._lock:
+            self._progress.pop(album_key, None)
 
     def is_running(self, album_key: str) -> bool:
         """Check if an operation is currently running for an album."""
-        progress = self._progress.get(album_key)
-        return progress is not None and progress.status in [
-            IndexStatus.SCANNING,
-            IndexStatus.INDEXING,
-            IndexStatus.UMAPPING,
-            IndexStatus.CURATING,
-        ]
+        with self._lock:
+            progress = self._progress.get(album_key)
+            return progress is not None and progress.status in [
+                IndexStatus.SCANNING,
+                IndexStatus.INDEXING,
+                IndexStatus.UMAPPING,
+                IndexStatus.CURATING,
+            ]
 
     def complete_operation(
         self, album_key: str, message: str = "Operation completed"
     ) -> None:
         """Mark an operation as completed."""
-        if album_key in self._progress:
-            progress = self._progress[album_key]
-            progress.status = IndexStatus.COMPLETED
-            progress.current_step = message
-            progress.images_processed = progress.total_images
+        with self._lock:
+            if album_key in self._progress:
+                progress = self._progress[album_key]
+                progress.status = IndexStatus.COMPLETED
+                progress.current_step = message
+                progress.images_processed = progress.total_images
 
 
 # Global instance

--- a/photomap/backend/routers/curation.py
+++ b/photomap/backend/routers/curation.py
@@ -2,6 +2,7 @@ import logging
 import os
 import random
 import shutil
+import threading
 import uuid
 from collections import Counter
 from pathlib import Path
@@ -19,8 +20,11 @@ from .index import check_album_lock
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-# Store results for completed curation jobs
+# Store results for completed curation jobs. The background task writes here
+# from a worker thread while request handlers read in the event-loop thread,
+# so guard accesses with a lock to keep the dict from being mutated mid-read.
 _curation_results: dict[str, Any] = {}
+_curation_results_lock = threading.Lock()
 
 class CurationRequest(BaseModel):
     """
@@ -127,7 +131,8 @@ def _run_curation_task(job_id: str, request: CurationRequest):
         }
 
         # Store result
-        _curation_results[job_id] = result
+        with _curation_results_lock:
+            _curation_results[job_id] = result
 
         # Mark as completed
         progress_tracker.complete_operation(job_id, "Curation completed")
@@ -136,10 +141,11 @@ def _run_curation_task(job_id: str, request: CurationRequest):
     except Exception as e:
         logger.error(f"Curation Job {job_id}: Error - {str(e)}")
         progress_tracker.set_error(job_id, str(e))
-        _curation_results[job_id] = {
-            "status": "error",
-            "error": str(e)
-        }
+        with _curation_results_lock:
+            _curation_results[job_id] = {
+                "status": "error",
+                "error": str(e)
+            }
 
 @router.post("/curate")
 async def run_curation(request: CurationRequest, background_tasks: BackgroundTasks):
@@ -185,10 +191,12 @@ async def get_curation_progress(job_id: str):
 
     if progress is None:
         # Check if we have a completed result
-        if job_id in _curation_results:
+        with _curation_results_lock:
+            cached = _curation_results.get(job_id)
+        if cached is not None:
             return {
                 "status": "completed",
-                "result": _curation_results[job_id]
+                "result": cached
             }
         raise HTTPException(status_code=404, detail="Job not found")
 
@@ -200,7 +208,8 @@ async def get_curation_progress(job_id: str):
 
     if progress.status == IndexStatus.COMPLETED:
         # Return result if available
-        result = _curation_results.get(job_id, {})
+        with _curation_results_lock:
+            result = _curation_results.get(job_id, {})
         return {
             "status": "completed",
             "result": result

--- a/photomap/frontend/static/javascript/search.js
+++ b/photomap/frontend/static/javascript/search.js
@@ -3,6 +3,12 @@
 import { state } from "./state.js";
 import { hideSpinner, showSpinner } from "./utils.js";
 
+// Tracks the AbortController of the in-flight search request so a newer
+// query can cancel an older one. Without this, a slower response wins and
+// overwrites the latest search results — confusing the user and breaking
+// the swiper state.
+let _activeSearchController = null;
+
 // Call the server to fetch the image indicated by the index
 export async function fetchImageByIndex(index) {
   let response;
@@ -93,17 +99,33 @@ export async function searchTextAndImage({
     use_query_optimization: state.useQueryOptimization,
   };
 
+  // Cancel any in-flight search so the most recent query wins.
+  if (_activeSearchController) {
+    _activeSearchController.abort();
+  }
+  const controller = new AbortController();
+  _activeSearchController = controller;
+
   try {
     const response = await fetch(`search_with_text_and_image/${encodeURIComponent(state.album)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
+      signal: controller.signal,
     });
     const result = await response.json();
     return result.results || [];
   } catch (err) {
+    if (err.name === "AbortError") {
+      // Superseded by a newer search — fall through silently.
+      return [];
+    }
     console.error("search_with_text_and_image request failed:", err);
     return [];
+  } finally {
+    if (_activeSearchController === controller) {
+      _activeSearchController = null;
+    }
   }
 }
 

--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -28,6 +28,17 @@ class SwiperManager {
     this.isAppending = false;
     this.isInternalSlideChange = false;
 
+    // Single-flight gate for resetAllSlides. albumChanged, searchResultsChanged,
+    // and swiperModeChanged can all fire in quick succession (e.g. switching
+    // album while a search is in flight). Without coordination, two concurrent
+    // resets each call removeAllSlides + addSlideByIndex + slideTo and race
+    // for the DOM. ``_resetInFlight`` holds the active rebuild and
+    // ``_resetPending`` records that another reset is queued; we coalesce so
+    // at most one rebuild runs at a time and a second is run once on top of
+    // the latest slideState.
+    this._resetInFlight = null;
+    this._resetPending = false;
+
     // Store event listeners for cleanup
     this.eventListeners = [];
 
@@ -237,17 +248,15 @@ class SwiperManager {
       }
     });
 
-    // Reset slide show when the album changes
+    // Reset slide show when the album, search results, or mode changes.
+    // All three go through the single-flight resetAllSlides so they coalesce
+    // instead of racing for the DOM if more than one fires in the same tick.
     this.addEventListener(window, "albumChanged", () => {
       this.resetAllSlides();
     });
-
-    // Reset slide show when the search results change
     this.addEventListener(window, "searchResultsChanged", () => {
       this.resetAllSlides();
     });
-
-    // Handle slideshow mode changes
     this.addEventListener(window, "swiperModeChanged", () => {
       this.resetAllSlides();
     });
@@ -507,6 +516,37 @@ class SwiperManager {
   // The random_nextslide parameter is a hack that will make the preloaded next slide a random one
   // It is a hack that should be fixed.
   async resetAllSlides(random_nextslide = false) {
+    // Single-flight: if a rebuild is already running, mark that we want
+    // another rebuild after it finishes and await the eventual completion.
+    // Otherwise kick off a rebuild that loops until no further reset is
+    // pending. Coalescing this way means three quickly-fired events become
+    // at most two sequential rebuilds — one in flight, one that catches the
+    // latest slideState afterwards.
+    if (this._resetInFlight) {
+      this._resetPending = true;
+      try {
+        await this._resetInFlight;
+      } catch {
+        // Errors are logged by the underlying rebuild; don't propagate.
+      }
+      return;
+    }
+
+    const runner = (async () => {
+      try {
+        do {
+          this._resetPending = false;
+          await this._doResetAllSlides(random_nextslide);
+        } while (this._resetPending);
+      } finally {
+        this._resetInFlight = null;
+      }
+    })();
+    this._resetInFlight = runner;
+    await runner;
+  }
+
+  async _doResetAllSlides(random_nextslide = false) {
     if (!this.swiper) {
       return;
     }


### PR DESCRIPTION
## Summary

Backend:
- Process-wide `asyncio.Semaphore(1)` in `embeddings._process_images_batch_async` so two concurrent album indexes don't both pin an encoder in VRAM and OOM the GPU (resolves the long-open question in `concurrent_indexing_vram.md`).
- `threading.RLock` on every mutating/reading method of `ConfigManager` (`load_config`, `save_config`, `add_album`, `update_album`, `delete_album`, `set_locationiq_api_key`, `set_invokeai_settings`). Concurrent API requests could previously read-modify-write the YAML and lose a write.
- `threading.Lock` on every accessor of `ProgressTracker`, plus a dedicated `_curation_results_lock` on the curation router's results dict. Background tasks no longer race the request thread for torn reads.
- `embeddings.update_image_path` no longer mutates the `_open_npz_file` LRU cache in place — it loads via `np.load(...).copy()`, invalidates the cache before AND after writing.
- Idle encoder watcher re-acquires `_search_encoder_lock` and re-verifies cache membership around each `encoder.offload()` so `clear_encoder_cache` can't `close()` the encoder mid-offload.

Frontend:
- `searchTextAndImage` now uses an `AbortController` stored at module scope; a newer search aborts the older request, `AbortError` falls through silently. The slower-response-wins bug is gone.
- `SwiperManager.resetAllSlides` is now a single-flight runner — `albumChanged` / `searchResultsChanged` / `swiperModeChanged` coalesce into at most two sequential rebuilds (one in flight, one that catches the latest `slideState`).
- `eslint.config.js` adds `AbortController` to the browser globals.

Also piggybacks a one-line CLAUDE.md doc fix: the worktree setup snippet referenced `.[dev,test]`, but the actual extras names are `development` and `testing`.

## Skipped findings (not actually bugs on closer look)

- `cluster-utils.getImageLabelInfo` was flagged for setting `imageLabelInFlight` after the IIFE's first `await`, but the `.set(key, promise)` runs synchronously *before* the function returns, so a concurrent caller sees the in-flight entry. JS single-threading covers it.
- `swiper.isInternalSlideChange` was flagged for being reset around the synchronous `slideTo()` fast path, but Swiper fires `slideChange` synchronously inside `slideTo`, so the flag is set when the handler runs.

## Test plan

- [x] `ruff check photomap tests` — clean
- [x] `npm run lint` + `npm run format:check` — clean
- [x] `pytest tests/backend` — 257 passed
- [x] `npm test` — 288 passed across 18 suites
- [x] Manual: kick off `update_index` on two albums back-to-back, watch `nvidia-smi`: only one CLIP/SigLIP weight should sit in VRAM at a time
- [x] Manual: rapid-fire several searches in the input box — confirm only the latest result set lands
- [x] Manual: switch albums while a search result panel is mounted — confirm the swiper rebuilds cleanly with no torn frames

🤖 Generated with [Claude Code](https://claude.com/claude-code)