### PR TITLE
fix(umap): preserve cluster id 0 in landmark hover/click

### DIFF
--- a/photomap/frontend/static/javascript/umap-helpers.js
+++ b/photomap/frontend/static/javascript/umap-helpers.js
@@ -1,0 +1,17 @@
+// umap-helpers.js
+// Small pure helpers extracted from umap.js so they can be unit-tested without
+// pulling in the full UMAP module (which has DOM side effects at load time).
+
+// Find which landmark cluster a point falls inside, given the landmark trace's
+// coordinates and the half-extent of the clickable square (in plot units).
+// Returns the cluster id at the first match, or null if no landmark contains
+// the point. Uses `??` (not `||`) so that a cluster id of 0 — a valid cluster
+// that is falsy — is not silently coerced to null.
+export function findLandmarkClusterAt(point, landmarkXs, landmarkYs, landmarkClusters, halfSizeX, halfSizeY) {
+  for (let i = 0; i < landmarkXs.length; i++) {
+    if (Math.abs(point.x - landmarkXs[i]) <= halfSizeX && Math.abs(point.y - landmarkYs[i]) <= halfSizeY) {
+      return landmarkClusters[i] ?? null;
+    }
+  }
+  return null;
+}

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -14,6 +14,7 @@ import {
   setUmapShowLandmarks,
   state,
 } from "./state.js";
+import { findLandmarkClusterAt } from "./umap-helpers.js";
 import { debounce, getPercentile, isColorLight } from "./utils.js";
 
 const UMAP_SIZES = {
@@ -486,14 +487,7 @@ function findLandmarkCluster(point) {
   const landmarkYs = landmarkTrace.y;
   const landmarkClusters = landmarkTrace.customdata || [];
 
-  let foundLandmark = null;
-  for (let i = 0; i < landmarkXs.length; i++) {
-    if (Math.abs(point.x - landmarkXs[i]) <= halfSizeX && Math.abs(point.y - landmarkYs[i]) <= halfSizeY) {
-      foundLandmark = landmarkClusters[i] || null;
-      break;
-    }
-  }
-  return foundLandmark;
+  return findLandmarkClusterAt(point, landmarkXs, landmarkYs, landmarkClusters, halfSizeX, halfSizeY);
 }
 
 const plotDiv = document.getElementById("umapPlot");

--- a/tests/frontend/umap-helpers.test.js
+++ b/tests/frontend/umap-helpers.test.js
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { findLandmarkClusterAt } from "../../photomap/frontend/static/javascript/umap-helpers.js";
+
+describe("findLandmarkClusterAt", () => {
+  // Three landmarks at distinct positions, deliberately covering cluster ids
+  // 0, 1, and 2 so we can pin down the cluster-0 falsy-coercion regression.
+  const landmarkXs = [10, 20, 30];
+  const landmarkYs = [10, 20, 30];
+  const landmarkClusters = [0, 1, 2];
+  const halfSizeX = 2;
+  const halfSizeY = 2;
+
+  it("returns the matching cluster id when the point is inside a landmark square", () => {
+    const result = findLandmarkClusterAt(
+      { x: 20, y: 20 },
+      landmarkXs,
+      landmarkYs,
+      landmarkClusters,
+      halfSizeX,
+      halfSizeY
+    );
+    expect(result).toBe(1);
+  });
+
+  // Regression: previously the production code used `landmarkClusters[i] || null`,
+  // which coerced cluster id 0 to null. That made hover/click for Cluster 0's
+  // landmark fall through to the "regular point" branch and pop up info for
+  // Image 0 instead of the cluster medoid.
+  it("returns 0 (not null) when the matching landmark is Cluster 0", () => {
+    const result = findLandmarkClusterAt(
+      { x: 10, y: 10 },
+      landmarkXs,
+      landmarkYs,
+      landmarkClusters,
+      halfSizeX,
+      halfSizeY
+    );
+    expect(result).toBe(0);
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null when no landmark contains the point", () => {
+    const result = findLandmarkClusterAt(
+      { x: 100, y: 100 },
+      landmarkXs,
+      landmarkYs,
+      landmarkClusters,
+      halfSizeX,
+      halfSizeY
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns the first match when a point falls inside multiple landmark squares", () => {
+    // Overlapping landmarks at the same coordinates; first one wins, matching
+    // the existing loop semantics.
+    const xs = [10, 10];
+    const ys = [10, 10];
+    const clusters = [0, 5];
+    const result = findLandmarkClusterAt({ x: 10, y: 10 }, xs, ys, clusters, 2, 2);
+    expect(result).toBe(0);
+  });
+
+  it("returns null when customdata is missing for a matched landmark", () => {
+    const result = findLandmarkClusterAt({ x: 10, y: 10 }, landmarkXs, landmarkYs, [], halfSizeX, halfSizeY);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `findLandmarkCluster` used `landmarkClusters[i] || null`, which coerced the valid cluster id `0` to `null`. The hover handler then fell through to the regular-point branch and read `pt.customdata` from the `LandmarkClickTargets` trace — that customdata is the cluster id (`0`) — and displayed it as image index `0`. The same falsy-coercion routed clicks on Cluster 0's landmark to Image 0.
- Extracted the inner match loop into a pure `findLandmarkClusterAt` helper in a new `umap-helpers.js` so it is testable without the DOM-coupled side effects in `umap.js`, and switched the coercion to `??`.
- Added a Jest regression suite (`tests/frontend/umap-helpers.test.js`) covering the cluster-0 case plus the surrounding semantics (no-match returns `null`, first overlap wins, missing customdata returns `null`).

## Test plan
- [x] `npm test` — full Jest suite passes (293/293), `umap-helpers.js` at 100% coverage.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [x] Reverted the fix locally to confirm the regression test fails against the buggy `||`, then re-applied.
- [ ] Manual: hover the Cluster 0 landmark in the UMAP view and confirm the popup shows the cluster's medoid info, not "Image 0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)