### PR TITLE
fix(frontend): live-refresh back-nav flyout + misc UI tweaks

### DIFF
--- a/photomap/frontend/static/css/control-and-search-panels.css
+++ b/photomap/frontend/static/css/control-and-search-panels.css
@@ -68,10 +68,15 @@
   padding: 8px;
   border-radius: 6px;
   z-index: 10000;
-  display: flex;
-  flex-wrap: wrap;
+  /* Fixed 4×3 grid sized to the FLYOUT_LIMIT of 12. back-button.js places
+     each thumb with explicit grid-column / grid-row so the oldest sits at the
+     bottom-right corner, newer entries fill upward then leftward, and partial
+     fills leave empty cells at the top-left — mirroring the grid view's
+     column-major ordering. */
+  display: grid;
+  grid-template-columns: repeat(4, 72px);
+  grid-template-rows: repeat(3, 72px);
   gap: 6px;
-  max-width: 360px;
 }
 
 #backNavFlyout .back-nav-thumb {

--- a/photomap/frontend/static/javascript/back-button.js
+++ b/photomap/frontend/static/javascript/back-button.js
@@ -6,7 +6,9 @@
 import { backStack } from "./back-stack.js";
 import { state } from "./state.js";
 
-const FLYOUT_LIMIT = 12;
+const FLYOUT_ROWS = 3;
+const FLYOUT_COLS = 4;
+const FLYOUT_LIMIT = FLYOUT_ROWS * FLYOUT_COLS;
 const DISABLED_CLASS = "back-nav-disabled";
 const FLYOUT_ID = "backNavFlyout";
 
@@ -37,20 +39,20 @@ function thumbnailUrl(globalIndex) {
   return `thumbnails/${encodeURIComponent(state.album)}/${globalIndex}?size=128`;
 }
 
-function buildFlyout(x, y) {
-  removeFlyout();
-
+function populateFlyout(flyout) {
+  flyout.replaceChildren();
   const entries = backStack.recent(FLYOUT_LIMIT);
-  if (entries.length === 0) {
-    return;
-  }
-
-  const flyout = document.createElement("div");
-  flyout.id = FLYOUT_ID;
-
-  for (const entry of entries) {
+  // Anchor the fill to the bottom-right with the OLDEST entry in the corner;
+  // newer entries walk upward in the rightmost column, then jump one column
+  // left at the next column's bottom. backStack.recent() is newest-first, so
+  // iterate from the tail to place the oldest first. When fewer than
+  // FLYOUT_LIMIT entries exist, the unfilled slots land at the top-left.
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[entries.length - 1 - i];
     const img = document.createElement("img");
     img.className = "back-nav-thumb";
+    img.style.gridColumn = String(FLYOUT_COLS - Math.floor(i / FLYOUT_ROWS));
+    img.style.gridRow = String(FLYOUT_ROWS - (i % FLYOUT_ROWS));
     img.src = thumbnailUrl(entry.globalIndex);
     img.alt = `slide ${entry.globalIndex}`;
     img.title = `Back to ${entry.kind === "step" ? "earlier slide" : entry.kind} #${entry.globalIndex}`;
@@ -61,14 +63,13 @@ function buildFlyout(x, y) {
     });
     flyout.appendChild(img);
   }
+}
 
