### PR TITLE
fix(umap): keep close button visible at small/medium window sizes

### DIFF
--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -26,8 +26,8 @@ import { debounce, getPercentile, isColorLight, makeDraggable } from "./utils.js
 
 const UMAP_SIZES = {
   big: { width: 800, height: 590 },
-  medium: { width: 440, height: 310 },
-  small: { width: 360, height: 210 },
+  medium: { width: 520, height: 310 },
+  small: { width: 440, height: 210 },
   fullscreen: { width: window.innerWidth, height: window.innerHeight },
 };
 const landmarkCount = 18; // Maximum number of non-overlapping landmarks to show at any time

--- a/photomap/frontend/templates/modules/umap-floating-window.html
+++ b/photomap/frontend/templates/modules/umap-floating-window.html
@@ -5,7 +5,7 @@
   <!-- Titlebar -->
   <div id="umapTitlebar">
     <select id="semanticMapAlbumSelect" title="Switch album" aria-label="Switch album"></select>
-    <div style="display: flex; align-items: center; gap: 8px">
+    <div style="display: flex; align-items: center; gap: 3px">
       <!-- Resizing icons -->
       <button id="umapResizeFullscreen" title="Fullscreen" class="icon-btn">
         <svg width="24" height="24" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

- At small (420px) and medium (500px) sizes the semantic-map titlebar buttons (~340px total) plus the album select (max-width 60%) overflowed the window's `overflow: hidden` right edge, clipping the close (×) button.
- Widen `UMAP_SIZES.small` 360→440 and `.medium` 440→520 (plot widths; window widths are plot+60).
- Tighten the titlebar icon-group flex `gap` from 8px to 3px, freeing ~30px across the 6 inter-button gaps.
- Size-detection thresholds in `getCurrentWindowSize()` still order correctly: small_window=500 < medium_threshold=520 ≤ medium_window=580 < big_threshold=800 ≤ big_window=860.

## Test plan

- [ ] Open the semantic map and click the **Small** size icon — confirm the × close button is fully visible to the right of the controls icon.
- [ ] Click the **Medium** size icon — confirm the × close button is fully visible.
- [ ] Click **Large** and **Fullscreen** — confirm no regression (sizes/layout unchanged).
- [ ] Toggle shade (double-click titlebar) and restore — confirm the restored size is the previous unshaded size.
- [ ] Switch between albums via the titlebar dropdown with a long album name — confirm the close button still shows at small/medium.
- [ ] `npm test` (already verified locally: 339/339 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)