### PR TITLE
feat(slideshow): gray out play button on last slide in sequential mode

### DIFF
--- a/photomap/frontend/static/css/control-and-search-panels.css
+++ b/photomap/frontend/static/css/control-and-search-panels.css
@@ -56,7 +56,9 @@
 }
 
 #controlPanel button.back-nav-disabled,
-#controlPanel button.back-nav-disabled:hover {
+#controlPanel button.back-nav-disabled:hover,
+#controlPanel button.slideshow-disabled,
+#controlPanel button.slideshow-disabled:hover {
   opacity: 0.25;
   cursor: default;
 }

--- a/photomap/frontend/static/javascript/events.js
+++ b/photomap/frontend/static/javascript/events.js
@@ -205,7 +205,9 @@ export function showHidePanelText(hide) {
 
 // Listen for slide changes to update UI
 window.addEventListener("slideChanged", () => {
-  // nothing to do here yet, but could be used to update UI elements
+  // Refresh the play/pause button so it grays out when we land on the last
+  // slide in sequential mode (and re-activates when we navigate away).
+  updateSlideshowButtonIcon();
 });
 
 // Toggle grid/swiper views

--- a/photomap/frontend/static/javascript/slideshow.js
+++ b/photomap/frontend/static/javascript/slideshow.js
@@ -1,4 +1,5 @@
 import { saveSettingsToLocalStorage, state } from "./state.js";
+import { slideState } from "./slide-state.js";
 import { isUmapFullscreen, toggleUmapWindow } from "./umap.js";
 
 // SVG icons used for the button/menu
@@ -13,6 +14,14 @@ const SHUFFLE_SVG = `<svg id="shuffleIcon" width="32" height="32" viewBox="0 0 2
 
 export function slideShowRunning() {
   return !!state.single_swiper?.swiper?.autoplay?.running;
+}
+
+// In sequential mode there is a genuine end of the list, so a stopped slideshow
+// resting on the final slide has nowhere to advance to. resolveOffset(+1)
+// reports null only at that end (wrap mode always resolves to a real index, and
+// random mode has no end), so it cleanly captures the "last slide" case.
+function atSequentialEnd() {
+  return state.mode !== "random" && slideState.resolveOffset(+1).globalIndex === null;
 }
 
 // public: update the icon displayed on the start/stop button according to state
@@ -41,6 +50,13 @@ export function updateSlideshowButtonIcon() {
     if (btn) {
       btn.title = `Start Slideshow (${modeLabel})`;
     }
+  }
+
+  // Gray out and disable Play when stopped on the final slide in sequential
+  // mode — there is nothing left to play. Never disable the Pause button.
+  if (btn) {
+    const disabled = !isRunning && atSequentialEnd();
+    btn.classList.toggle("slideshow-disabled", disabled);
   }
 }
 
@@ -90,6 +106,12 @@ export async function toggleSlideshowWithIndicator(e) {
   if (e && e.preventDefault) {
     e.preventDefault();
     e.stopPropagation();
+  }
+
+  // Ignore clicks while parked on the last sequential slide (button is grayed
+  // out): there is nothing to start.
+  if (!slideShowRunning() && atSequentialEnd()) {
+    return;
   }
 
   if (slideShowRunning()) {


### PR DESCRIPTION
## Summary

A tiny UI tweak: when the slideshow mode is **sequential** and the current slide is the **last** slide (album or search results), the play button now grays out and is inactivated.

## Behavior

- **Sequential mode, parked on the last slide** → play button grays out (opacity 0.25, `cursor: default`) and clicks are ignored.
- **Shuffle mode** → unaffected (there is no "end of list").
- **Wrap-navigation enabled** → unaffected (`resolveOffset` always resolves to a real index).
- **Pause button** → never disabled; only a *stopped* play button on the final slide is grayed.
- The button re-activates automatically as soon as you navigate away from the last slide.

## Implementation

- **`slideshow.js`** — new `atSequentialEnd()` helper reuses `slideState.resolveOffset(+1)` (the same end-of-list signal the auto-pause path from #293 relies on). `updateSlideshowButtonIcon()` toggles a `slideshow-disabled` class; `toggleSlideshowWithIndicator()` no-ops a click in that state.
- **`events.js`** — wired the icon refresh into the existing (previously empty) `slideChanged` listener so the button stays in sync across every navigation path (swipe, seek slider, UMAP, etc.).
- **`control-and-search-panels.css`** — extended the existing `.back-nav-disabled` rule to also cover `.slideshow-disabled`, following the established disabled-button convention.

## Testing

- `npm test` — 343 frontend tests pass
- `npm run lint` + `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)