### PR TITLE
chore(ci): use CLAUDE_CODE_OAUTH_TOKEN for claude-code-action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary
- The `claude.yml` workflow was passing `secrets.ANTHROPIC_API_KEY`, but the repo is configured with a `CLAUDE_CODE_OAUTH_TOKEN` secret (from `/install-github-app`).
- The action saw no API key, fell back to looking for the OAuth token, and reported it unset.
- Switch the workflow to pass `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` so the existing repo secret is actually used.

## Test plan
- [ ] After merge, open an issue or PR comment containing `@claude` and confirm the workflow runs without the "CLAUDE_CODE_OAUTH_TOKEN is not set" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)