### PR TITLE
feat: add Python 3.14 support

### DIFF
--- a/INSTALL/lib/windows.ps1
+++ b/INSTALL/lib/windows.ps1
@@ -77,7 +77,7 @@ $version = python -c "import sys; print(f'{sys.version_info.major}.{sys.version_
 if (-not $version) {
     Install-Python "Could not determine Python version."
 }
-if ([version]$version -lt [version]"3.10" -or [version]$version -ge [version]"3.14") {
+if ([version]$version -lt [version]"3.10" -or [version]$version -ge [version]"3.15") {
     Install-Python "An incompatible Python version is installed."
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = { content-type = "text/markdown", file = "README.md" }
 license = { text = "MIT" }
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.10, <3.15"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: End Users/Desktop",
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Graphics :: Viewers",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
Extends `requires-python` from `>=3.10, <3.14` to `>=3.10, <3.15` and adds a Python 3.14 classifier, allowing installation on Python 3.14. Also fixes the Windows installer guard that was blocking Python 3.14.

The Python source code was already fully 3.14-compatible (modern type hints, no deprecated stdlib usage).

Fixes #207

Generated with [Claude Code](https://claude.ai/code)