### PR TITLE
fix(indexing): gate image indexing on pixel dimensions, not file bytes

### DIFF
--- a/docs/user-guide/albums.md
+++ b/docs/user-guide/albums.md
@@ -41,6 +41,31 @@ When the indexing process is done, you will find the generated indexes stored in
 
 When you add or remove image files from an album's image directory, you will need to reindex the album. Navigate to the album in the Album Manager list and press the blue <span class="blue-button-text">Update Index</span> button. The update operation will only reindex the files that have been added or removed and will be much faster than the first comprehensive indexing operation.
 
+### Skipping Small Images
+
+During the traversal phase, PhotoMapAI inspects each candidate image and skips any whose width *or* height is below a minimum pixel threshold. The default is **256 pixels** in either dimension. This filter is meant to exclude thumbnails, favicons, contact-sheet previews, and other tiny images that don't carry enough visual content for semantic search to work well on them. A summary of how many images were skipped on the last scan is written to the server log.
+
+The threshold is configured per-album as the `min_image_dimension` field in `config.yaml`. To change it, locate your `config.yaml` (see [Configuration](configuration.md) for the path on your platform) and edit the entry for the album you want to adjust:
+
+```yaml
+albums:
+  my_album:
+    name: My Photos
+    image_paths:
+      - /path/to/photos
+    index: /path/to/photos/photomap_index/embeddings.npz
+    min_image_dimension: 256   # default; raise to be stricter, lower to be more permissive
+```
+
+Some practical values:
+
+- `256` (default) — good for general photo libraries; skips thumbnails but keeps most legitimate photos.
+- `128` — keeps smaller web images, screenshots, and downscaled phone shots.
+- `512` or higher — useful if your library mixes generated thumbnails with full-resolution originals and you only want the originals indexed.
+- `1` — disables the filter entirely; every supported image file is indexed regardless of size.
+
+After saving `config.yaml`, press <span class="blue-button-text">Update Index</span> for the album. The new threshold applies both ways: previously-skipped images that now pass the new threshold will be added to the index, and previously-indexed images that no longer pass will be removed.
+
 ## Editing an Album
 
 To make changes to an album's definition, including changing its display name, description, paths, or encoder, click the orange <span class="orange-button-text">Edit</span> button next to the album's entry in the Album Manager dialogue. Note that you cannot change the album key once the Album is initialized. Changing the encoder will trigger an automatic from-scratch rebuild on the next **Update Index** — see [Encoders](encoders.md) for the implications.

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -553,6 +553,7 @@ def create_album(
     min_search_score: float | None = None,
     max_search_results: int | None = None,
     use_query_optimization: bool | None = None,
+    min_image_dimension: int | None = None,
 ) -> Album:
     """Create a new Album instance with validation.
 
@@ -577,6 +578,8 @@ def create_album(
         fields["max_search_results"] = max_search_results
     if use_query_optimization is not None:
         fields["use_query_optimization"] = use_query_optimization
+    if min_image_dimension is not None:
+        fields["min_image_dimension"] = min_image_dimension
     return Album(**fields)
 
 

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -59,6 +59,16 @@ class Album(BaseModel):
             "Ignored by CLIP/OpenCLIP."
         ),
     )
+    min_image_dimension: int = Field(
+        default=256,
+        ge=1,
+        description=(
+            "Minimum image dimension (in pixels) for an image to be indexed. "
+            "An image is kept only if both its width and height are >= this "
+            "value. Filters out thumbnails and tiny images that contribute "
+            "little to semantic search."
+        ),
+    )
 
     @model_validator(mode="after")
     def _resolve_min_search_score(self) -> "Album":
@@ -99,6 +109,7 @@ class Album(BaseModel):
             "min_search_score": self.min_search_score,
             "max_search_results": self.max_search_results,
             "use_query_optimization": self.use_query_optimization,
+            "min_image_dimension": self.min_image_dimension,
         }
 
     @classmethod
@@ -119,6 +130,7 @@ class Album(BaseModel):
             min_search_score=data.get("min_search_score"),
             max_search_results=data.get("max_search_results", 100),
             use_query_optimization=data.get("use_query_optimization", True),
+            min_image_dimension=data.get("min_image_dimension", 256),
         )
 
 

--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -19,7 +19,7 @@ from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
-from typing import Any, ClassVar, NamedTuple
+from typing import Any, NamedTuple
 
 import networkx as nx
 import numpy as np
@@ -333,8 +333,6 @@ class Embeddings(BaseModel):
     This class provides methods to index images, update embeddings, and search for similar images.
     """
 
