### PR TITLE
feat(curation): grid view + UMAP on completion, and ~200x BLOCKS speedup

### DIFF
--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -28,7 +28,7 @@ import torch.nn.functional as F
 from PIL import Image, ImageOps
 from pillow_heif import register_heif_opener
 from pydantic import BaseModel
-from sklearn.cluster import KMeans
+from sklearn.cluster import MiniBatchKMeans
 from sklearn.neighbors import NearestNeighbors
 from tqdm import tqdm
 from umap import UMAP
@@ -204,23 +204,31 @@ def get_kmeans_indices_global(
     if n_target >= n_samples:
         return filenames[valid_global_indices].tolist()
 
-    # Cluster
-    kmeans = KMeans(n_clusters=n_target, random_state=seed, n_init=10)
+    # MiniBatchKMeans + n_init=1 are ~300x faster than the previous
+    # KMeans(n_init=10) on CLIP-dim embeddings with n_target in the hundreds
+    # (measured: 682s -> 2s for n_target=200, n_samples=85k, dim=768) and
+    # land within ~0.5% of the same inertia. The Monte Carlo outer loop in
+    # ``_compute_curation`` already aggregates per-run variance via voting,
+    # so the single init costs us nothing in result quality. sklearn's
+    # default batch_size (1024) and max_iter (100) are well-tuned here —
+    # the custom batch_size we tried first was measurably slower.
+    kmeans = MiniBatchKMeans(
+        n_clusters=n_target,
+        random_state=seed,
+        n_init=1,
+    )
     labels = kmeans.fit_predict(vectors)
 
-    selected_local_indices = []
+    # One vectorized distance pass beats a per-cluster ``np.linalg.norm`` —
+    # same total work, no Python-level loop over centroids for the heavy bit.
+    dist_to_assigned = np.linalg.norm(vectors - kmeans.cluster_centers_[labels], axis=1)
 
+    selected_local_indices = []
     for i in range(n_target):
         cluster_indices = np.where(labels == i)[0]
         if len(cluster_indices) == 0:
             continue
-
-        cluster_vectors = vectors[cluster_indices]
-        centroid = kmeans.cluster_centers_[i]
-
-        dists = np.linalg.norm(cluster_vectors - centroid, axis=1)
-        best_local_sub_idx = np.argmin(dists)
-        best_local_idx = cluster_indices[best_local_sub_idx]
+        best_local_idx = cluster_indices[np.argmin(dist_to_assigned[cluster_indices])]
         selected_local_indices.append(best_local_idx)
 
     # Map back to global

--- a/photomap/frontend/static/javascript/curation.js
+++ b/photomap/frontend/static/javascript/curation.js
@@ -1,10 +1,18 @@
 import { backStack } from "./back-stack.js";
 import { bookmarkManager } from "./bookmarks.js";
+import { toggleGridSwiperView } from "./events.js";
 import { createSimpleDirectoryPicker } from "./filetree.js";
 import { updateSearchCheckmarks } from "./search-ui.js";
 import { slideState } from "./slide-state.js";
 import { state } from "./state.js";
-import { highlightCurationSelection, setCurationMode, setUmapClickCallback, updateCurrentImageMarker } from "./umap.js";
+import {
+  highlightCurationSelection,
+  setCurationMode,
+  setUmapClickCallback,
+  setUmapMediumSize,
+  toggleUmapWindow,
+  updateCurrentImageMarker,
+} from "./umap.js";
 import { fetchJson, hideSpinner, makeDraggable, showSpinner } from "./utils.js";
 
 let currentSelectionIndices = new Set();
@@ -496,6 +504,12 @@ function setupEventListeners() {
 
             // Show clear search button for curation results
             updateSearchCheckmarks("curation");
+
+            // The unselected images are dimmed by ``applyGridHighlights`` — that
+            // dim only reads well in grid mode, so jump into grid view, scroll
+            // the first selected image into position, and surface the UMAP at
+            // its medium size so the user can see the spatial selection too.
+            await applyPostSelectionLayout(data.selected_indices);
           } else if (progressData.status === "error") {
             clearInterval(pollInterval);
             throw new Error(progressData.error || "Curation failed");
@@ -716,6 +730,29 @@ function applyGridHighlights() {
       img.classList.add("curation-dimmed-img");
     }
   });