-  document.body.appendChild(flyout);
-
-  // Position after appending so we can measure the flyout's actual size.
+function clampFlyoutPosition(flyout) {
   const rect = flyout.getBoundingClientRect();
   const margin = 6;
-  let left = x;
-  let top = y;
+  let left = flyout._anchorX;
+  let top = flyout._anchorY;
   if (left + rect.width > window.innerWidth - margin) {
     left = Math.max(margin, window.innerWidth - rect.width - margin);
   }
@@ -77,6 +78,41 @@ function buildFlyout(x, y) {
   }
   flyout.style.left = `${left}px`;
   flyout.style.top = `${top}px`;
+}
+
+// Rebuilds the open flyout (if any) from the current back stack. Called on
+// every backStackChanged so keyboard / scrollwheel / swiper navigation while
+// the flyout is open reflects the latest position list in real time.
+function refreshFlyout() {
+  const flyout = document.getElementById(FLYOUT_ID);
+  if (!flyout) {
+    return;
+  }
+  if (backStack.recent(FLYOUT_LIMIT).length === 0) {
+    removeFlyout();
+    return;
+  }
+  populateFlyout(flyout);
+  clampFlyoutPosition(flyout);
+}
+
+function buildFlyout(x, y) {
+  removeFlyout();
+
+  const entries = backStack.recent(FLYOUT_LIMIT);
+  if (entries.length === 0) {
+    return;
+  }
+
+  const flyout = document.createElement("div");
+  flyout.id = FLYOUT_ID;
+  flyout._anchorX = x;
+  flyout._anchorY = y;
+  populateFlyout(flyout);
+
+  document.body.appendChild(flyout);
+  // Position after appending so we can measure the flyout's actual size.
+  clampFlyoutPosition(flyout);
 
   const onDocClick = (ev) => {
     if (!flyout.contains(ev.target)) {
@@ -132,6 +168,11 @@ export function initializeBackButton() {
   // The back stack emits backStackChanged on every mutation. Listening for
   // that (rather than slideChanged) keeps the button in sync even when the
   // swiper suppresses its own slideChange event during an in-place restore.
-  window.addEventListener("backStackChanged", () => updateButtonState(btn));
+  // Same event drives live refresh of the open flyout so keyboard / scroll
+  // navigation updates the thumbnail strip without the user reopening it.
+  window.addEventListener("backStackChanged", () => {
+    updateButtonState(btn);
+    refreshFlyout();
+  });
   window.addEventListener("albumChanged", () => removeFlyout());
 }

--- a/photomap/frontend/static/javascript/back-button.js
+++ b/photomap/frontend/static/javascript/back-button.js
@@ -6,7 +6,7 @@
 import { backStack } from "./back-stack.js";
 import { state } from "./state.js";
 
-const FLYOUT_LIMIT = 10;
+const FLYOUT_LIMIT = 12;
 const DISABLED_CLASS = "back-nav-disabled";
 const FLYOUT_ID = "backNavFlyout";
 

--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -84,11 +84,6 @@ class SwiperManager {
         disableOnInteraction: true,
         enabled: false,
       },
-      pagination: {
-        el: ".swiper-pagination",
-        clickable: true,
-        dynamicBullets: true,
-      },
       loop: false,
       touchEventsTarget: "container",
       allowTouchMove: true,

--- a/tests/frontend/back-button.test.js
+++ b/tests/frontend/back-button.test.js
@@ -93,17 +93,70 @@ describe("back-button.js", () => {
       expect(document.getElementById("backNavFlyout")).toBeNull();
     });
 
-    it("opens a flyout with up to 10 recent thumbnails on right-click", () => {
-      for (let i = 0; i < 12; i++) {
+    it("opens a flyout with up to 12 recent thumbnails on right-click", () => {
+      for (let i = 0; i < 14; i++) {
         emitSlideChanged(i);
       }
       openFlyout(document.getElementById("backNavBtn"));
       const flyout = document.getElementById("backNavFlyout");
       expect(flyout).not.toBeNull();
       const thumbs = flyout.querySelectorAll("img.back-nav-thumb");
-      expect(thumbs.length).toBe(10);
-      // Newest first: the entry just below the current one (globalIndex 10).
-      expect(thumbs[0].src).toContain("/test-album/10?");
+      expect(thumbs.length).toBe(12);
+      // Oldest of the 12 (globalIndex 1) pinned to bottom-right;
+      // newest (globalIndex 12) lands top-left.
+      expect(thumbs[0].src).toContain("/test-album/1?");
+      expect(thumbs[0].style.gridColumn).toBe("4");
+      expect(thumbs[0].style.gridRow).toBe("3");
+      expect(thumbs[11].src).toContain("/test-album/12?");
+      expect(thumbs[11].style.gridColumn).toBe("1");
+      expect(thumbs[11].style.gridRow).toBe("1");
+    });
+
+    it("anchors a partial fill to the bottom-right corner with oldest in the corner", () => {
+      // 3 previous positions — should occupy the rightmost column, bottom-up,
+      // with the oldest pinned to the bottom-right.
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      emitSlideChanged(3);
+      openFlyout(document.getElementById("backNavBtn"));
+      const thumbs = document.querySelectorAll("#backNavFlyout img.back-nav-thumb");
+      expect(thumbs.length).toBe(3);
+      // Oldest (globalIndex 0) at bottom-right; newest of the three (globalIndex 2)
+      // sits at the top of the same column.
+      expect(thumbs[0].src).toContain("/test-album/0?");
+      expect(thumbs[0].style.gridColumn).toBe("4");
+      expect(thumbs[0].style.gridRow).toBe("3");
+      expect(thumbs[2].src).toContain("/test-album/2?");
+      expect(thumbs[2].style.gridColumn).toBe("4");
+      expect(thumbs[2].style.gridRow).toBe("1");
+    });
+
+    it("refreshes thumbnails live when the back stack changes while open", () => {
+      emitSlideChanged(0);
+      emitSlideChanged(1);
+      emitSlideChanged(2);
+      openFlyout(document.getElementById("backNavBtn"));
+      let thumbs = document.querySelectorAll("#backNavFlyout img.back-nav-thumb");
+      expect(thumbs.length).toBe(2);
+      // Oldest (globalIndex 0) anchors the bottom-right corner.
+      expect(thumbs[0].src).toContain("/test-album/0?");
+      expect(thumbs[0].style.gridColumn).toBe("4");
+      expect(thumbs[0].style.gridRow).toBe("3");
+
+      // Simulate keyboard / scrollwheel navigation while the flyout stays open.
+      emitSlideChanged(3);
+
+      thumbs = document.querySelectorAll("#backNavFlyout img.back-nav-thumb");
+      expect(thumbs.length).toBe(3);
+      // Oldest still anchored to the bottom-right; newest now at the top of
+      // the column.
+      expect(thumbs[0].src).toContain("/test-album/0?");
+      expect(thumbs[0].style.gridColumn).toBe("4");
+      expect(thumbs[0].style.gridRow).toBe("3");
+      expect(thumbs[2].src).toContain("/test-album/2?");
+      expect(thumbs[2].style.gridColumn).toBe("4");
+      expect(thumbs[2].style.gridRow).toBe("1");
     });
 
     it("clicking a thumbnail truncates the stack to that entry and navigates", () => {


### PR DESCRIPTION
## Summary
- Back-nav flyout now refreshes in real time as the selected image changes — keyboard / scrollwheel / swiper / grid navigation update the thumbnail strip live while the flyout stays open, instead of showing a stale snapshot from when it was right-clicked.
- Switched the flyout layout from flex-wrap to a fixed 4×3 CSS grid with explicit per-thumb placement. This fixes the uneven black margin on the right edge (max-width 360px overshot a row of 4 × 72px thumbs by ~54px) and anchors the fill to the bottom-right corner: oldest entry in the corner, newer entries walking upward in the rightmost column then jumping one column left, mirroring the grid view's column-major fill. Partial fills leave empty cells at the top-left.
- Earlier commit on the branch also removed the swiper navigation dots and bumped `FLYOUT_LIMIT` from 10 to 12.

## Test plan
- [x] `npm test` — 320 passing, including new cases covering live refresh on `backStackChanged`, full 4×3 fill placement, and partial-fill bottom-right anchoring.
- [x] `npm run lint` and `npm run format:check` clean.
- [x] Manual: open the flyout (right-click Back), then navigate via arrow keys / scrollwheel and confirm thumbs update in place without flicker; verify margins look uniform on all four sides; reduce the back stack to <12 entries and confirm empties stack at the top-left while the oldest stays in the bottom-right corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)