### PR TITLE
refactor(frontend): unify drag handlers behind a single makeDraggable helper

### DIFF
--- a/photomap/frontend/static/javascript/curation.js
+++ b/photomap/frontend/static/javascript/curation.js
@@ -5,7 +5,7 @@ import { updateSearchCheckmarks } from "./search-ui.js";
 import { slideState } from "./slide-state.js";
 import { state } from "./state.js";
 import { highlightCurationSelection, setCurationMode, setUmapClickCallback, updateCurrentImageMarker } from "./umap.js";
-import { fetchJson, hideSpinner, showSpinner } from "./utils.js";
+import { fetchJson, hideSpinner, makeDraggable, showSpinner } from "./utils.js";
 
 let currentSelectionIndices = new Set();
 const excludedIndices = new Set();
@@ -59,68 +59,16 @@ function makePanelDraggable() {
     return;
   }
 
-  let isDragging = false;
-  let startX, startY, initialLeft, initialTop;
-
-  // Helper function to get coordinates from event (mouse or touch)
-  const getEventCoords = (e) => {
-    if (e.touches && e.touches.length > 0) {
-      return { x: e.touches[0].clientX, y: e.touches[0].clientY };
-    }
-    return { x: e.clientX, y: e.clientY };
-  };
-
-  // Start dragging (mouse or touch)
-  const startDrag = (e) => {
-    // Don't drag if clicking the close button
-    if (e.target.classList.contains("close-icon")) {
-      return;
-    }
-
-    isDragging = true;
-    const coords = getEventCoords(e);
-    startX = coords.x;
-    startY = coords.y;
-
-    const rect = panel.getBoundingClientRect();
-    initialLeft = rect.left;
-    initialTop = rect.top;
-
-    e.preventDefault();
-  };
-
-  // Handle dragging movement (mouse or touch)
-  const handleDrag = (e) => {
-    if (!isDragging) {
-      return;
-    }
-
-    const coords = getEventCoords(e);
-    const deltaX = coords.x - startX;
-    const deltaY = coords.y - startY;
-
-    panel.style.left = initialLeft + deltaX + "px";
-    panel.style.top = initialTop + deltaY + "px";
-    panel.style.bottom = "auto"; // Remove bottom positioning
-
-    e.preventDefault(); // Prevent scrolling while dragging on touch devices
-  };
-
-  // End dragging (mouse or touch)
-  const endDrag = () => {
-    isDragging = false;
-  };
-
-  // Mouse events
-  header.addEventListener("mousedown", startDrag);
-  document.addEventListener("mousemove", handleDrag);
-  document.addEventListener("mouseup", endDrag);
-
-  // Touch events
-  header.addEventListener("touchstart", startDrag, { passive: false });
-  document.addEventListener("touchmove", handleDrag, { passive: false });
-  document.addEventListener("touchend", endDrag);
-  document.addEventListener("touchcancel", endDrag);
+  makeDraggable(header, panel, {
+    shouldDrag: (e) => !e.target.classList.contains("close-icon"),
+    setPosition: (left, top) => {
+      panel.style.left = `${left}px`;
+      panel.style.top = `${top}px`;
+      // Remove bottom positioning so the panel doesn't get pinned to the
+      // bottom edge of the viewport once the user moves it.
+      panel.style.bottom = "auto";
+    },
+  });
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/photomap/frontend/static/javascript/metadata-drawer.js
+++ b/photomap/frontend/static/javascript/metadata-drawer.js
@@ -5,7 +5,7 @@ import { scoreDisplay } from "./score-display.js";
 import { slideState } from "./slide-state.js";
 import { state, setShowMetadataFields } from "./state.js";
 import { setSearchResults } from "./search.js";
-import { isColorLight } from "./utils.js";
+import { isColorLight, makeDraggable } from "./utils.js";
 import {
   getClusterColorFromPoints,
   getClusterInfoForImage,
@@ -418,10 +418,9 @@ if (copyMetadataBtn && metadataTextArea) {
   });
 }
 
