### PR TITLE
fix(slideshow): rebuild buffer sequentially when pausing a shuffle run

### DIFF
--- a/photomap/frontend/static/javascript/slideshow.js
+++ b/photomap/frontend/static/javascript/slideshow.js
@@ -94,8 +94,19 @@ export async function toggleSlideshowWithIndicator(e) {
 
   if (slideShowRunning()) {
     // pause
+    const wasShuffling = state.mode === "random";
     try {
       state.single_swiper.pauseSlideshow();
+      // A shuffle run fills the swiper buffer with slides in random order. Once
+      // stopped, the forward/back buttons just walk that buffer, so the user
+      // would see the shuffled neighborhood instead of the current image's real
+      // sequential neighbors. Rebuild the buffer in album order around the
+      // current slide so manual navigation behaves sequentially again.
+      // (Sequential runs already leave an in-order buffer, so only shuffle needs
+      // this.)
+      if (wasShuffling) {
+        await state.single_swiper.resetAllSlides();
+      }
     } catch (err) {
       console.warn("pauseSlideshow failed:", err);
     }

--- a/tests/frontend/slideshow.test.js
+++ b/tests/frontend/slideshow.test.js
@@ -38,8 +38,13 @@ jest.unstable_mockModule("../../photomap/frontend/static/javascript/umap.js", ()
 }));
 
 // Now import the module we want to test
-const { slideShowRunning, updateSlideshowButtonIcon, showPlayPauseIndicator, removeExistingIndicator } =
-  await import("../../photomap/frontend/static/javascript/slideshow.js");
+const {
+  slideShowRunning,
+  updateSlideshowButtonIcon,
+  showPlayPauseIndicator,
+  removeExistingIndicator,
+  toggleSlideshowWithIndicator,
+} = await import("../../photomap/frontend/static/javascript/slideshow.js");
 
 const { state } = await import("../../photomap/frontend/static/javascript/state.js");
 
@@ -162,6 +167,43 @@ describe("slideshow.js", () => {
 
       const container = document.getElementById("slideshowIcon");
       expect(container.innerHTML).toContain("playIcon");
+    });
+  });
+
+  describe("toggleSlideshowWithIndicator (pause path)", () => {
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <div id="slideshowIcon"></div>
+        <button id="startStopSlideshowBtn" title=""></button>
+      `;
+    });
+
+    it("rebuilds the buffer sequentially when pausing a shuffle run", async () => {
+      // Regression: after stopping a shuffle slideshow, the swiper buffer is
+      // still in random order, so forward/back navigation would walk the
+      // leftover shuffle instead of the current image's sequential neighbors.
+      const resetAllSlides = jest.fn(() => Promise.resolve());
+      const pauseSlideshow = jest.fn();
+      state.single_swiper = { swiper: { autoplay: { running: true } }, pauseSlideshow, resetAllSlides };
+      state.mode = "random";
+
+      await toggleSlideshowWithIndicator();
+
+      expect(pauseSlideshow).toHaveBeenCalled();
+      expect(resetAllSlides).toHaveBeenCalled();
+    });
+
+    it("does not rebuild the buffer when pausing a sequential run", async () => {
+      // Sequential runs already leave an in-order buffer, so no rebuild needed.
+      const resetAllSlides = jest.fn(() => Promise.resolve());
+      const pauseSlideshow = jest.fn();
+      state.single_swiper = { swiper: { autoplay: { running: true } }, pauseSlideshow, resetAllSlides };
+      state.mode = "chronological";
+
+      await toggleSlideshowWithIndicator();
+
+      expect(pauseSlideshow).toHaveBeenCalled();
+      expect(resetAllSlides).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Problem

When the user runs the slideshow in **shuffle** mode, then stops it and navigates with the forward/back buttons, navigation showed the **shuffled** neighborhood instead of the current image's sequential neighbors.

## Root cause

During a shuffle run the swiper buffer fills with slides in random order (the shuffle "bag"). When the slideshow stops, `pauseSlideshow()` only halts autoplay — it never rebuilds the buffer. The nav buttons (`slideNext`/`slidePrev`) then walk that stale shuffled buffer; only at the buffer edges does the sequential `resolveOffset` logic kick in.

## Fix

In the pause branch of `toggleSlideshowWithIndicator` (play/pause button and spacebar — the "stop the slideshow" action), when the run being stopped was in shuffle mode, call `resetAllSlides()`. That rebuilds the buffer in album order around the current image, so forward/back navigation immediately walks real sequential neighbors. Sequential runs are skipped since they already leave an in-order buffer.

`resetAllSlides()` is safe here: it reads `slideState.getCurrentSlide()` (kept in sync with the on-screen image during shuffle), rebuilds prev/current/next sequentially, and won't restart autoplay since it was just paused.

### Intended behavior, not changed

Navigating *during* a still-running shuffle slideshow continues to walk the shuffle order — that is intended.

## Tests

Added two cases to `tests/frontend/slideshow.test.js`:
- pausing a shuffle run rebuilds the buffer (`resetAllSlides` called)
- pausing a sequential run does not (`resetAllSlides` not called)

Full frontend suite passes; lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)