### PR TITLE
fix(umap): render landmark triangles with scattergl to fix touch-pan desync

### DIFF
--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -1210,12 +1210,19 @@ function updateLandmarkTrace() {
     const y = clustersInView.map((c) => c.center.y + verticalOffset);
     const markerColors = clustersInView.map((c) => c.color);
 
-    // Triangle-down markers at bottom of thumbnails
+    // Triangle-down markers at bottom of thumbnails.
+    // Rendered with scattergl (WebGL) to match the main point traces. The main
+    // points use scattergl, so an SVG `scatter` trace here was the only visible
+    // element on the SVG layer. During a touch pan, Plotly translates the SVG
+    // layer immediately but only repaints the WebGL scene once the gesture
+    // settles, so on tablets a touch-and-immediately-drag made the triangles
+    // slide alone while the dots stayed frozen. Keeping the triangles in the
+    // same WebGL pipeline makes them freeze-and-snap together with the points.
     const landmarkTrace = {
       x,
       y,
       mode: "markers",
-      type: "scatter",
+      type: "scattergl",
       marker: {
         size: triangleSize,
         color: markerColors,


### PR DESCRIPTION
## Problem

On tablets, touching the UMAP plot and **immediately** dragging to pan made only the colored landmark triangles move with the finger while the dots and the rest of the plot stayed frozen. Touching, pausing briefly, then dragging worked fine.

## Cause

The main point traces use `scattergl` (WebGL) while the landmark triangle trace used `scatter` (SVG). During a touch pan, Plotly translates the SVG layer immediately but only repaints the WebGL scene once the gesture settles. So a touch-and-immediately-drag translated the SVG layer (the triangles — the only visible SVG element on the plot) while the WebGL scene (the dots) stayed put until release.

## Fix

Switch the `landmarkTrace` to `type: "scattergl"` so the triangles live in the same WebGL pipeline as the points and freeze-and-snap together with the rest of the plot.

The invisible `clickableTrace` is intentionally left as SVG `scatter`: its hit squares can be up to 256px and would risk GL point-size clamping, and being invisible its drag-time position is never seen. Landmark hit-testing (`umap-helpers.js`) is pure x/y geometry and the trace is located by `name === "Landmarks"`, so neither depends on the renderer type.

## Testing

- Verified on a tablet: the touch-and-immediately-drag pan no longer desyncs.
- `npm test` — 343/343 frontend tests pass; ESLint and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)