-let isDraggingDrawer = false;
-let startX, startY, initialLeft, initialTop;
-
-// Helper to get/set drawer position
+// Helper to set/reset drawer position. ``setDrawerPosition`` is passed to
+// ``makeDraggable`` below as a custom writer so it can also clear the CSS
+// ``transform`` that originally centered the drawer.
 function setDrawerPosition(left, top) {
   const container = document.getElementById("bannerDrawerContainer");
   container.style.left = `${left}px`;
@@ -436,126 +435,30 @@ function resetDrawerPosition() {
   container.style.transform = ""; // Restore original transform
 }
 
-// Helper function to get coordinates from event (mouse or touch)
-const getEventCoords = (e) => {
-  if (e.touches && e.touches.length > 0) {
-    return { x: e.touches[0].clientX, y: e.touches[0].clientY };
-  }
-  return { x: e.clientX, y: e.clientY };
-};
-
-// Mouse/touch drag handlers
-function onDrawerMouseDown(e) {
-  // Only drag if clicking on the titlebar, but not on the copy button
-  const isTitlebar =
-    e.target.id === "filenameTitlebar" ||
-    e.target.classList.contains("filename-titlebar") ||
-    e.target.id === "filenameText";
-  const isCopyButton = e.target.id === "copyTextBtn" || e.target.closest("#copyTextBtn");
-
-  if (isTitlebar && !isCopyButton) {
-    isDraggingDrawer = true;
-    const coords = getEventCoords(e);
-    startX = coords.x;
-    startY = coords.y;
-
-    const container = document.getElementById("bannerDrawerContainer");
-    const rect = container.getBoundingClientRect();
-    initialLeft = rect.left;
-    initialTop = rect.top;
-    container.classList.add("dragging");
-
-    document.body.style.userSelect = "none";
-    e.preventDefault();
-  }
-}
-
-function onDrawerMouseMove(e) {
-  if (!isDraggingDrawer) {
-    return;
-  }
-
-  const coords = getEventCoords(e);
-  const deltaX = coords.x - startX;
-  const deltaY = coords.y - startY;
-
-  const left = initialLeft + deltaX;
-  const top = initialTop + deltaY;
-  setDrawerPosition(left, top);
-
-  e.preventDefault();
-}
-
-function onDrawerMouseUp() {
-  if (!isDraggingDrawer) {
-    return;
-  }
-  isDraggingDrawer = false;
-  document.getElementById("bannerDrawerContainer")?.classList.remove("dragging");
-  document.body.style.userSelect = "";
-}
-
-// Touch support
-function onDrawerTouchStart(e) {
-  // Only drag if clicking on the titlebar, but not on the copy button
-  const isTitlebar =
-    e.target.id === "filenameTitlebar" ||
-    e.target.classList.contains("filename-titlebar") ||
-    e.target.id === "filenameText";
-  const isCopyButton = e.target.id === "copyTextBtn" || e.target.closest("#copyTextBtn");
-
-  if (isTitlebar && !isCopyButton) {
-    isDraggingDrawer = true;
-    const coords = getEventCoords(e);
-    startX = coords.x;
-    startY = coords.y;
-
-    const container = document.getElementById("bannerDrawerContainer");
-    const rect = container.getBoundingClientRect();
-    initialLeft = rect.left;
-    initialTop = rect.top;
-    container.classList.add("dragging");
-
-    document.body.style.userSelect = "none";
-    e.preventDefault();
-  }
-}
-
-function onDrawerTouchMove(e) {
-  if (!isDraggingDrawer) {
-    return;
-  }
-
-  const coords = getEventCoords(e);
-  const deltaX = coords.x - startX;
-  const deltaY = coords.y - startY;
-
-  const left = initialLeft + deltaX;
-  const top = initialTop + deltaY;
-  setDrawerPosition(left, top);
-
-  e.preventDefault();
-}
-
-function onDrawerTouchEnd() {
-  if (!isDraggingDrawer) {
-    return;
-  }
-  isDraggingDrawer = false;
-  document.getElementById("bannerDrawerContainer")?.classList.remove("dragging");
-  document.body.style.userSelect = "";
-}
-
-// Attach event listeners
+// Wire up the drawer's titlebar to the shared `makeDraggable` helper.
 const drawer = document.getElementById("bannerDrawerContainer");
 if (drawer) {
-  drawer.addEventListener("mousedown", onDrawerMouseDown);
-  window.addEventListener("mousemove", onDrawerMouseMove);
-  window.addEventListener("mouseup", onDrawerMouseUp);
-
-  drawer.addEventListener("touchstart", onDrawerTouchStart, { passive: false });
-  window.addEventListener("touchmove", onDrawerTouchMove, { passive: false });
-  window.addEventListener("touchend", onDrawerTouchEnd);
+  makeDraggable(drawer, drawer, {
+    // The drawer is its own handle — restrict to the titlebar region and
+    // exclude the copy button so its click still works.
+    shouldDrag: (e) => {
+      const isTitlebar =
+        e.target.id === "filenameTitlebar" ||
+        e.target.classList.contains("filename-titlebar") ||
+        e.target.id === "filenameText";
+      const isCopyButton = e.target.id === "copyTextBtn" || e.target.closest("#copyTextBtn");
+      return isTitlebar && !isCopyButton;
+    },
+    setPosition: setDrawerPosition,
+    onDragStart: () => {
+      drawer.classList.add("dragging");
+      document.body.style.userSelect = "none";
+    },
+    onDragEnd: () => {
+      drawer.classList.remove("dragging");
+      document.body.style.userSelect = "";
+    },
+  });
 }
 
 // 2. Snap back when handle is clicked

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -15,7 +15,7 @@ import {
   state,
 } from "./state.js";
 import { findLandmarkClusterAt } from "./umap-helpers.js";
-import { debounce, getPercentile, isColorLight } from "./utils.js";
+import { debounce, getPercentile, isColorLight, makeDraggable } from "./utils.js";
 
 const UMAP_SIZES = {
   big: { width: 800, height: 590 },
@@ -1468,64 +1468,25 @@ document.getElementById("umapToggleControlsBtn").onclick = () => {
 };
 
 // --- Draggable Window ---
-function makeDraggable(dragHandleId, windowId) {
+// Wire the UMAP floating window's titlebar to the shared `makeDraggable` helper.
+// The right/bottom/position overrides keep the win element from snapping back
+// to its CSS-defined corner when its layout was originally anchored that way.
+function setupUmapWindowDrag(dragHandleId, windowId) {
   const dragHandle = document.getElementById(dragHandleId);
   const win = document.getElementById(windowId);
-  let offsetX = 0,
-    offsetY = 0,
-    dragging = false;
-
-  dragHandle.addEventListener("mousedown", startDrag);
-  dragHandle.addEventListener("touchstart", startDrag, { passive: false });
-
-  function startDrag(e) {
-    // Prevent drag if touching a button in the titlebar
-    if (e.target.closest(".icon-btn") || e.target.id === "umapCloseBtn") {
-      return; // Don't start drag
-    }
-    dragging = true;
-    const rect = win.getBoundingClientRect();
-    if (e.type === "touchstart") {
-      offsetX = e.touches[0].clientX - rect.left;
-      offsetY = e.touches[0].clientY - rect.top;
-      document.addEventListener("touchmove", onDrag, { passive: false });
-      document.addEventListener("touchend", stopDrag);
-    } else {
-      offsetX = e.clientX - rect.left;
-      offsetY = e.clientY - rect.top;
-      document.addEventListener("mousemove", onDrag);
-      document.addEventListener("mouseup", stopDrag);
-    }
-    e.preventDefault();
+  if (!dragHandle || !win) {
+    return;
   }
-
-  function onDrag(e) {
-    if (!dragging) {
-      return;
-    }
-    let clientX, clientY;
-    if (e.type === "touchmove") {
-      clientX = e.touches[0].clientX;
-      clientY = e.touches[0].clientY;
-    } else {
-      clientX = e.clientX;
-      clientY = e.clientY;
-    }
-    win.style.left = `${clientX - offsetX}px`;
-    win.style.top = `${clientY - offsetY}px`;
-    win.style.right = "auto"; // Prevent CSS conflicts
-    win.style.bottom = "auto";
-    win.style.position = "fixed";
-    e.preventDefault();
-  }
-
-  function stopDrag() {
-    dragging = false;
-    document.removeEventListener("mousemove", onDrag);
-    document.removeEventListener("mouseup", stopDrag);
-    document.removeEventListener("touchmove", onDrag);
-    document.removeEventListener("touchend", stopDrag);
-  }
+  makeDraggable(dragHandle, win, {
+    shouldDrag: (e) => !e.target.closest(".icon-btn") && e.target.id !== "umapCloseBtn",
+    setPosition: (left, top) => {
+      win.style.left = `${left}px`;
+      win.style.top = `${top}px`;
+      win.style.right = "auto";
+      win.style.bottom = "auto";
+      win.style.position = "fixed";
+    },
+  });
 }
 
 function setActiveResizeIcon(sizeKey) {
@@ -1666,7 +1627,7 @@ function setUmapWindowSize(sizeKey) {
 // Initialize draggable UMAP window a fter DOM is ready
 document.addEventListener("DOMContentLoaded", () => {
   updateUmapColorModeAvailability();
-  makeDraggable("umapTitlebar", "umapFloatingWindow");
+  setupUmapWindowDrag("umapTitlebar", "umapFloatingWindow");
   toggleUmapWindow();
 });
 

--- a/photomap/frontend/static/javascript/utils.js
+++ b/photomap/frontend/static/javascript/utils.js
@@ -156,3 +156,108 @@ export function debounce(fn, delay) {
     timer = setTimeout(() => fn.apply(this, args), delay);
   };
 }
+
+/**
+ * Make ``target`` draggable by mousedown/touchstart on ``handle``.
+ *
+ * Handles both mouse and touch, captures the initial pointer offset, and
+ * registers document-level move/end listeners only while a drag is active
+ * (so listeners don't outlive detached nodes the way ``window``-scoped
+ * ones did in the per-module copies this replaces).
+ *
+ * ``options``:
+ *
+ * - ``shouldDrag(event)`` — return ``false`` to skip starting a drag for
+ *   the current pointer event (e.g. clicks on a close button inside the
+ *   handle). Defaults to always-true.
+ *
+ * - ``setPosition(left, top)`` — override the default
+ *   ``target.style.left/top = '${n}px'`` writer. Use when the target
+ *   needs additional CSS resets (``transform: none``, ``right: auto``,
+ *   ``bottom: auto``) or has to flow through a setter that also
+ *   notifies other code.
+ *
+ * - ``onDragStart()`` / ``onDragEnd()`` — fire after a drag begins / ends.
+ *   Useful for ``classList.add('dragging')`` and toggling
+ *   ``document.body.style.userSelect``.
+ *
+ * Returns a teardown function that removes the handle listeners and any
+ * still-attached document listeners.
+ */
+export function makeDraggable(handle, target, options = {}) {
+  const { shouldDrag = () => true, setPosition = null, onDragStart = null, onDragEnd = null } = options;
+
+  let startX = 0;
+  let startY = 0;
+  let initialLeft = 0;
+  let initialTop = 0;
+
+  function getCoords(e) {
+    if (e.touches && e.touches.length > 0) {
+      return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+    }
+    return { x: e.clientX, y: e.clientY };
+  }
+
+  function writePosition(left, top) {
+    if (setPosition) {
+      setPosition(left, top);
+    } else {
+      target.style.left = `${left}px`;
+      target.style.top = `${top}px`;
+    }
+  }
+
+  function onMove(e) {
+    const { x, y } = getCoords(e);
+    writePosition(initialLeft + (x - startX), initialTop + (y - startY));
+    e.preventDefault();
+  }
+
+  function onEnd() {
+    document.removeEventListener("mousemove", onMove);
+    document.removeEventListener("mouseup", onEnd);
+    document.removeEventListener("touchmove", onMove);
+    document.removeEventListener("touchend", onEnd);
+    document.removeEventListener("touchcancel", onEnd);
+    if (onDragEnd) {
+      onDragEnd();
+    }
+  }
+
+  function onStart(e) {
+    if (!shouldDrag(e)) {
+      return;
+    }
+    const { x, y } = getCoords(e);
+    startX = x;
+    startY = y;
+    const rect = target.getBoundingClientRect();
+    initialLeft = rect.left;
+    initialTop = rect.top;
+
+    if (e.type === "touchstart") {
+      document.addEventListener("touchmove", onMove, { passive: false });
+      document.addEventListener("touchend", onEnd);
+      document.addEventListener("touchcancel", onEnd);
+    } else {
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onEnd);
+    }
+
+    if (onDragStart) {
+      onDragStart();
+    }
+    e.preventDefault();
+  }
+
+  handle.addEventListener("mousedown", onStart);
+  handle.addEventListener("touchstart", onStart, { passive: false });
+
+  return function teardown() {
+    handle.removeEventListener("mousedown", onStart);
+    handle.removeEventListener("touchstart", onStart);
+    // Drop any in-flight document listeners (no-op if no drag is active).
+    onEnd();
+  };
+}


### PR DESCRIPTION
## Summary

Three modules each carried their own ~60-line draggable-window implementation:

- \`umap.js\` — UMAP floating window, with \`.icon-btn\` / \`#umapCloseBtn\` exclusion and \`right/bottom: auto; position: fixed\` resets
- \`curation.js\` — curation panel, with \`.close-icon\` exclusion and \`bottom: auto\` reset
- \`metadata-drawer.js\` — drawer titlebar, with titlebar id/class + copy-button exclusion, \`transform: none\` reset, and \`dragging\` class + \`body.userSelect\` toggling

All three implement the same delta-based math (capture pointer + element position on start, apply the delta on move) but differ in:

- which CSS properties they reset
- which target subtrees they refuse to drag from
- whether they register the document-level move/end listeners per-drag (umap) or once-and-filter (curation, metadata-drawer)

## The helper

\`makeDraggable(handle, target, options)\` in \`utils.js\`. The options pick up the differences:

- \`shouldDrag(event)\` — predicate over the pointer event; return \`false\` to skip dragging for clicks on close buttons or non-titlebar regions
- \`setPosition(left, top)\` — override the default \`target.style.left/top = '\${n}px'\` writer so callers that also reset \`transform\`/\`right\`/\`bottom\` keep that behavior inline
- \`onDragStart()\` / \`onDragEnd()\` — fire after a drag begins / ends; used by the metadata-drawer for the \`dragging\` class and \`body.userSelect\` toggles

The helper registers document-level move/end listeners only while a drag is in flight (the per-drag pattern from umap.js). The existing perma-listeners on \`document\`/\`window\` in curation and metadata-drawer were leaking onto detached nodes; the new code path doesn't.

## Test plan

- [x] \`npm run lint\` + \`npm run format:check\` — clean
- [x] \`npm test\` — 293 passed, including the 4 \`metadata-drawer-draggable\` tests that directly exercise the drag code (mouse drag, touch drag, non-draggable-element exclusion, smooth tracking)
- [x] \`pytest tests/backend\` — 256 passed (no backend changes, ran for safety)
- [x] Manual: drag the UMAP titlebar; confirm the window moves and the close button still closes
- [x] Manual: drag the curation panel by its header; confirm the close icon still closes the panel
- [x] Manual: drag the metadata drawer by its titlebar; confirm the copy button still copies; tap the drawer handle to snap back to original position
- [x] Manual: same three drags on touch (phone or browser device emulation)

Net **−83 lines** across 4 files. Each call site is now a ~15-line wiring instead of ~60 lines of hand-rolled mouse/touch state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)