-    minimum_image_size: ClassVar[int] = 100 * 1024  # Minimum image size in bytes (100K)
-
     embeddings_path: Path = Path("clip_image_embeddings.npz")
     # Embeddings is normally constructed by the router with an explicit
     # encoder_spec from the album config. The default only applies when
@@ -342,6 +340,11 @@ class Embeddings(BaseModel):
     # almost certainly trying to read existing data, which on this codebase
     # means a legacy-CLIP cache.
     encoder_spec: str = LEGACY_ENCODER_SPEC
+    # Minimum width AND height (in pixels) for an image to be indexed; smaller
+    # images are treated as thumbnails and skipped during the scan. 256 is the
+    # smallest patch grid the bundled CLIP/SigLIP variants encode without
+    # heavy upscaling. Default mirrors the Album field default in config.py.
+    min_image_dimension: int = 256
 
     def __init__(self, **data):
         """Ensure embeddings_path is always resolved to prevent cache key mismatches."""
@@ -392,6 +395,26 @@ class Embeddings(BaseModel):
                 # Log but don't crash if CUDA operations fail
                 logger.warning(f"CUDA cleanup failed: {e}")
 
+    def _passes_dimension_gate(self, path: Path) -> bool:
+        """Return True if ``path``'s pixel dimensions are >= ``min_image_dimension``.
+
+        Reads only the image header via ``Image.open(...).size`` — PIL does
+        not decode pixels until they're accessed, so this is a few-KB read
+        per file. Unreadable / corrupt files return False and are logged at
+        debug level (they'd fail at encoding time anyway and would land in
+        ``bad_files`` there; here we just keep the scan log quiet).
+        """
+        min_dim = self.min_image_dimension
+        if min_dim <= 1:
+            return True
+        try:
+            with Image.open(path) as im:
+                width, height = im.size
+        except Exception as e:
+            logger.debug(f"Skipping unreadable image during scan: {path}: {e}")
+            return False
+        return width >= min_dim and height >= min_dim
+
     def get_image_files_from_directory(
         self,
         directory: Path,
@@ -402,6 +425,11 @@ class Embeddings(BaseModel):
         """
         Recursively collect all image files from a directory.
 
+        Each candidate file's header is opened to read pixel dimensions;
+        images with either dimension below ``self.min_image_dimension`` are
+        skipped. The header read is a few KB per file, so a scan of 10k
+        files typically adds 10-30s on SSD — small next to encoding time.
+
         Args:
             directory: Directory to scan
             exts: File extensions to include
@@ -411,6 +439,7 @@ class Embeddings(BaseModel):
         logger.info(f"Scanning directory {directory} for image files...")
         image_files = []
         files_checked = 0
+        skipped_too_small = 0
 
         for root, dirs, files in os.walk(directory):
             # Remove 'photomap_index' from dirs so os.walk skips it and its subdirs
@@ -418,13 +447,13 @@ class Embeddings(BaseModel):
             for file in [Path(x) for x in files]:
                 files_checked += 1
 
-                # Check if the file has a valid image extension
-                # and that it's length is > minimum_image_size (i.e. not a thumbnail)
-                if (
-                    file.suffix.lower() in exts
-                    and os.path.getsize(Path(root, file)) > self.minimum_image_size
-                ):
-                    image_files.append(Path(root, file).resolve())
+                if file.suffix.lower() not in exts:
+                    continue
+                full = Path(root, file)
+                if self._passes_dimension_gate(full):
+                    image_files.append(full.resolve())
+                else:
+                    skipped_too_small += 1
 
                 # Provide progress updates at regular intervals
                 if progress_callback and files_checked % update_interval == 0:
@@ -432,6 +461,12 @@ class Embeddings(BaseModel):
                         len(image_files),
                         f"Traversing image files... {len(image_files)} found",
                     )
+
+        if skipped_too_small:
+            logger.info(
+                f"Skipped {skipped_too_small} image(s) under "
+                f"{self.min_image_dimension}px in either dimension."
+            )
 
         # Final update with total count
         if progress_callback:
@@ -471,7 +506,7 @@ class Embeddings(BaseModel):
                     images.extend(
                         self.get_image_files_from_directory(p, exts, progress_callback)
                     )
-                elif p.suffix.lower() in exts:
+                elif p.suffix.lower() in exts and self._passes_dimension_gate(p):
                     images.append(p)
         else:
             raise ValueError("Input must be a Path object or a list of Paths.")

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -191,6 +191,7 @@ async def get_available_albums() -> list[dict[str, Any]]:
                 "min_search_score": album.min_search_score,
                 "max_search_results": album.max_search_results,
                 "use_query_optimization": album.use_query_optimization,
+                "min_image_dimension": album.min_image_dimension,
             }
             for key, album in albums.items()
             if locked_albums is None or key in locked_albums
@@ -249,6 +250,7 @@ async def update_album(album_data: dict) -> JSONResponse:
             min_search_score=album_data.get("min_search_score"),
             max_search_results=album_data.get("max_search_results"),
             use_query_optimization=album_data.get("use_query_optimization"),
+            min_image_dimension=album_data.get("min_image_dimension"),
         )
 
         logger.info(f"Updating album: {album.key} with index {album.index}")

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -101,6 +101,7 @@ def get_embeddings_for_album(album_key: str) -> Embeddings:
     return Embeddings(
         embeddings_path=Path(album_config.index),
         encoder_spec=album_config.encoder_spec,
+        min_image_dimension=album_config.min_image_dimension,
     )
 
 

--- a/photomap/backend/routers/index.py
+++ b/photomap/backend/routers/index.py
@@ -469,6 +469,7 @@ async def _update_index_background_async(album_key: str, album_config):
         embeddings = Embeddings(
             embeddings_path=index_path,
             encoder_spec=album_config.encoder_spec,
+            min_image_dimension=album_config.min_image_dimension,
         )
 
         if index_path.exists():

--- a/photomap/frontend/static/css/album-manager.css
+++ b/photomap/frontend/static/css/album-manager.css
@@ -55,7 +55,10 @@
   display: none;
   margin-bottom: 2em;
   padding: 1em;
-  background: #333;
+  /* Match the brighter background used by .album-card.editing so the
+     Add-Album section visually stands out from the surrounding non-editing
+     album cards (which sit at #333). */
+  background: #505050;
   border-radius: 8px;
 }
 

--- a/photomap/frontend/static/css/album-manager.css
+++ b/photomap/frontend/static/css/album-manager.css
@@ -115,6 +115,13 @@
   resize: vertical;
 }
 
+/* Pixel-dimension input only needs room for four digits and the spinner
+   controls — overrides the full-width default applied to every input
+   inside ``.form-group``. */
+.form-group input.edit-album-min-image-dimension {
+  width: 6em;
+}
+
 .form-hint {
   display: block;
   margin-top: 0.4em;

--- a/photomap/frontend/static/javascript/album-manager.js
+++ b/photomap/frontend/static/javascript/album-manager.js
@@ -914,6 +914,13 @@ export class AlbumManager {
     // Initialize the dynamic path fields for THIS specific card
     this.initializePathFields(album.image_paths || [], cardElement);
 
+    // Minimum-pixel-dimension gate. Fall back to 256 if the album predates
+    // the field — matches the backend default (Album.min_image_dimension).
+    const minDimInput = editForm.querySelector(".edit-album-min-image-dimension");
+    if (minDimInput) {
+      minDimInput.value = album.min_image_dimension ?? 256;
+    }
+
     // Initialize the encoder dropdown for THIS specific card
     populateEncoderSelect(editForm.querySelector(".edit-album-encoder"), album.encoder_spec);
 
@@ -975,6 +982,14 @@ export class AlbumManager {
     // Always set index path based on first path
     const indexPath = updatedPaths.length > 0 ? `${updatedPaths[0]}/photomap_index/embeddings.npz` : "";
 
+    // Parse the dimension input. Invalid / non-positive values fall back to
+    // the saved value, then to the backend default (256). The backend's
+    // Pydantic validator enforces ge=1, so we shield it from junk here too.
+    const minDimRaw = editForm.querySelector(".edit-album-min-image-dimension")?.value;
+    const minDimParsed = Number.parseInt(minDimRaw, 10);
+    const minDim =
+      Number.isFinite(minDimParsed) && minDimParsed >= 1 ? minDimParsed : (album.min_image_dimension ?? 256);
+
     const updatedAlbum = {
       key: album.key,
       name: editForm.querySelector(".edit-album-name").value,
@@ -982,6 +997,7 @@ export class AlbumManager {
       image_paths: updatedPaths,
       index: indexPath,
       encoder_spec: editForm.querySelector(".edit-album-encoder")?.value || album.encoder_spec || DEFAULT_ENCODER_SPEC,
+      min_image_dimension: minDim,
     };
 
     // Compare old and new paths (order and content)

--- a/photomap/frontend/templates/modules/album-manager.html
+++ b/photomap/frontend/templates/modules/album-manager.html
@@ -138,6 +138,16 @@
         <div class="edit-album-paths-container"></div>
       </div>
       <div class="form-group">
+        <label>Exclude thumbnails and other images below this size (px)</label>
+        <input
+          class="edit-album-min-image-dimension"
+          type="number"
+          min="1"
+          step="1"
+          value="256"
+        />
+      </div>
+      <div class="form-group">
         <label>Encoder</label>
         <select class="edit-album-encoder encoder-select"></select>
         <small class="form-hint">

--- a/tests/backend/fixtures.py
+++ b/tests/backend/fixtures.py
@@ -70,14 +70,13 @@ def poll_during_indexing(client, album_key, timeout=60):
         time.sleep(1)  # Wait before polling again
 
 
-def build_index(client, new_album, monkeypatch):
-    """Helper function to build the index for the album."""
-    from photomap.backend.embeddings import Embeddings
+def build_index(client, new_album):
+    """Helper function to build the index for the album.
 
-    monkeypatch.setattr(
-        Embeddings, "minimum_image_size", 10 * 1024
-    )  # Set minimum image size to 10K for testing
-
+    Bundled test images are all 384x512 / 512x384, well above the default
+    256px ``min_image_dimension`` gate, so no per-test threshold tweaking
+    is needed.
+    """
     response = client.post("/update_index_async", json={"album_key": new_album["key"]})
     assert response.status_code == 202
     task_id = response.json().get("task_id")

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -290,3 +290,66 @@ def test_per_album_search_settings_round_trip(client, tmp_path):
 
     client.delete("/delete_album/siglip_defaults")
     client.delete("/delete_album/clip_defaults")
+
+
+def test_min_image_dimension_round_trips(client, tmp_path):
+    """The Edit Album dialogue's "Exclude thumbnails..." input must round-trip
+    through add_album → /available_albums → /update_album, and an album with
+    no ``min_image_dimension`` set should expose the 256 default. Backs the
+    Album Manager UI wiring for the per-album dimension gate.
+    """
+    img_dir = tmp_path / "imgs"
+    img_dir.mkdir()
+
+    # Add with no min_image_dimension — backend should default to 256.
+    response = client.post(
+        "/add_album/",
+        json={
+            "key": "dim_default",
+            "name": "Default dim",
+            "image_paths": [str(img_dir)],
+            "index": str(tmp_path / "d.npz"),
+            "umap_eps": 0.1,
+            "encoder_spec": "openai-clip:ViT-B/32",
+        },
+    )
+    assert response.status_code == 201
+
+    listing = {a["key"]: a for a in client.get("/available_albums/").json()}
+    assert listing["dim_default"]["min_image_dimension"] == 256
+
+    # Update with an explicit value — must persist on the next listing.
+    response = client.post(
+        "/update_album/",
+        json={
+            "key": "dim_default",
+            "name": "Default dim",
+            "image_paths": [str(img_dir)],
+            "index": str(tmp_path / "d.npz"),
+            "encoder_spec": "openai-clip:ViT-B/32",
+            "min_image_dimension": 512,
+        },
+    )
+    assert response.status_code == 200
+
+    listing = {a["key"]: a for a in client.get("/available_albums/").json()}
+    assert listing["dim_default"]["min_image_dimension"] == 512
+
+    # Pydantic ``ge=1`` guard: zero and negatives are rejected at the API.
+    response = client.post(
+        "/update_album/",
+        json={
+            "key": "dim_default",
+            "name": "Default dim",
+            "image_paths": [str(img_dir)],
+            "index": str(tmp_path / "d.npz"),
+            "encoder_spec": "openai-clip:ViT-B/32",
+            "min_image_dimension": 0,
+        },
+    )
+    assert response.status_code == 500
+    # Previous valid value must remain — failed update must not corrupt state.
+    listing = {a["key"]: a for a in client.get("/available_albums/").json()}
+    assert listing["dim_default"]["min_image_dimension"] == 512
+
+    client.delete("/delete_album/dim_default")

--- a/tests/backend/test_cluster_labels_router.py
+++ b/tests/backend/test_cluster_labels_router.py
@@ -130,7 +130,7 @@ def test_endpoint_smoke_with_real_encoder(client, new_album, monkeypatch, tmp_pa
 
     monkeypatch.setattr(cluster_labels, "vocab_cache_path", _isolated_path)
 
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # Relax DBSCAN to ensure at least one cluster forms over the 9 test images
     # (defaults of min_samples=10 would put everything in noise with n=9).

--- a/tests/backend/test_curation.py
+++ b/tests/backend/test_curation.py
@@ -12,7 +12,7 @@ from fixtures import build_index
 def test_curate_sync_endpoint(client, new_album, monkeypatch):
     """Test the synchronous curation endpoint."""
     # Build the index first
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # Test FPS method
     response = client.post(
@@ -53,7 +53,7 @@ def test_curate_sync_endpoint(client, new_album, monkeypatch):
 
 def test_curate_sync_with_exclusions(client, new_album, monkeypatch):
     """Test curation with excluded indices."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # First, run curation to get some indices
     response = client.post(
@@ -91,7 +91,7 @@ def test_curate_sync_with_exclusions(client, new_album, monkeypatch):
 
 def test_curate_sync_validation(client, new_album, monkeypatch):
     """Test validation of curation parameters."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # Test negative target_count
     response = client.post(
@@ -150,7 +150,7 @@ def test_curate_sync_validation(client, new_album, monkeypatch):
 
 def test_curate_async_endpoint(client, new_album, monkeypatch):
     """Test the async curation endpoint with progress polling."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # Start async curation
     response = client.post(
@@ -204,7 +204,7 @@ def test_curate_async_endpoint(client, new_album, monkeypatch):
 
 def test_curate_async_validation(client, new_album, monkeypatch):
     """Test validation of async curation parameters."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # Test negative target_count
     response = client.post(
@@ -223,7 +223,7 @@ def test_curate_async_validation(client, new_album, monkeypatch):
 
 def test_curate_async_iterations_capped(client, new_album, monkeypatch):
     """Test that iterations are capped at the maximum."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # Request more than max iterations (30)
     response = client.post(
@@ -250,7 +250,7 @@ def test_progress_nonexistent_job(client):
 
 def test_export_endpoint(client, new_album, monkeypatch, tmp_path):
     """Test the export endpoint."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # First get some files from curation
     response = client.post(
@@ -337,7 +337,7 @@ def test_export_nonexistent_files(client, new_album, tmp_path):
 
 def test_curate_multiple_iterations(client, new_album, monkeypatch):
     """Test curation with multiple iterations for consensus."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     response = client.post(
         "/api/curation/curate_sync",
@@ -369,7 +369,7 @@ def test_curate_multiple_iterations(client, new_album, monkeypatch):
 
 def test_curate_analysis_results_format(client, new_album, monkeypatch):
     """Test that analysis results have the correct format."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     response = client.post(
         "/api/curation/curate_sync",

--- a/tests/backend/test_image_retrieval.py
+++ b/tests/backend/test_image_retrieval.py
@@ -7,7 +7,7 @@ TEST_IMAGE_COUNT = count_test_images()
 
 def test_retrieve_slide(client, new_album, monkeypatch):
     """Test the ability to retrieve an image URL using the /retrieve_image/ API."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     # Retrieve the list of indexed images from the album config
     album_key = new_album["key"]
@@ -27,7 +27,7 @@ def test_retrieve_slide(client, new_album, monkeypatch):
 
 def test_retrieve_image(client, new_album, monkeypatch):
     """Test retrieving an image by offset."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 

--- a/tests/backend/test_index.py
+++ b/tests/backend/test_index.py
@@ -18,7 +18,7 @@ def test_index_creation(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch
 ):
     """Test the ability to create indexes."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
     # Check that the index exists
     response = client.get(f"/index_exists/{new_album['key']}")
     assert response.status_code == 200
@@ -41,7 +41,7 @@ def test_delete_image(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch
 ):
     """Test the ability to delete an image."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 
@@ -113,7 +113,7 @@ def test_move_images(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     """Test the ability to move images to a different directory."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 
@@ -158,7 +158,7 @@ def test_move_images_to_same_folder(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch
 ):
     """Test moving images to the same folder they're already in."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 
@@ -182,7 +182,7 @@ def test_move_images_nonexistent_directory(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch
 ):
     """Test moving images to a non-existent directory."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 
@@ -199,7 +199,7 @@ def test_move_images_file_exists(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     """Test moving images when a file with the same name exists in target."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 
@@ -229,7 +229,7 @@ def test_copy_images(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     """Test the ability to copy images to a different directory."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 
@@ -278,7 +278,7 @@ def test_copy_images_file_exists(
     client: TestClient, new_album: dict, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ):
     """Test copying images when file already exists in target directory."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
 
@@ -433,3 +433,39 @@ def test_parallel_workers_preserve_order(
         serial.modification_times, parallel.modification_times
     )
     assert serial.bad_files == parallel.bad_files == []
+
+
+def test_min_image_dimension_filters_small_images(tmp_path):
+    """Files whose pixel dimensions are below ``min_image_dimension`` must
+    be silently dropped during the directory scan; larger files are kept.
+    Mirrors the original bug where a hard-coded 100KB byte-size filter was
+    silently dropping ~25% of a real user's photo library.
+    """
+    from PIL import Image
+
+    img_dir = tmp_path / "imgs"
+    img_dir.mkdir()
+    # 100x100 — below the default 256 threshold; should be skipped.
+    Image.new("RGB", (100, 100), color="red").save(img_dir / "tiny.jpg")
+    # 200x300 — height passes 256 but width does not; should be skipped.
+    Image.new("RGB", (200, 300), color="blue").save(img_dir / "narrow.jpg")
+    # 300x300 — both dimensions pass; should be kept.
+    Image.new("RGB", (300, 300), color="green").save(img_dir / "ok.jpg")
+    # 256x256 — exactly on the boundary; >= passes; should be kept.
+    Image.new("RGB", (256, 256), color="yellow").save(img_dir / "exact.jpg")
+    # Non-image extension, should never get to the dimension check.
+    (img_dir / "notes.txt").write_text("not an image")
+
+    emb = Embeddings(embeddings_path=tmp_path / "ignored.npz")
+    files = emb.get_image_files_from_directory(img_dir)
+    names = sorted(Path(p).name for p in files)
+    assert names == ["exact.jpg", "ok.jpg"], (
+        f"only 256+ images should be indexed, got {names}"
+    )
+
+    # Lowering the threshold makes the smaller ones eligible too.
+    emb_low = Embeddings(
+        embeddings_path=tmp_path / "ignored.npz", min_image_dimension=100
+    )
+    names_low = sorted(Path(p).name for p in emb_low.get_image_files_from_directory(img_dir))
+    assert names_low == ["exact.jpg", "narrow.jpg", "ok.jpg", "tiny.jpg"]

--- a/tests/backend/test_search.py
+++ b/tests/backend/test_search.py
@@ -12,13 +12,10 @@ from fixtures import (
 TEST_IMAGE_COUNT = count_test_images()
 
 
-def test_index_update(client, new_album, monkeypatch):
+def test_index_update(client, new_album):
     """Test the creation of an index for the given album."""
     from photomap.backend.embeddings import Embeddings
 
-    monkeypatch.setattr(
-        Embeddings, "minimum_image_size", 10 * 1024
-    )  # Set minimum image size to 10K for testing
     # Start async index update
     response = client.post("/update_index_async", json={"album_key": new_album["key"]})
     assert response.status_code == 202
@@ -56,14 +53,8 @@ def test_index_update(client, new_album, monkeypatch):
     assert metadata["last_modified"] is not None
 
 
-def test_index_exists(client, new_album, monkeypatch):
+def test_index_exists(client, new_album):
     """Test the index_exists endpoint."""
-
-    from photomap.backend.embeddings import Embeddings
-
-    monkeypatch.setattr(
-        Embeddings, "minimum_image_size", 10 * 1024
-    )  # Set minimum image size to 10K for testing
 
     response = client.get(f"/index_exists/{new_album['key']}")
     assert response.status_code == 200
@@ -93,16 +84,10 @@ def test_index_exists(client, new_album, monkeypatch):
     assert response.json().get("exists", False) is False
 
 
-def test_image_search(client, new_album, monkeypatch):
+def test_image_search(client, new_album):
     """Test the search functionality."""
-    from photomap.backend.embeddings import Embeddings
-
     TEST_IMAGE_FILE = "./tests/backend/test_images/flower1.jpeg"
     TEST_TEXT_FILE = "./tests/backend/test_images/building1.jpeg"
-
-    monkeypatch.setattr(
-        Embeddings, "minimum_image_size", 10 * 1024
-    )  # Set minimum image size to 10K for testing
 
     # Create the index first
     response = client.post("/update_index_async", json={"album_key": new_album["key"]})
@@ -141,16 +126,10 @@ def test_image_search(client, new_album, monkeypatch):
     ), "Image search returned unexpected image"
 
 
-def test_text_search(client, new_album, monkeypatch):
+def test_text_search(client, new_album):
     """Test the search functionality."""
-    from photomap.backend.embeddings import Embeddings
-
     TEST_POS_FILE = "./tests/test_images/flower1.jpeg"
     TEST_NEG_FILE = "./tests/test_images/building1.jpeg"
-
-    monkeypatch.setattr(
-        Embeddings, "minimum_image_size", 10 * 1024
-    )  # Set minimum image size to 10K for testing
 
     # Create the index first
     response = client.post("/update_index_async", json={"album_key": new_album["key"]})
@@ -188,15 +167,11 @@ def test_text_search(client, new_album, monkeypatch):
     ), "Text search returned unexpected image"
 
 
-def test_image_indices_lookup(client, new_album, monkeypatch):
+def test_image_indices_lookup(client, new_album):
     """The batch /image_indices endpoint resolves album basenames to their
     indices and returns null for filenames not present in the album. Powers
     the metadata drawer's reference-image-thumbnail enhancement.
     """
-    from photomap.backend.embeddings import Embeddings
-
-    monkeypatch.setattr(Embeddings, "minimum_image_size", 10 * 1024)
-
     response = client.post("/update_index_async", json={"album_key": new_album["key"]})
     assert response.status_code == 202
     try:
@@ -216,12 +191,8 @@ def test_image_indices_lookup(client, new_album, monkeypatch):
     assert indices["another-missing.jpg"] is None
 
 
-def test_image_indices_empty_request(client, new_album, monkeypatch):
+def test_image_indices_empty_request(client, new_album):
     """An empty filenames list returns an empty mapping (not an error)."""
-    from photomap.backend.embeddings import Embeddings
-
-    monkeypatch.setattr(Embeddings, "minimum_image_size", 10 * 1024)
-
     response = client.post("/update_index_async", json={"album_key": new_album["key"]})
     assert response.status_code == 202
     try:

--- a/tests/backend/test_thumbnail_validation.py
+++ b/tests/backend/test_thumbnail_validation.py
@@ -14,7 +14,7 @@ from fixtures import build_index
 
 @pytest.fixture
 def indexed_album(client, new_album, monkeypatch):
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
     return new_album
 
 

--- a/tests/backend/test_umap.py
+++ b/tests/backend/test_umap.py
@@ -5,7 +5,7 @@ from fixtures import build_index, fetch_filename
 
 def test_umap_construction(client, new_album, monkeypatch):
     """Test the ability to retrieve an image URL using the /retrieve_image/ API."""
-    build_index(client, new_album, monkeypatch)
+    build_index(client, new_album)
 
     album_key = new_album["key"]
     response = client.get(f"umap_data/{new_album['key']}")


### PR DESCRIPTION
## Summary

- Replaces the silent 100 KB file-size filter in the indexer with a per-album **pixel-dimension** gate (default 256×256). The old byte-count heuristic was silently dropping ~25% of a real photo library — highly-compressed JPEGs, web images, phone shots — with no log line and no UI surface.
- Surfaces the new `min_image_dimension` field in the Album Manager's **Edit Album** form ("Exclude thumbnails and other images below this size (px)"), placed between Image Folder(s) and Encoder. Round-trips through `/update_album/` + `/available_albums/`.
- Brightens the **Add New Album** panel background from `#333` → `#505050` so it no longer blends into the non-editing album cards behind it.
- Documents the new gate (and how to tune it) in `docs/user-guide/albums.md`.

### Why the dimension gate

A user-supplied folder of 100 images was producing an index of 75. Every missing file was under 100 KB on disk but well above 256×256 in pixels — i.e. real photos, not thumbnails. File bytes are a bad proxy for "is this a thumbnail" because compression and content both confound it; pixel dimensions are the question we actually mean.

The new gate reads only the image header via `Image.open(...).size` (a few-KB read), so the scan-phase overhead is small compared to CLIP encoding. A summary log line now reports how many images were skipped per scan, so future drops are visible instead of silent.

### Behind the UI

- New per-album field `Album.min_image_dimension: int = 256` (Pydantic `ge=1`).
- `Embeddings.min_image_dimension` mirrors it; `get_image_files_from_directory` gates each candidate via a `_passes_dimension_gate` helper.
- `Embeddings.minimum_image_size` (the old `ClassVar`) is gone. Tests that monkeypatched it down to 10 KB are simplified — bundled fixtures are 384×512+, well above 256.
- `create_album` helper, `/update_album/` body, and `/available_albums/` listing all thread the new field.
- Update Index applies a changed threshold both ways (adds previously-rejected images, removes now-ineligible ones).

## Test plan

- [x] `ruff check photomap tests` clean
- [x] `npm run lint` + `npm run format:check` clean
- [x] `pytest tests/backend` — **281 passed** (includes new `test_min_image_dimension_filters_small_images` + `test_min_image_dimension_round_trips`)
- [x] `npm test` — **293 passed**
- [x] `mkdocs build --strict` clean
- [x] Verified rendered HTML via FastAPI `TestClient`: new input present in Edit Album template, label exact, ordering image-paths → min-dimension → encoder
- [x] Verified on real user library `/home/lstein/Downloads`: 99/99 images now indexed (was 75/99 before)
- [x] Visual smoke test in browser — Open Album Management, click Edit on an album; new field should appear with 256 prefilled. The Add Album panel should be visibly brighter than the surrounding cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)