### PR TITLE
fix(seek-slider): show position index for favorites instead of uniform scores

### DIFF
--- a/photomap/frontend/static/javascript/seek-slider.js
+++ b/photomap/frontend/static/javascript/seek-slider.js
@@ -229,7 +229,9 @@ class SeekSlider {
     this.resetFadeOutTimer();
 
     let panelText = "";
-    if (state.searchResults?.length > 0 && state.searchResults[0].score !== undefined) {
+    if (state.searchType === "bookmarks") {
+      panelText = `Favorite: ${value}`;
+    } else if (state.searchResults?.length > 0 && state.searchResults[0].score !== undefined) {
       const result = state.searchResults[value - 1];
       panelText = result ? `Score: ${result.score.toFixed(4)}` : "";
     } else if (!state.searchResults || state.searchResults.length === 0) {
@@ -471,6 +473,9 @@ class SeekSlider {
           }
         })
       );
+    } else if (state.searchType === "bookmarks") {
+      contextText = "Favorite";
+      ticks = positions.map((idx) => `${idx}`);
     } else if (state.searchResults.length > 0 && state.searchResults[0].score !== undefined) {
       contextText = "Score";
       ticks = positions.map((idx) => {


### PR DESCRIPTION
## Problem

When viewing the set of **favorite** images, the seek slider tick labels were in "Score" mode and showed a uniform `1.000` for every position. This is not useful — the indices should indicate the slide # within the set of favorites, similar to how cluster positions are shown when a cluster is selected.

## Cause

Favorites/bookmarks are stored in `state.searchResults` with `score: 1.0` on every entry (`bookmarks.js`). The seek slider chose its label mode by checking `searchResults[0].score !== undefined`, so favorites incorrectly fell into the "Score" branch.

## Fix

Use `state.searchType`, which is already set to `"bookmarks"` when favorites are shown. Added a `searchType === "bookmarks"` branch **before** the score check in both rendering paths in `seek-slider.js`:

- `renderSliderTicks()` — labels the context `"Favorite"` and renders each tick as its position index, matching cluster mode.
- `onSliderInput()` — the hover/drag info panel now shows `Favorite: <n>` instead of `Score: 1.0000`.

The branch is correctly scoped: `searchType` is always reassigned through `setSearchResults`, and bookmarks.js restores the prior type (or `"clear"`) on exit, so it only triggers while actually viewing favorites.

## Testing

- Verified manually in the app (favorites view now shows position indices).
- Prettier and ESLint pass clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)