### PR TITLE
fix(umap): respect album_config.umap_eps in /umap_data and /cluster_labels

### DIFF
--- a/photomap/backend/routers/cluster_labels.py
+++ b/photomap/backend/routers/cluster_labels.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from ..cluster_labels import compute_image_label, get_or_build_cluster_labels
-from .album import EmbeddingsDep
+from .album import AlbumDep, EmbeddingsDep
 
 cluster_labels_router = APIRouter()
 
@@ -23,8 +23,9 @@ cluster_labels_router = APIRouter()
 @cluster_labels_router.get("/cluster_labels/{album_key}", tags=["UMAP"])
 async def get_cluster_labels(
     album_key: str,
+    album_config: AlbumDep,
     embeddings: EmbeddingsDep,
-    cluster_eps: float = 0.07,
+    cluster_eps: float | None = None,
     cluster_min_samples: int = 10,
     top_k: int = 3,
 ) -> JSONResponse:
@@ -32,8 +33,10 @@ async def get_cluster_labels(
 
     Args:
         album_key: Album to label.
-        cluster_eps: DBSCAN epsilon. Must match the value passed to
-            `/umap_data` for cluster IDs to align.
+        cluster_eps: DBSCAN epsilon. Omit (or send ``None``) to use the
+            album's persisted ``umap_eps`` — the same resolution
+            ``/umap_data`` uses, so cluster IDs align between the two
+            endpoints.
         cluster_min_samples: DBSCAN min_samples. Same constraint.
         top_k: How many candidate phrases to return per cluster
             (the top one is shown, the rest are alternates).
@@ -42,6 +45,11 @@ async def get_cluster_labels(
         `{"labels": {"<cluster_id>": {"label": str, "alternates": [str, ...],
         "score": float}, ...}}`. Cluster `-1` (DBSCAN noise) is omitted.
     """
+    # Mirror ``routers/umap.py``'s eps fallback so ``/cluster_labels`` and
+    # ``/umap_data`` resolve to the same value for the same request.
+    # If they disagree, the cluster IDs returned by the two endpoints
+    # diverge and the hover-label feature breaks.
+    cluster_eps = cluster_eps if cluster_eps is not None else album_config.umap_eps
     labels = await asyncio.to_thread(
         get_or_build_cluster_labels,
         embeddings,

--- a/photomap/backend/routers/umap.py
+++ b/photomap/backend/routers/umap.py
@@ -17,7 +17,7 @@ async def get_umap_data(
     album_key: str,
     album_config: AlbumDep,
     embeddings: EmbeddingsDep,
-    cluster_eps: float = 0.07,
+    cluster_eps: float | None = None,
     cluster_min_samples: int = 10,
 ) -> JSONResponse:
     """
@@ -25,12 +25,21 @@ async def get_umap_data(
 
     Args:
         album_key: The key of the album to retrieve data for.
-        cluster_eps: Epsilon parameter for DBSCAN clustering.
+        cluster_eps: Epsilon parameter for DBSCAN clustering. Omit (or send
+            ``None``) to use the album's persisted ``umap_eps`` from YAML.
         cluster_min_samples: Min samples parameter for DBSCAN clustering.
 
     Returns:
         JSONResponse containing a list of points with x, y, index, and cluster ID.
     """
+    # When the caller doesn't override eps, fall back to the album's
+    # persisted ``umap_eps``. This used to be dead code: the parameter
+    # defaulted to ``0.07``, so ``cluster_eps is not None`` was always
+    # true and ``album_config.umap_eps`` was silently ignored. The
+    # corresponding parameter on ``/cluster_labels`` is kept in lockstep
+    # so the two endpoints resolve identical eps values for the same
+    # request — otherwise the cluster IDs they return would disagree
+    # and the hover-label feature would break.
     cluster_eps = cluster_eps if cluster_eps is not None else album_config.umap_eps
 
     # Load cached UMAP embeddings (will compute/cache if missing)

--- a/tests/backend/test_cluster_labels_router.py
+++ b/tests/backend/test_cluster_labels_router.py
@@ -38,8 +38,10 @@ def test_endpoint_returns_labels_dict(client, new_album, monkeypatch):
         "alternates": ["wedding", "kitchen"],
         "score": 0.27,
     }
-    # Defaults match the umap router so cluster IDs align
-    assert captured_call["eps"] == 0.07
+    # Default eps now comes from the album's persisted ``umap_eps`` (the
+    # test fixture sets 0.1). Both ``/cluster_labels`` and ``/umap_data``
+    # resolve eps the same way, so cluster IDs align across endpoints.
+    assert captured_call["eps"] == 0.1
     assert captured_call["ms"] == 10
     assert captured_call["top_k"] == 3
     assert captured_call["album_index"].endswith("embeddings.npz")


### PR DESCRIPTION
## Problem

The query-param default for `cluster_eps` in `routers/umap.py` was `0.07` (non-None), so the fallback line

```python
cluster_eps = cluster_eps if cluster_eps is not None else album_config.umap_eps
```

was unreachable: `cluster_eps` always had a concrete value before the test ran. A per-album `umap_eps` configured in YAML was silently ignored by the backend.

`routers/cluster_labels.py` carried the same hardcoded default *by design* — its docstring explicitly stated the value had to match `/umap_data` so cluster IDs returned by the two endpoints would align. So the fix has to be applied in lockstep: change *both* defaults to `None` and resolve eps the same way in both.

## Changes

| File | Change |
|---|---|
| `routers/umap.py:20` | `cluster_eps: float = 0.07` → `cluster_eps: float \| None = None`. The existing fallback now actually fires. |
| `routers/cluster_labels.py:27` | Same signature change. Added `album_config: AlbumDep` dependency and the mirroring fallback expression before the call to `get_or_build_cluster_labels`. |
| `tests/backend/test_cluster_labels_router.py:42` | Default test now expects eps `0.1` (the test album's persisted `umap_eps`) instead of the old hardcoded `0.07`. |

## Behavior changes worth flagging

- API callers hitting `/umap_data` or `/cluster_labels` **without** passing `cluster_eps` will now resolve to the album's persisted `umap_eps` (default `0.2` for new albums; whatever YAML says for existing ones) instead of the old hardcoded `0.07`.
- The frontend is unaffected — `umap.js` always sends `cluster_eps` from the spinner.

## Cleanup-list items deliberately not in scope

Two structural items from the original code-review cleanup list were considered for this PR and rejected after inspection:

### `imagetool.py` argparse subparsers — declined

The current basename dispatch (`index_images` / `search_images` / etc. each pointing to `imagetool:main` and routed via `sys.argv[0]`) is a conventional `console_scripts` pattern. Converting to subparsers would change the CLI surface from `index_images foo` to `photomap index foo` — a breaking change for any user scripts. Not a bug; a redesign that would require renaming all the documented entry points.

### `embeddings.py` import-time side effects — declined

`register_heif_opener()` and `print_cuda_message()` are the documented one-time-per-process patterns. `print_cuda_message` is misnamed (it uses `logger.info` + an env-var gripe-once guard, not `print`). Moving them into an explicit `initialize()` would add a regression surface — any CLI tool or test forgetting to call it would silently break HEIF support — without solving any verified test pain.

## Test plan

- [x] `ruff check` — clean
- [x] `pytest tests/backend` — **281 passed**
- [x] Manual: edit an album's YAML to set `umap_eps: 0.3`, open the UMAP view. Confirm the cluster strength spinner loads with `0.3` (existing get_umap_eps endpoint) and the rendered clusters use `0.3` (this PR's fix).
- [x] Manual: hover an image in the UMAP plot. Confirm the cluster label that pops up matches the cluster ID assigned to the dot under the cursor (i.e., `/umap_data` and `/cluster_labels` still agree on cluster IDs after the lockstep fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