+}
+
+async function applyPostSelectionLayout(selectedIndices) {
+  const firstSelected = selectedIndices.find((idx) => !excludedIndices.has(idx));
+  if (firstSelected === undefined) {
+    return;
+  }
+
+  // Update slide state before swapping views so the grid loads the batch
+  // containing the first selection on its initial reset instead of doing a
+  // second round-trip after navigating.
+  if (!state.gridViewActive) {
+    slideState.setCurrentIndex(firstSelected, false);
+    await toggleGridSwiperView(true);
+  } else {
+    slideState.navigateToIndex(firstSelected, false);
+  }
+
+  const umapWindow = document.getElementById("umapFloatingWindow");
+  if (!umapWindow || umapWindow.style.display !== "block") {
+    await toggleUmapWindow(true);
+  }
+  setUmapMediumSize();
 }
 
 function setStatus(msg, type) {

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -1694,13 +1694,14 @@ addButtonHandlers("umapResizeBig", () => {
   isFullscreen = false;
   updateExitFullscreenCheckboxState();
 });
-addButtonHandlers("umapResizeMedium", () => {
+export function setUmapMediumSize() {
   setUmapWindowSize("medium");
   lastUnshadedSize = "medium";
   saveCurrentPosition();
   isFullscreen = false;
   updateExitFullscreenCheckboxState();
-});
+}
+addButtonHandlers("umapResizeMedium", setUmapMediumSize);
 addButtonHandlers("umapResizeSmall", () => {
   setUmapWindowSize("small");
   lastUnshadedSize = "small";


### PR DESCRIPTION
## Summary

Two related curation improvements:

1. **`feat(curation)`** — When a selection run finishes, auto-shift into grid view, scroll the first selected (non-excluded) image into position, and make the UMAP window visible at its medium size. The dimmed-image styling on unselected images only reads well in grid mode, so manually switching is no longer required. Exports a new `setUmapMediumSize` from `umap.js` (extracted from the existing resize button handler) so `curation.js` can drive the size programmatically.
2. **`perf(curation)`** — The BLOCKS (K-Means) algorithm was excruciatingly slow on large albums: ~682s/iter for `n_target=200` on a 85k-image, 768-dim album → nearly 6 hours at the 30-iteration Monte Carlo cap. Switched to `MiniBatchKMeans` with `n_init=1`. The outer Monte Carlo loop already aggregates per-run variance via vote-counting, so the previous `n_init=10` was pure overhead. Also vectorized the per-cluster "closest-to-centroid" pass.

Measured speedup on the same album (`n_samples=85491`, `dim=768`):

| `n_target` | Before | After | Speedup |
| --- | --- | --- | --- |
| 80  | 277s/iter | 1.6s/iter | 173× |
| 200 | 682s/iter | 2.6s/iter | 263× |
| 500 | (didn't measure; estimated ~25 min) | 5.4s/iter | ~280× |

Inertia (clustering quality) stays within ~0.5% of the previous results.

## Test plan

- [x] `pytest tests/backend/test_curation.py` — 12 passed
- [x] `npm test` — 301 passed
- [x] `ruff check` — clean
- [x] Manual: ran K-Means selection on the InvokeAI album, confirmed it now returns in seconds instead of hours
- [ ] Manual: verify the post-selection auto-layout (grid + UMAP medium) feels right on a fresh page load with the UMAP previously hidden
- [ ] Manual: verify the same flow when starting from grid view (should just scroll, not flicker through a view switch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)