### PR TITLE
fix(swiper): duplicate current image when toggling grid → swiper

### DIFF
--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -556,46 +556,59 @@ class SwiperManager {
 
     const slideShowRunning = this.swiper.autoplay?.running;
     this.pauseSlideshow();
-    this.swiper.removeAllSlides();
 
-    const { globalIndex, searchIndex } = slideState.getCurrentSlide();
+    // Suppress the swiper.slideChange handler for the duration of the
+    // rebuild. The first appendSlide after removeAllSlides moves activeIndex
+    // onto the just-added prev slide, which fires slideChange; without
+    // suppression, the handler writes that prev slide's globalIndex back
+    // into slideState, and the resolveOffset(+1) call below then resolves
+    // to the *original* current globalIndex — duplicating it as the "next"
+    // slide. (seekToSlideIndex's rebuild path is suppressed the same way.)
+    this.isInternalSlideChange = true;
+    try {
+      this.swiper.removeAllSlides();
 
-    const swiperContainer = document.getElementById("singleSwiper");
-    if (swiperContainer) {
-      swiperContainer.style.visibility = "hidden";
+      const { globalIndex, searchIndex } = slideState.getCurrentSlide();
+
+      const swiperContainer = document.getElementById("singleSwiper");
+      if (swiperContainer) {
+        swiperContainer.style.visibility = "hidden";
+      }
+
+      // Add previous slide if available
+      const { globalIndex: prevGlobal, searchIndex: prevSearch } = slideState.resolveOffset(-1);
+      if (prevGlobal !== null) {
+        await this.addSlideByIndex(prevGlobal, prevSearch, false, random_nextslide);
+      }
+
+      // Add current slide
+      await this.addSlideByIndex(globalIndex, searchIndex);
+
+      // Add next slide if available
+      const { globalIndex: nextGlobal, searchIndex: nextSearch } = slideState.resolveOffset(1);
+      if (nextGlobal !== null) {
+        await this.addSlideByIndex(nextGlobal, nextSearch, false, random_nextslide);
+      }
+
+      // Navigate to the current slide
+      const slideIndex = prevGlobal !== null ? 1 : 0;
+      this.swiper.slideTo(slideIndex, 0);
+
+      await new Promise(requestAnimationFrame);
+      if (swiperContainer) {
+        swiperContainer.style.visibility = "";
+      }
+
+      updateMetadataOverlay(this.currentSlide());
+      if (slideShowRunning) {
+        this.resumeSlideshow();
+      }
+
+      setTimeout(() => updateCurrentImageMarker(window.umapPoints), 500);
+      window.dispatchEvent(new CustomEvent("slidesReset"));
+    } finally {
+      this.isInternalSlideChange = false;
     }
-
-    // Add previous slide if available
-    const { globalIndex: prevGlobal, searchIndex: prevSearch } = slideState.resolveOffset(-1);
-    if (prevGlobal !== null) {
-      await this.addSlideByIndex(prevGlobal, prevSearch, false, random_nextslide);
-    }
-
-    // Add current slide
-    await this.addSlideByIndex(globalIndex, searchIndex);
-
-    // Add next slide if available
-    const { globalIndex: nextGlobal, searchIndex: nextSearch } = slideState.resolveOffset(1);
-    if (nextGlobal !== null) {
-      await this.addSlideByIndex(nextGlobal, nextSearch, false, random_nextslide);
-    }
-
-    // Navigate to the current slide
-    const slideIndex = prevGlobal !== null ? 1 : 0;
-    this.swiper.slideTo(slideIndex, 0);
-
-    await new Promise(requestAnimationFrame);
-    if (swiperContainer) {
-      swiperContainer.style.visibility = "";
-    }
-
-    updateMetadataOverlay(this.currentSlide());
-    if (slideShowRunning) {
-      this.resumeSlideshow();
-    }
-
-    setTimeout(() => updateCurrentImageMarker(window.umapPoints), 500);
-    window.dispatchEvent(new CustomEvent("slidesReset"));
   }
 
   enforceHighWaterMark(backward = false) {


### PR DESCRIPTION
## Summary

Toggling from grid view back to single-swiper view (via the grid icon **or** by double-clicking a grid thumbnail) duplicated the currently-selected image as the next slide. The swiper showed the correct image, but pressing the next arrow showed the same image again.

## Root cause

In `_doResetAllSlides`:

```js
this.swiper.removeAllSlides();
...
await this.addSlideByIndex(prevGlobal, prevSearch, ...);   // adds prev
await this.addSlideByIndex(globalIndex, searchIndex);       // adds current
const { globalIndex: nextGlobal, ... } = slideState.resolveOffset(1);
await this.addSlideByIndex(nextGlobal, nextSearch, ...);   // adds next
```

The first `appendSlide` after `removeAllSlides` moves Swiper's `activeIndex` onto the just-added prev slide, which fires `slideChange`. The unsuppressed handler then calls `slideState.updateFromExternal(prevGlobal, prevSearch)` and mutates `slideState.currentGlobalIndex` from the original current value to `prevGlobal`. The very next line — `resolveOffset(+1)` — reads from that corrupted state and returns `prevGlobal + 1`, i.e. the **original** current globalIndex, so the current image is appended a second time as the "next" slide.

`seekToSlideIndex`'s rebuild path was wrapped in `isInternalSlideChange = true` for exactly this reason in #241 — the back-nav feature is what introduced the slideState→swiper feedback path that turned this otherwise-harmless `slideChange` into a visible duplicate. The parallel rebuild in `_doResetAllSlides` was never given the same treatment. The fix is one suppression flag around the whole rebuild block.

## Verification

Playwright probe against the live app, starting at globalIndex=5:

- Before: slides after toggle = `[4, 5, 5]`, advance → `5` (same image)
- After:  slides after toggle = `[4, 5, 6]`, advance → `6` (correct)

Reproduces and is fixed on both toggle paths (grid button + double-click).

## Test plan

- [x] Toggle grid → swiper via the grid icon at a non-zero album position; verify the next arrow advances to a distinct image.
- [x] Double-click a grid thumbnail to open it in swiper; verify the next arrow advances to a distinct image.
- [x] Same checks while in search-results mode (search-index navigation).
- [x] Same checks at the album boundaries (index 0, last image) and with wrap-navigation enabled.
- [x] `npm test` — 320 frontend Jest tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)