### PR TITLE
feat(exif): show DateTimeOriginal, Orientation, and Exif image dimensions

### DIFF
--- a/photomap/backend/metadata_modules/exif_formatter.py
+++ b/photomap/backend/metadata_modules/exif_formatter.py
@@ -105,6 +105,7 @@ def format_exif_metadata(
 
     # Prioritize important fields
     priority_fields = {
+        "DateTimeOriginal": "Date Taken",
         "DateTime": "Date/Time",
         "Make": "Camera Make",
         "Model": "Camera Model",
@@ -115,8 +116,11 @@ def format_exif_metadata(
         "FocalLength": "Focal Length",
         "Flash": "Flash",
         "WhiteBalance": "White Balance",
+        "Orientation": "Orientation",
         "ImageWidth": "Width",
+        "ExifImageWidth": "Width",
         "ImageLength": "Height",
+        "ExifImageHeight": "Height",
         "GPSLatitudeDecimal": "GPS Latitude",
         "GPSLongitudeDecimal": "GPS Longitude",
         "GPSAltitude": "GPS Altitude",
@@ -125,11 +129,14 @@ def format_exif_metadata(
 
     # Add priority fields first. display_name comes from the hardcoded
     # priority_fields dict above, so it's already trusted; value comes from
-    # the image's EXIF and must be escaped.
+    # the image's EXIF and must be escaped. Skip duplicate labels so that
+    # e.g. ImageWidth and ExifImageWidth don't both render a "Width" row.
+    seen_labels: set[str] = set()
     for field, display_name in priority_fields.items():
-        if field in metadata:
+        if field in metadata and display_name not in seen_labels:
             value = _format_field_value(field, metadata[field])
             html_doc += f"<tr><th>{display_name}</th><td>{_esc(value)}</td></tr>"
+            seen_labels.add(display_name)
 
     html_doc += "</table></div></div>"  # Close right column and flex container
 
@@ -184,7 +191,20 @@ def _format_field_value(field_name: str, value) -> str:
         wb_modes = {0: "Auto", 1: "Manual"}
         return wb_modes.get(value, f"Mode {value}")
 
-    elif field_name in ["ImageWidth", "ImageLength"]:
+    elif field_name == "Orientation":
+        orientations = {
+            1: "Normal",
+            2: "Mirrored horizontally",
+            3: "Rotated 180°",
+            4: "Mirrored vertically",
+            5: "Mirrored horizontally, rotated 270° CW",
+            6: "Rotated 90° CW",
+            7: "Mirrored horizontally, rotated 90° CW",
+            8: "Rotated 270° CW",
+        }
+        return orientations.get(value, f"Orientation {value}")
+
+    elif field_name in ["ImageWidth", "ImageLength", "ExifImageWidth", "ExifImageHeight"]:
         return f"{value} pixels"
 
     # Default formatting for other fields

--- a/tests/backend/test_metadata_formatting.py
+++ b/tests/backend/test_metadata_formatting.py
@@ -67,6 +67,39 @@ class TestExifMetadata:
         assert 'data-recall-mode="remix"' not in result.description
 
 
+class TestExifFieldRendering:
+    """Verify individual EXIF fields render with expected labels and formatting."""
+
+    def test_datetime_original_rendered_with_date_taken_label(self, clear_invokeai_config):
+        metadata = {"DateTimeOriginal": "2021:08:28 13:40:19"}
+        result = format_metadata(_filepath(), metadata, 0, 1)
+        assert "Date Taken" in result.description
+        assert "2021:08:28 13:40:19" in result.description
+
+    def test_orientation_rendered_as_human_readable(self, clear_invokeai_config):
+        result = format_metadata(_filepath(), {"Orientation": 1}, 0, 1)
+        assert "Orientation" in result.description
+        assert "Normal" in result.description
+
+        result = format_metadata(_filepath(), {"Orientation": 6}, 0, 1)
+        assert "Rotated 90° CW" in result.description
+
+    def test_exif_image_dimensions_rendered_with_pixel_suffix(self, clear_invokeai_config):
+        metadata = {"ExifImageWidth": 2048, "ExifImageHeight": 1536}
+        result = format_metadata(_filepath(), metadata, 0, 1)
+        assert "2048 pixels" in result.description
+        assert "1536 pixels" in result.description
+
+    def test_image_and_exif_image_dimensions_dedupe(self, clear_invokeai_config):
+        # When both ImageWidth and ExifImageWidth are present, only one
+        # "Width" row should render (ImageWidth wins because it comes first).
+        metadata = {"ImageWidth": 4000, "ExifImageWidth": 2048}
+        result = format_metadata(_filepath(), metadata, 0, 1)
+        assert result.description.count("<th>Width</th>") == 1
+        assert "4000 pixels" in result.description
+        assert "2048 pixels" not in result.description
+
+
 class TestInvokeMetadata:
     INVOKE = {
         "metadata_version": 3,


### PR DESCRIPTION
## Summary

Photos written with only the SubIFD EXIF tags (e.g. some screenshots and phone cameras) — `DateTimeOriginal`, `Orientation`, `ExifImageWidth`, `ExifImageHeight` — rendered nothing useful in the metadata drawer because it filtered for the IFD0 equivalents only.

- Add the four tags to `priority_fields` in `exif_formatter.py`.
- `DateTimeOriginal` → "Date Taken" (placed before `DateTime`; it's the actual capture time).
- `Orientation` → human-readable strings for the 8 standard EXIF values ("Normal", "Rotated 90° CW", …).
- `ExifImageWidth`/`ExifImageHeight` → reuse the existing `{n} pixels` formatter.
- Dedupe by display label so `ImageWidth` + `ExifImageWidth` don't render two "Width" rows (IFD0 wins by ordering).

## Test plan

- [x] `pytest tests/backend/test_metadata_formatting.py` — 10/10 pass (4 new cases for the new fields + dedupe).
- [x] `ruff check` clean on the changed files.
- [x] Manual: open a screenshot whose EXIF matches the example in the issue and confirm Date Taken / Orientation / Width / Height all appear in the drawer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)