### PR TITLE
feat(installer): signed uv-bootstrap desktop launcher

### DIFF
--- a/.github/workflows/deploy-launcher.yml
+++ b/.github/workflows/deploy-launcher.yml
@@ -1,0 +1,267 @@
+name: Deploy Launcher
+
+# Builds the small native launcher for each OS, signs/notarizes it, packages it
+# (.dmg / setup.exe / .AppImage), and uploads the result as a build artifact.
+# Replaces deploy-pyinstaller.yml: the launcher does NOT bundle torch, so there
+# is no cpu/cu129 matrix and no disk-space juggling — builds are small and fast.
+#
+# Required repository secrets (signing is skipped gracefully if absent, so
+# workflow_dispatch still produces unsigned artifacts for testing):
+#   macOS    MACOS_CERT_P12_BASE64, MACOS_CERT_PASSWORD, MACOS_KEYCHAIN_PASSWORD,
+#            APPLE_API_KEY_P8_BASE64, APPLE_API_KEY_ID, APPLE_API_ISSUER_ID
+#   Windows  AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET
+#
+# Required repository variables (non-secret Azure Trusted Signing config):
+#   AZURE_CODESIGN_ENDPOINT  e.g. https://eus.codesigning.azure.net
+#   AZURE_CODESIGN_ACCOUNT   the Trusted Signing account name
+#   AZURE_CODESIGN_PROFILE   the certificate profile name
+
+on:
+  workflow_call:
+    secrets:
+      MACOS_CERT_P12_BASE64: { required: false }
+      MACOS_CERT_PASSWORD: { required: false }
+      MACOS_KEYCHAIN_PASSWORD: { required: false }
+      APPLE_API_KEY_P8_BASE64: { required: false }
+      APPLE_API_KEY_ID: { required: false }
+      APPLE_API_ISSUER_ID: { required: false }
+      AZURE_TENANT_ID: { required: false }
+      AZURE_CLIENT_ID: { required: false }
+      AZURE_CLIENT_SECRET: { required: false }
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Pin the uv we have tested the launcher against (must support
+  # `--torch-backend` on `uv tool install`).
+  UV_VERSION: "0.11.19"
+  GO_VERSION: "1.22"
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Extract version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(python -c "import tomllib;print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+  # --------------------------------------------------------------------------
+  linux:
+    needs: version
+    runs-on: ubuntu-22.04
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Fetch uv ${{ env.UV_VERSION }}
+        run: |
+          mkdir -p launcher/assets
+          curl -fsSL -o /tmp/uv.tar.gz \
+            "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf /tmp/uv.tar.gz --strip-components=1 -C launcher/assets uv-x86_64-unknown-linux-gnu/uv
+          mv launcher/assets/uv launcher/assets/uv-bin
+
+      - name: Build launcher
+        run: |
+          mkdir -p dist
+          cd launcher
+          go build -tags embed_uv -ldflags "-X main.version=${VERSION}" -o ../dist/photomap .
+
+      - name: Build AppImage
+        run: |
+          curl -fsSL -o /tmp/appimagetool \
+            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+          chmod +x /tmp/appimagetool
+          export PATH="/tmp:$PATH"
+          export APPIMAGE_EXTRACT_AND_RUN=1   # CI has no FUSE
+          chmod +x INSTALL/launcher/linux/build_appimage.sh
+          INSTALL/launcher/linux/build_appimage.sh \
+            dist/photomap "${VERSION}" \
+            "dist/PhotoMapAI-${VERSION}-x86_64.AppImage" \
+            photomap/frontend/static/icons/favicon-32x32.png
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: photomap-launcher-linux-x64-v${{ env.VERSION }}
+          path: dist/PhotoMapAI-${{ env.VERSION }}-x86_64.AppImage
+          retention-days: 30
+
+  # --------------------------------------------------------------------------
+  macos:
+    needs: version
+    runs-on: macos-latest
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
+      # 'true' when the signing/notarization secrets are configured.
+      SIGNING_ENABLED: ${{ secrets.MACOS_CERT_P12_BASE64 != '' && secrets.APPLE_API_KEY_P8_BASE64 != '' }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Fetch uv ${{ env.UV_VERSION }}
+        run: |
+          mkdir -p launcher/assets
+          # macos-latest runners are Apple Silicon (arm64). Intel Macs are not
+          # covered by this build; add an x86_64 leg / universal2 if needed.
+          curl -fsSL -o /tmp/uv.tar.gz \
+            "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-aarch64-apple-darwin.tar.gz"
+          tar -xzf /tmp/uv.tar.gz --strip-components=1 -C launcher/assets uv-aarch64-apple-darwin/uv
+          mv launcher/assets/uv launcher/assets/uv-bin
+
+      - name: Build launcher
+        run: |
+          mkdir -p dist
+          cd launcher
+          go build -tags embed_uv -ldflags "-X main.version=${VERSION}" -o ../dist/photomap .
+
+      - name: Assemble .app
+        run: |
+          chmod +x INSTALL/launcher/macos/build_app.sh
+          INSTALL/launcher/macos/build_app.sh \
+            dist/photomap "${VERSION}" "dist/PhotoMapAI.app" \
+            photomap/frontend/static/icons/icon.icns
+
+      - name: Import signing certificate
+        if: env.SIGNING_ENABLED == 'true'
+        env:
+          MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          KEYCHAIN="$RUNNER_TEMP/build.keychain"
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          echo "$MACOS_CERT_P12_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$MACOS_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security list-keychains -d user -s "$KEYCHAIN" login.keychain
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN" | grep "Developer ID Application" | head -1 | sed -E 's/.*"(.*)".*/\1/')
+          echo "SIGN_IDENTITY=$IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Sign .app (hardened runtime)
+        if: env.SIGNING_ENABLED == 'true'
+        run: |
+          # Sign the nested Mach-O first, then the bundle.
+          codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" \
+            "dist/PhotoMapAI.app/Contents/Resources/photomap"
+          codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" \
+            "dist/PhotoMapAI.app"
+          codesign --verify --deep --strict --verbose=2 "dist/PhotoMapAI.app"
+
+      - name: Build DMG
+        run: |
+          DMG="dist/PhotoMapAI-${VERSION}.dmg"
+          ROOT="$RUNNER_TEMP/dmg-root"
+          mkdir -p "$ROOT"
+          cp -R "dist/PhotoMapAI.app" "$ROOT/"
+          ln -s /Applications "$ROOT/Applications"
+          hdiutil create -volname "PhotoMapAI" -srcfolder "$ROOT" -ov -format UDZO "$DMG"
+          echo "DMG=$DMG" >> "$GITHUB_ENV"
+
+      - name: Sign + notarize + staple DMG
+        if: env.SIGNING_ENABLED == 'true'
+        env:
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          codesign --force --timestamp --sign "$SIGN_IDENTITY" "$DMG"
+          echo "$APPLE_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/api_key.p8"
+          xcrun notarytool submit "$DMG" \
+            --key "$RUNNER_TEMP/api_key.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$DMG"
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: photomap-launcher-macos-arm64-v${{ env.VERSION }}
+          path: dist/PhotoMapAI-${{ env.VERSION }}.dmg
+          retention-days: 30
+
+  # --------------------------------------------------------------------------
+  windows:
+    needs: version
+    runs-on: windows-latest
+    env:
+      VERSION: ${{ needs.version.outputs.version }}
+      SIGNING_ENABLED: ${{ secrets.AZURE_CLIENT_ID != '' }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Fetch uv ${{ env.UV_VERSION }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path launcher/assets | Out-Null
+          Invoke-WebRequest -Uri "https://github.com/astral-sh/uv/releases/download/$env:UV_VERSION/uv-x86_64-pc-windows-msvc.zip" -OutFile "$env:TEMP/uv.zip"
+          Expand-Archive -Path "$env:TEMP/uv.zip" -DestinationPath "$env:TEMP/uv" -Force
+          # Embed file name is extension-less on every OS; the bytes are the exe.
+          Copy-Item "$env:TEMP/uv/uv.exe" "launcher/assets/uv-bin"
+
+      - name: Build launcher
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Set-Location launcher
+          go build -tags embed_uv -ldflags "-X main.version=$env:VERSION" -o ../dist/photomap.exe .
+
+      - name: Sign launcher exe (Azure Trusted Signing)
+        if: env.SIGNING_ENABLED == 'true'
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ vars.AZURE_CODESIGN_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.AZURE_CODESIGN_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_CODESIGN_PROFILE }}
+          files-folder: dist
+          files-folder-filter: exe
+
+      - name: Build installer (Inno Setup)
+        shell: pwsh
+        run: |
+          choco install innosetup --no-progress -y
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
+            "/DAppVersion=$env:VERSION" `
+            "/DSourceExe=dist\photomap.exe" `
+            INSTALL\launcher\windows\photomap.iss
+
+      - name: Sign installer (Azure Trusted Signing)
+        if: env.SIGNING_ENABLED == 'true'
+        uses: azure/trusted-signing-action@v0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ vars.AZURE_CODESIGN_ENDPOINT }}
+          trusted-signing-account-name: ${{ vars.AZURE_CODESIGN_ACCOUNT }}
+          certificate-profile-name: ${{ vars.AZURE_CODESIGN_PROFILE }}
+          files-folder: dist
+          files-folder-filter: exe
+          files-folder-recurse: false
+
+      - uses: actions/upload-artifact@v5
+        with:
+          name: photomap-launcher-windows-x64-v${{ env.VERSION }}
+          path: dist/PhotoMapAI-${{ env.VERSION }}-setup.exe
+          retention-days: 30

--- a/.github/workflows/deploy-pyinstaller.yml
+++ b/.github/workflows/deploy-pyinstaller.yml
@@ -1,5 +1,10 @@
 name: Deploy PyInstaller Executables
 
+# DEPRECATED: superseded by deploy-launcher.yml (the small signed uv-bootstrap
+# launcher). No longer wired into deploy.yml; kept one release cycle as a
+# fallback and for manual dispatch. Remove this workflow, photomap.spec, and
+# INSTALL/pyinstaller/ once the signed launcher has shipped on all platforms.
+
 on:
   workflow_call:
   workflow_dispatch:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,12 +74,22 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  deploy-pyinstaller:
+  deploy-launcher:
     needs: deploy-dockerhub
-    uses: ./.github/workflows/deploy-pyinstaller.yml
+    uses: ./.github/workflows/deploy-launcher.yml
+    secrets:
+      MACOS_CERT_P12_BASE64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+      MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
   upload-release:
-    needs: [tag-release, deploy-pypi, deploy-dockerhub, deploy-pyinstaller]
+    needs: [tag-release, deploy-pypi, deploy-dockerhub, deploy-launcher]
     uses: ./.github/workflows/upload-artifacts.yml
     with:
       tag_name: ${{ needs.tag-release.outputs.tag }}

--- a/.github/workflows/upload-artifacts.yml
+++ b/.github/workflows/upload-artifacts.yml
@@ -14,10 +14,10 @@ jobs:
   upload-release: 
     runs-on: ubuntu-latest
     steps:
-      - name: Download CPU installer package artifacts
+      - name: Download launcher artifacts
         uses: actions/download-artifact@v5
-        with: 
-          pattern: "*-cpu-*"
+        with:
+          pattern: "photomap-launcher-*"
           path: artifacts
 
       - name: List downloaded artifacts
@@ -27,6 +27,6 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag_name }}
-          files: artifacts/*-cpu-*/*
+          files: artifacts/photomap-launcher-*/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,9 @@ demo_images/photomap_index
 
 # Node.js
 node_modules/
+
+# Go launcher: build output and the uv binary CI fetches/embeds at build time
+/launcher/launcher
+/launcher/photomap
+/launcher/photomap.exe
+/launcher/assets/uv-bin

--- a/INSTALL/install_linux_mac.sh
+++ b/INSTALL/install_linux_mac.sh
@@ -103,6 +103,12 @@ create_mac_launcher() {
     local repo_root=.
     local icon_path="$repo_root/photomap/frontend/static/icons/favicon-32x32.icns"
 
+    # Read the installed package version rather than hardcoding it, so the bundle
+    # version never drifts from what's actually installed.
+    local app_version
+    app_version="$("$install_path/bin/python" -c "from importlib.metadata import version; print(version('photomapai'))" 2>/dev/null)"
+    app_version="${app_version:-0.0.0}"
+
     # Create app bundle structure
     mkdir -p "$app_dir/Contents/MacOS"
     mkdir -p "$app_dir/Contents/Resources"
@@ -124,9 +130,9 @@ create_mac_launcher() {
     <key>CFBundleIconFile</key>
     <string>photomap.icns</string>
     <key>CFBundleVersion</key>
-    <string>0.3.0</string>
+    <string>$app_version</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.3.0</string>
+    <string>$app_version</string>
     <key>LSUIElement</key>
     <false/>
 </dict>
@@ -194,8 +200,10 @@ main() {
     pip install --upgrade pip
     
     # Step 5: Install PhotoMap
+    # Non-editable install: an editable (-e) install hard-links the venv to this
+    # unpacked source directory, so moving or deleting it later breaks the launcher.
     print_info "Installing PhotoMap..."
-    pip install -e .
+    pip install .
 
     # Step 6: Install the CLIP model
     print_info "Downloading CLIP model..."

--- a/INSTALL/launcher/linux/build_appimage.sh
+++ b/INSTALL/launcher/linux/build_appimage.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Package the compiled Go launcher as a single-file AppImage.
+#
+# Usage: build_appimage.sh <go-binary> <version> <output.AppImage> <png-icon>
+#
+# Requires appimagetool on PATH (CI installs it). The AppImage is a portable
+# executable that runs across distros; the launcher then fetches Python + the
+# app via uv on first run.
+set -euo pipefail
+
+BIN="$1"
+VERSION="$2"
+OUT="$3"
+ICON="$4"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+APPDIR="$(mktemp -d)/PhotoMapAI.AppDir"
+
+mkdir -p "$APPDIR"
+cp "$BIN" "$APPDIR/photomap"
+chmod +x "$APPDIR/photomap"
+cp "$HERE/photomap.desktop" "$APPDIR/photomap.desktop"
+cp "$ICON" "$APPDIR/photomap.png"
+
+# AppRun is the AppImage entry point.
+cat > "$APPDIR/AppRun" << 'EOF'
+#!/bin/bash
+HERE="$(dirname "$(readlink -f "$0")")"
+exec "$HERE/photomap" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+ARCH="${ARCH:-x86_64}" appimagetool "$APPDIR" "$OUT"
+echo "Built $OUT"

--- a/INSTALL/launcher/linux/photomap.desktop
+++ b/INSTALL/launcher/linux/photomap.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=PhotoMapAI
+Comment=AI-powered local photo browser and semantic map
+Exec=photomap
+Icon=photomap
+Categories=Graphics;Photography;Viewer;
+Terminal=true

--- a/INSTALL/launcher/macos/Info.plist.template
+++ b/INSTALL/launcher/macos/Info.plist.template
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>PhotoMapAI</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.lincolnstein.photomapai</string>
+    <key>CFBundleName</key>
+    <string>PhotoMapAI</string>
+    <key>CFBundleDisplayName</key>
+    <string>PhotoMapAI</string>
+    <key>CFBundleIconFile</key>
+    <string>photomap.icns</string>
+    <key>CFBundleVersion</key>
+    <string>__VERSION__</string>
+    <key>CFBundleShortVersionString</key>
+    <string>__VERSION__</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>

--- a/INSTALL/launcher/macos/build_app.sh
+++ b/INSTALL/launcher/macos/build_app.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Assemble PhotoMapAI.app around the compiled Go launcher.
+#
+# The bundle's main executable is a tiny wrapper script that opens Terminal and
+# runs the real Go binary (kept in Resources/). This is what makes the multi-GB
+# first-run install progress visible to the user — a bare Mach-O launched from
+# Finder shows no window. The Go binary is a normal Mach-O and gets code-signed
+# with the hardened runtime by the caller (see deploy-launcher.yml).
+#
+# Usage: build_app.sh <go-binary> <version> <output-app-dir> <icns-icon>
+set -euo pipefail
+
+BIN="$1"
+VERSION="$2"
+APP="$3"
+ICON="$4"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+
+# Real launcher binary lives in Resources; sign target for the caller.
+cp "$BIN" "$APP/Contents/Resources/photomap"
+chmod +x "$APP/Contents/Resources/photomap"
+
+cp "$ICON" "$APP/Contents/Resources/photomap.icns"
+
+sed "s/__VERSION__/${VERSION}/g" "$HERE/Info.plist.template" > "$APP/Contents/Info.plist"
+
+# Wrapper: open Terminal running the real binary so the user sees progress.
+cat > "$APP/Contents/MacOS/PhotoMapAI" << 'EOF'
+#!/bin/bash
+RES="$(cd "$(dirname "$0")/../Resources" && pwd)"
+osascript \
+  -e "tell application \"Terminal\" to do script \"clear; '$RES/photomap'\"" \
+  -e 'tell application "Terminal" to activate'
+EOF
+chmod +x "$APP/Contents/MacOS/PhotoMapAI"
+
+echo "Built $APP"

--- a/INSTALL/launcher/windows/photomap.iss
+++ b/INSTALL/launcher/windows/photomap.iss
@@ -1,0 +1,54 @@
+; Inno Setup script for the PhotoMapAI launcher.
+; Produces a per-user installer (no admin/UAC) that drops the small signed
+; launcher exe and creates Start Menu / desktop shortcuts. The heavy Python +
+; PyTorch stack is fetched by the launcher (via uv) on first run, not bundled.
+;
+; The version and source exe path are passed in from CI:
+;   iscc /DAppVersion=1.2.3 /DSourceExe=dist\photomap.exe photomap.iss
+
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+#ifndef SourceExe
+  #define SourceExe "dist\photomap.exe"
+#endif
+
+#define AppName "PhotoMapAI"
+#define AppExe "photomap.exe"
+#define AppPublisher "Lincoln Stein"
+
+[Setup]
+AppId={{8F2A6C71-3E4B-4D9A-9C2E-5B7A1D6F0E33}
+AppName={#AppName}
+AppVersion={#AppVersion}
+AppPublisher={#AppPublisher}
+DefaultDirName={autopf}\{#AppName}
+DefaultGroupName={#AppName}
+DisableProgramGroupPage=yes
+; Per-user install: no administrator rights required.
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
+OutputDir=dist
+OutputBaseFilename=PhotoMapAI-{#AppVersion}-setup
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+SetupIconFile=..\..\..\photomap\frontend\static\icons\favicon.ico
+UninstallDisplayIcon={app}\{#AppExe}
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Files]
+Source: "{#SourceExe}"; DestDir: "{app}"; DestName: "{#AppExe}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExe}"
+Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExe}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#AppExe}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # simple Makefile with scripts that are otherwise hard to remember
 # to use, run from the repo root `make <command>`
 
+# Version of uv to bundle into the launcher. Keep in sync with the UV_VERSION
+# pin in .github/workflows/deploy-launcher.yml.
+UV_VERSION ?= 0.11.19
+
 default: help
 
 help:
@@ -11,6 +15,7 @@ help:
 	@echo "docker-demo      Build the Docker demo site image."
 	@echo "docs             Serve the mkdocs site with live reload."
 	@echo "deploy-docs      Deploy the mkdocs site to GitHub pages."
+	@echo "appimage         Build the Linux launcher AppImage into dist/."
 	@echo "backend-lint     Run Python backend linting with Ruff."
 	@echo "frontend-lint    Run JavaScript frontend linting with ESLint and Prettier."
 	@echo "lint             Run both backend and frontend linting."
@@ -51,6 +56,36 @@ docs:
 
 deploy-docs:
 	mkdocs gh-deploy
+
+# Build the Linux launcher AppImage on demand (the same steps CI runs):
+#   1. fetch the pinned uv binary into launcher/assets/uv-bin (cached after first run)
+#   2. compile the Go launcher with the uv binary embedded (-tags embed_uv)
+#   3. package launcher + icon + .desktop into a single AppImage via appimagetool
+# Output: dist/PhotoMapAI-<version>-x86_64.AppImage
+.PHONY: appimage
+appimage:
+	@command -v go >/dev/null || { echo "Go is required: https://go.dev/dl/"; exit 1; }
+	version=$$(grep '^version\s*=' pyproject.toml | sed -E 's/.*=\s*"([^"]+)".*/\1/') \
+	&& mkdir -p dist launcher/assets \
+	&& if [ ! -f launcher/assets/uv-bin ]; then \
+		echo "Fetching uv $(UV_VERSION)..." ; \
+		curl -fsSL -o /tmp/uv-$(UV_VERSION).tar.gz "https://github.com/astral-sh/uv/releases/download/$(UV_VERSION)/uv-x86_64-unknown-linux-gnu.tar.gz" ; \
+		tar -xzf /tmp/uv-$(UV_VERSION).tar.gz --strip-components=1 -C launcher/assets uv-x86_64-unknown-linux-gnu/uv ; \
+		mv launcher/assets/uv launcher/assets/uv-bin ; \
+	fi \
+	&& echo "Building launcher v$$version (uv embedded)..." \
+	&& ( cd launcher && go build -tags embed_uv -ldflags "-X main.version=$$version" -o ../dist/photomap . ) \
+	&& if [ ! -x /tmp/appimagetool ]; then \
+		echo "Fetching appimagetool..." ; \
+		curl -fsSL -o /tmp/appimagetool "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage" ; \
+		chmod +x /tmp/appimagetool ; \
+	fi \
+	&& PATH="/tmp:$$PATH" APPIMAGE_EXTRACT_AND_RUN=1 \
+		INSTALL/launcher/linux/build_appimage.sh \
+		dist/photomap "$$version" "dist/PhotoMapAI-$$version-x86_64.AppImage" \
+		photomap/frontend/static/icons/favicon-32x32.png \
+	&& echo "" \
+	&& echo "Built dist/PhotoMapAI-$$version-x86_64.AppImage"
 
 # Run backend linting with Ruff
 # fix with ruff check photomap tests photomap --fix

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 	@echo "docker-demo      Build the Docker demo site image."
 	@echo "docs             Serve the mkdocs site with live reload."
 	@echo "deploy-docs      Deploy the mkdocs site to GitHub pages."
+	@echo "launcher         Build the launcher binary (fast, no embedded uv) into dist/."
 	@echo "appimage         Build the Linux launcher AppImage into dist/."
 	@echo "backend-lint     Run Python backend linting with Ruff."
 	@echo "frontend-lint    Run JavaScript frontend linting with ESLint and Prettier."
@@ -56,6 +57,18 @@ docs:
 
 deploy-docs:
 	mkdocs gh-deploy
+
+# Build just the launcher binary for fast dev iteration (~1s). No embedded uv,
+# so the binary downloads uv on first run; no packaging. Output: dist/photomap.
+# Run it with `./dist/photomap`. Use `make appimage` for the distributable.
+.PHONY: launcher
+launcher:
+	@command -v go >/dev/null || { echo "Go is required: https://go.dev/dl/"; exit 1; }
+	version=$$(grep '^version\s*=' pyproject.toml | sed -E 's/.*=\s*"([^"]+)".*/\1/') \
+	&& mkdir -p dist \
+	&& echo "Building launcher v$$version (no embedded uv)..." \
+	&& ( cd launcher && go build -ldflags "-X main.version=$$version" -o ../dist/photomap . ) \
+	&& echo "Built dist/photomap"
 
 # Build the Linux launcher AppImage on demand (the same steps CI runs):
 #   1. fetch the pinned uv binary into launcher/assets/uv-bin (cached after first run)

--- a/README.md
+++ b/README.md
@@ -67,92 +67,34 @@ PhotoMap supports most of the other features you would expect, including support
 
 ## Quick Start
 
-Here are quick start instructions for Windows, Mac and Linux users using the automated installer scripts that are provided with this package. For instructions on manual installation, see [Installation](https://lstein.github.io/PhotoMapAI/installation/).
+The easiest way to install PhotoMapAI is the native installer for your platform. **You don't need Python, CUDA, or anything else first** — the installer sets everything up on first launch.
 
-### Windows
+Download the file for your system from the latest [Releases page](https://github.com/lstein/PhotoMapAI/releases) (under **Assets**), where `X.X.X` is the current version:
 
-#### 1. Download and unpack the source code
+| Platform | Download | Install |
+|----------|----------|---------|
+| **macOS** | `PhotoMapAI-X.X.X.dmg` | Open the `.dmg`, drag **PhotoMapAI** to **Applications** |
+| **Windows** | `PhotoMapAI-X.X.X-setup.exe` | Run the installer (no admin rights needed) |
+| **Linux** | `PhotoMapAI-X.X.X-x86_64.AppImage` | `chmod +x` it and double-click, or run from a terminal |
 
-Download the PhotoMap source code as a .zip file from the latest stable [Releases page](https://github.com/lstein/PhotoMapAI/releases). For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMap home page.
+The **first** launch downloads a private copy of Python and the AI libraries (a multi-gigabyte, one-time download that takes a few minutes; a console window shows progress). When it finishes the server starts and your browser opens automatically. Later launches start in seconds. An NVIDIA GPU is detected and used automatically; Apple Silicon acceleration is automatic too.
 
-Choose a convenient location in your home folder and unzip the file to create a new folder named `PhotoMap`.
+For PyPI, Docker, and manual install instructions, see the [Installation guide](https://lstein.github.io/PhotoMapAI/installation/).
 
-#### 2. Run the installer script
+### Install from PyPI (command line)
 
-Navigate to the unpacked `PhotoMap` folder, find the `INSTALL` folder, and double-click the `install_windows` script file. The system will check that Python and other requirements are installed, download the necessary library files, and create a .bat script named `start_photomap`.
+If you already have Python 3.10–3.14 and prefer the command line:
 
-#### 3. [Optional] Install Microsoft C++ Runtime DLLs
-
-Several of PhotoMapAI's dependencies require Microsoft
-C++ Runtime DLLs. If these are not present, the installer will
-attempt to download and install them on your behalf. You will need to relaunch the install script after this is done.
-
-#### 4. Start the server
-
-Double-click `start_photomap.bat` to launch the server. You should see a few startup messages, followed by the URL for the running server.
-
-#### 5. **Open your browser:**
-
-Navigate to `http://localhost:8050` and follow the prompts to create and populate your first album.
-
----
-
-### Linux & Mac
-
-#### 1. Download and unpack the source code
-
-Download the PhotoMap source code as a .zip file from the latest stable [Releases page](https://github.com/lstein/PhotoMapAI/releases). For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMap home page.
-
-Choose a convenient location in your home or downloads directory and unzip the file to create a new folder named `PhotoMap-X.X.X` (where X.X.X is the current release).
-
-#### 2. Run the installer script
-
-Launch a command line shell ("Terminal" on the Mac) and navigate to the `PhotoMap-X.X.X` folder. Launch the `INSTALL/install_linux_mac.sh` shell script file. The script will check that Python and other requirements are installed, download the necessary library files, and create a launcher script named `start_photomap` on your desktop. If you are uncomfortable with the command line, here are the commands you need:
-
-```
-cd ~/Downloads/PhotoMap-X.X.X/INSTALL
-/bin/sh install_linux_mac.sh
+```bash
+uv tool install photomapai --torch-backend auto   # or: pip install photomapai
+start_photomap
 ```
 
-#### 3. Start the server
-
-Double click `start_photomap` to launch the server. You will see a few startup messages followed by the URL for the running server.
-
-#### 4. **Open your browser:**
-
-Navigate to `http://localhost:8050` and follow the prompts to create and populate your first album.
-
-### Manual Install
-
-Follow these instructions if you are comfortable with installing Python packages on the command line.
-
-#### Mac/Linux
-
-Make sure that your version of Python is between 3.10 and 3.13. Other versions are not guaranteed to work.
-
-python3 -m venv ~/photomap --prompt photomap
-source ~/photomap/bin/activate
-python3 -m pip install --upgrade pip
-pip install photomapai
-start_photomap
-
-Then open your web browser and point it to [http://127.0.0.1:8050](http://127.0.0.1:8050). Follow the prompts to create your first album.
-
-#### Windows
-
-Make sure that your version of Python is between 3.10 and 3.13. Other versions are not guaranteed to work. Also make sure that Python is on your PATH.
-
-python3 -m venv C:\Users\<your name>\Documents\photomap --prompt photomap
-C:\Users\<your name>\Documents\photomap\Scripts\activate
-python3 -m pip install --upgrade pip
-pip install photomapai
-start_photomap
-
-Then open your web browser and point it to [http://127.0.0.1:8050](http://127.0.0.1:8050). Follow the prompts to create your first album.
+Then open your browser to [http://127.0.0.1:8050](http://127.0.0.1:8050) (it opens automatically) and follow the prompts to create your first album.
 
 ## Other Installation Methods
 
-In addition to the above, PhotoMapAI can be installed via [Docker](https://lstein.github.io/PhotoMapAI/installation/#docker-install), [PyPi](https://lstein.github.io/PhotoMapAI/installation/#pypi-installation), or a [double-click desktop executable](https://lstein.github.io/PhotoMapAI/installation/#executable-install).
+In addition to the above, PhotoMapAI can be installed via [Docker](https://lstein.github.io/PhotoMapAI/installation/#alternative-docker), [PyPI](https://lstein.github.io/PhotoMapAI/installation/#alternative-install-from-pypi), or [from source](https://lstein.github.io/PhotoMapAI/installation/#manual-installation-from-source).
 
 ## Detailed Guides
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,10 @@ RUN python -c "import clip; clip.load('ViT-B/32')"
 RUN pip cache purge
 RUN rm -rf ./photomap ./build ./dist ./demo_images/photomap_index/
 
+# Never try to open a browser from inside the container (also implied by the
+# 0.0.0.0 bind, but set explicitly so it can't regress).
+ENV PHOTOMAP_NO_BROWSER=1
+
 # Expose the port your app runs on
 EXPOSE 8050
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -73,115 +73,28 @@ PhotoMapAI supports most of the other features you would expect, including suppo
 
 ## Quick Start
 
-Here are instructions for installation on [Windows](#windows), [Linux/Mac](#linux-mac), [From the Python repo](#python-repository), and [Docker](#docker-install)
+The easiest way to install PhotoMapAI is the native installer for your platform. **You don't need Python, CUDA, or anything else first** — the installer sets everything up on first launch. Download the file for your system from the latest [Releases page](https://github.com/lstein/PhotoMapAI/releases) (under **Assets**), where `X.X.X` is the current version:
 
-### Windows
+| Platform | Download | Install |
+|----------|----------|---------|
+| **macOS** | `PhotoMapAI-X.X.X.dmg` | Open the `.dmg`, drag **PhotoMapAI** to **Applications** |
+| **Windows** | `PhotoMapAI-X.X.X-setup.exe` | Run the installer (no admin rights needed) |
+| **Linux** | `PhotoMapAI-X.X.X-x86_64.AppImage` | `chmod +x` it and double-click, or run from a terminal |
 
-#### 1. Download and unpack the source code
+The **first** launch downloads a private copy of Python and the AI libraries (a multi-gigabyte, one-time download that takes a few minutes; a console window shows progress). When it finishes, the server starts and your browser opens automatically to create your first album. Later launches start in seconds. An NVIDIA GPU is detected and used automatically, as is Apple Silicon acceleration.
 
-Download the PhotoMapAI source code as a .zip file from the latest stable Releases page. For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMapAI home page.
+See the [Installation guide](installation.md) for PyPI, Docker, source, GPU overrides, and uninstall details.
 
-Choose a convenient location in your home folder and unzip the file to create a new folder named `PhotoMapAI`.
+### Install from the command line
 
-#### 2. Run the installer script
-
-Navigate to the unpacked `PhotoMapAI` folder, find the `INSTALL` folder, and double-click the `install_windows` script file. The system will check that Python and other requirements are installed, download the necessary library files, and create a .bat script named `start_photomap`.
-
-#### 3. Start the server
-
-Double-click `start_photomap.bat` to launch the server. You should see a few startup messages, followed by the URL for the running server.
-
-#### 4. **Open your browser:**
-
-Navigate to `http://localhost:8050` and follow the prompts to create and populate your first album.
-
----
-
-### Linux & Mac
-
-#### 1. Download and unpack the source code
-
-Download the PhotoMapAI source code as a .zip file from the latest stable Releases page. For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMapAI home page.
-
-Choose a convenient location in your home directory and unzip the file to create a new folder named `PhotoMapAI`.
-
-#### 2. Run the installer script
-
-Navigate to the `PhotoMapAI` folder and launch the `install_linux_mac` shell script file. The script will check that Python and other requirements are installed, download the necessary library files, and create a launcher script named `start_photomap` on your desktop.
-
-#### 3. Start the server
-
-Double click `start_photomap` to launch the server. You will see a few startup messages followed by the URL for the running server.
-
-#### 4. **Open your browser:**
-
-Navigate to `http://localhost:8050` and follow the prompts to create and populate your first album.
-
----
-
-
-### Python Repository
-
-If you are familiar with installing Python packages from the PyPi repo, here is a quick four line recipe:
+If you already have Python 3.10–3.14:
 
 ```bash
-pip -mvenv photomap --prompt photomap
-source photomap/bin/activate
-pip install photomapai
+uv tool install photomapai --torch-backend auto   # or: pip install photomapai
 start_photomap
 ```
 
-After the startup messages, point your browser to http://localhost:8050 and follow the prompts.
-
----
-
-### Docker Install
-
-If you have Docker installed on your system, here is a one-liner to get PhotoMapAI up and running:
-
-```bash
-docker -p 8050:8050 -v /path/to/a/picture_folder:/Pictures lstein/photomapai:latest
-```
-Change `/path/to/a/picture_folder` to a path on your desktop that contains the images/photos you wish to add to an album. After the startup messages, point your browser to http://localhost:8050 and follow the prompts. Your images will be found in the container directory `/Pictures`.
-
----
-
-### Executable Install
-
-As of version 0.9.4, there is also an option to install a prebuilt executable package. This package does not require you to install Python, CUDA, or any other PhotoMapAI dependencies. However, the executable is not yet code-signed, meaning that Windows and Mac users will have to bypass code safety checks.
-
-Go to the latest [release page](https://github.com/lstein/PhotoMapAI/releases) and look under **assets**. There you will find the following files, where X.X.X is replaced by the current released version number:
-
-| Name                              | Platform            | GPU Acceleration |
-|-----------------------------------|---------------------|--------------|
-| photomap-linux-x64-cpu-vX.X.X.zip | Linux | none |
-| photomap-linux-x64-cu129-vX.X.X.zip | Linux | CUDA 12.9 |
-| photomap-macos-x64-cpu-vX.X.X.zip | Macintosh | built-in acceleration|
-| photomap-windows-x64-cpu-vX.X.X.zip | Windows | none|
-| photomap-windows-x64-cu129-vX.X.X.zip | Windows | CUDA 12.9|
-
-If you have an Nvidia card and any of the CUDA 12.X libraries installed, you can take advantage of accelerated image indexing by choosing one of the `cu129` packages. Download the zip file for your platform and unpack it. Then follow these instructions to bypass the operating system's code-checking:
-
-#### Mac
-
-Using the command-line terminal, navigate to the unpacked folder `photomap-macos-x64-cpu-vX.X.X` and run this command:
-
-```bash
-xattr -d com.apple.quarantine ./photomap-macos-x64-cpu-vX.X.X`
-```
-(Use the actual version number, not X.X.X). This step only has to be done once.
-
-Now you can double-click on the package and the PhotoMapAI server will launch in a terminal window after a brief delay.
-
-#### Windows
-
-After unpacking, navigate into the folder and double-click on `photomap.exe`. You will be warned that you are trying to run untrusted code. Click on the `More info` link, and choose `Run anyway`. After a short delay, a new terminal window will open up with the output from the PhotoMapAI server.
-
-You'll need to override the untrusted code check each time you launch PhotoMapAI. 
-
-#### Linux
-
-Using the terminal/command-line shell, navigate to the unpacked folder and run `./photomap`. No trusted code workarounds are needed. If you prefer to double-click an icon, there is a `run_photomap.sh` script in the folder that will launch a terminal for you and run PhotoMapAI inside it.
+After the startup messages your browser opens to http://localhost:8050 automatically.
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,217 +10,111 @@ PhotoMapAI is a [Python](https://www.python.org/)-based web application that use
 * **CPU**: Any recent (post-2020) Intel or Apple CPU.
 * **GPU**: NVidia graphics card (optional)
 
-If an NVidia graphics card is available, then PhotoMapAI will take advantage of it during the initial indexing of your photo collection for a 10x increase in indexing speed. You may need to install additional libraries to take advantage of this feature as described below.
-
-PhotoMapAI will take advantage of the built-in GPU acceleration on Apple M1, M2 and M3 chips.
-
-## Installing Prerequisites
-
-Before installing PhotoMapAI, you'll need to install Python and optionally CUDA.
-
-- [Python](installation/python.md)
-- [CUDA](installation/cuda.md) (*Only if you need NVidia GPU card support*)
-
-After the preqrequisites are installed, follow the installation directions for [Linux & MacOS](#linux-macos) or [Windows](#windows). For those who are comfortable with the command shell, there are also instructions for [Manual Install](#manual-installation) and [Docker Install](#docker-install).
-
-Finally, there are a series of experimental double-click executables for all three platforms. See [Executable Install](#executable-install) for details.
+If an NVidia graphics card is available, PhotoMapAI uses it during the initial indexing of your photo collection for roughly a 10x speedup. The installer handles this for you automatically (see [GPU acceleration](#gpu-acceleration)). PhotoMapAI also uses the built-in GPU acceleration on Apple M-series chips.
 
 ---
 
+## Recommended: the desktop installer
 
-## Windows
+The easiest way to install PhotoMapAI is the native installer for your platform. **You do not need to install Python, CUDA, or anything else first** — the installer sets up everything on first launch.
 
-### 1. Download and unpack the source code
+Download the file for your platform from the latest [release page](https://github.com/lstein/PhotoMapAI/releases) (under **Assets**), where `X.X.X` is the current version:
 
-Download the PhotoMapAI source code as a .zip file from the latest stable Releases page. For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMapAI home page.
+| Platform | Download | Install |
+|----------|----------|---------|
+| **macOS** | `PhotoMapAI-X.X.X.dmg` | Open the `.dmg` and drag **PhotoMapAI** to **Applications** |
+| **Windows** | `PhotoMapAI-X.X.X-setup.exe` | Run the installer (no administrator rights needed) |
+| **Linux** | `PhotoMapAI-X.X.X-x86_64.AppImage` | Make it executable (`chmod +x`) and double-click, or run it from a terminal |
 
-Choose a convenient location in your home folder and unzip the file to create a new folder named `PhotoMapAI`.
+### First launch
 
-### 2. Run the installer script
+The first time you start PhotoMapAI, it downloads a private copy of Python and the AI libraries it needs. **This is a multi-gigabyte, one-time download that can take several minutes** — a console window shows the progress. When it finishes, the server starts and your web browser opens to the app automatically.
 
-Navigate to the unpacked `PhotoMapAI` folder, find the `INSTALL` folder, and double-click the `install_windows` script file. The system will check that Python and other requirements are installed, download the necessary library files, and create a .bat script named `start_photomap`.
+Every later launch skips that step and starts in a second or two.
 
-### 3. [Optional] Install Microsoft C++ Runtime DLLs
+Everything the installer downloads lives in a single per-user folder, so uninstalling is clean (see [Uninstalling](#uninstalling)). Your albums and settings are stored separately and are preserved across upgrades and reinstalls.
 
-Several of PhotoMapAI's dependencies require Microsoft
-C++ Runtime DLLs. If these are not present, the installer will
-attempt to download and install them on your behalf. You will need to relaunch the install script after this is done.
+### GPU acceleration
 
-### 4. Start the server
+On first run the installer auto-detects an NVIDIA GPU and installs the matching GPU-accelerated libraries; if there's no GPU it installs the CPU version. Apple Silicon acceleration is automatic. You normally don't need to do anything.
 
-Double-click `start_photomap.bat` to launch the server. You should see a few startup messages, followed by the URL for the running server. Cut and paste this into your browser, and follow the prompts to configure and index your first album. See [Albums](user-guide/albums.md) for a walkthrough.
-
-### 5. Exiting and relaunching
-
-To exit the server, press ^C (control-C). 
-
-To relaunch the server, run the `start_photomap` .bat script again. For your convenience, you may move this script anywhere you like. Don't move the PhotoMapAI folder, or the script will not be able to find it again. If this happens, simply re-run the installer script to generate an updated launcher.
-
----
-
-## Linux & MacOS
-
-### 1. Download and unpack the source code
-
-Download the PhotoMapAI source code as a .zip file from the latest stable Releases page. For development versions, use the "Download ZIP" link in the green "Code" button near the top of the GitHub PhotoMapAI home page.
-
-Choose a convenient location in your Downloads directory and unzip the file to create a new folder named `PhotoMapAI-X.X.X`, where X.X.X is the current release number
-
-### 2. Run the installer script
-
-Launch a command-line shell ("Terminal" on the Mac) and navigate to the `PhotoMap-X.X.X` folder. Launch the `INSTALL/install_linux_mac.sh` shell script file. The script will check that Python and other requirements are installed, download the necessary library files, and create a launcher script named `start_photomap` on your desktop. If you are uncomfortable with the command line, here are the commands you need:
-
-```
-cd ~/Downloads/PhotoMap-X.X.X/INSTALL
-/bin/sh install_linux_mac.sh
-```
-
-### 3. Start the server
-
-Double click `start_photomap` to launch the server. You will see a few startup messages followed by the URL for the running server. Cut and paste this into your browser and follow the prompts to configure and index your first album. See [Albums](user-guide/albums.md) for a walkthrough.
-
-### 4. Exiting and relaunching
-
-To exit the server, press ^C (control-C). 
-
-To relaunch the server, run the `start_photomap` launcher again. For your convenience, you may move this script anywhere you like. If you move the PhotoMapAI folder itself, you will need to re-run the installer script.
-
----
-
-## PyPi  Installation
-
-If you are familiar with installing Python packages, here is a quick recipe:
+If you need to override the automatic choice (for example you added a GPU later, or want to force CPU mode), launch the app from a terminal with a flag:
 
 ```bash
-python -mvenv photomap --prompt photomap
-source photomap/bin/activate
+# macOS app:   PhotoMapAI.app/Contents/Resources/photomap
+# Windows:     %LOCALAPPDATA%\Programs\PhotoMapAI\photomap.exe
+# Linux:       ./PhotoMapAI-X.X.X-x86_64.AppImage
+
+photomap --gpu     # re-detect and use an NVIDIA GPU
+photomap --cpu     # force the CPU-only build
+```
+
+### Security warnings
+
+The macOS and Windows installers are code-signed, so they should open without warnings. On Windows, a brand-new release may still briefly show a SmartScreen "Windows protected your PC" prompt until the download builds reputation — click **More info → Run anyway**. On Linux, AppImages are not signed; just make the file executable.
+
+### Uninstalling
+
+- **Windows:** uninstall "PhotoMapAI" from *Settings → Apps*.
+- **macOS:** drag **PhotoMapAI** from Applications to the Trash.
+- **Linux:** delete the `.AppImage`.
+
+To also remove the downloaded Python/libraries, run `photomap --uninstall` (paths above) before deleting the app, or delete the runtime folder manually:
+
+| OS | Runtime folder |
+|----|----------------|
+| Windows | `%LOCALAPPDATA%\PhotoMapAI` |
+| macOS | `~/Library/Application Support/PhotoMapAI` |
+| Linux | `~/.local/share/PhotoMapAI` |
+
+---
+
+## Alternative: install from PyPI
+
+If you are comfortable with the command line and already have Python 3.10–3.14, you can install the package directly. We recommend [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install photomapai --torch-backend auto
+start_photomap
+```
+
+`--torch-backend auto` picks GPU or CPU PyTorch automatically. Or with plain `pip` in a virtual environment:
+
+```bash
+python -m venv photomap --prompt photomap
+source photomap/bin/activate          # Windows: photomap\Scripts\activate
 pip install --upgrade pip
 pip install photomapai
 start_photomap
 ```
 
-After the startup messages, point your browser to http://localhost:8050 and follow the prompts.
+After the startup messages, your browser opens to `http://localhost:8050` automatically. (Pass `--no-browser`, or set `PHOTOMAP_NO_BROWSER=1`, to suppress that.)
 
 ---
 
-## Manual Installation
+## Alternative: Docker
 
-Download and unpack the source code as described in the sections above. Then follow these steps:
-
-### 1. Create an installation directory for the executables
-
-In a command line window, enter the PhotoMapAI folder and run the `pip` (Python package installer) command to create a home for the PhotoMapAI executable and library files:
-
-```bash
-cd ~/PhotoMapAI
-pip -mvenv install --prompt photomap
-```
-
-### 2. Activate the folder for installation:
-
-```bash
-source install/bin/activate
-```
-
-Your system prompt should change to read `(photomap)` at this point.
-
-### 3. Install a CUDA enabled version of PyTorch (Optional: Windows only)
-
-If you have an NVidia graphics card, are installing on a Windows machine, and have the [CUDA Library](installation/cuda.md) installed, you can take advantage of GPU acceleration by installing a CUDA-enabled version of the PyTorch machine learning library used by PhotoMapAI during photo indexing. *This step is not required for Linux or Macintosh systems, which will take advantage of GPU hardware acceleration automatically.*
-
-Go to https://pytorch.org/get-started/locally/ and use the version selector to choose the version of PyTorch that matches your CUDA library version. Then issue the recommended installation command, e.g.
-
-```bash
-pip install torch torchvision --index-url https://download.pytorch.org/whl/cu129
-```
-
-If you initially installed the CPU-only version of PyTorch, don't despair. You can come back and install CUDA PyTorch at any time.
-
-### 4. Install PhotoMapAI and its libraries:
-
-```bash
-pip install .
-```
-
-This will download and install all the libraries that PhotoMapAI requires. Depending on your internet speed, this may take a while.
-
-### 4. Launch the PhotoMapAI application.
-
-If installation completed without errors, launch the PhotoMapAI server with the `start_photomap` command:
-
-```bash
-start_photomap
-```
-
-You should see a few startup messages, followed by the URL for the running server. Cut and paste this into your browser, and follow the prompts to configure and index your first album. See [Albums](user-guide/albums.md) for a walkthrough.
-
-### 5. Exiting and relaunching
-
-To exit the server, press ^C (control-C). 
-
-To launch the server again, run its executable.
-
-On Windows:
-
-```bash
-C:\path\to\PhotoMapAI\install\scripts\start_photomap.exe
-```
-
-On Linux/MacOS:
-
-```
-bash
-/path/to/PhotoMapAI/install/bin/start_photomap
-```
-
-You can also just use the file browser to navigate to the `start_photomap` executable and double-click it.
-
----
-
-### Docker Install
-
-If you have Docker installed on your system, here is a one-liner to get PhotoMapAI up and running:
+If you have Docker installed:
 
 ```bash
 docker run -p 8050:8050 -v /path/to/a/picture_folder:/Pictures lstein/photomapai:latest
 ```
-Change `/path/to/a/picture_folder` to a path on your desktop that contains the images/photos you wish to add to an album. After the startup messages, point your browser to http://localhost:8050 and follow the prompts. Your images will be found in the container directory `/Pictures`.
+
+Change `/path/to/a/picture_folder` to a folder of images you want to browse, then point your browser to `http://localhost:8050`. Your images appear in the container directory `/Pictures`.
 
 ---
 
-## Executable Install
+## Manual installation from source
 
-As of version 0.9.4, there is also an option to install a prebuilt executable package. This package does not require you to install Python, CUDA, or any other PhotoMapAI dependencies. However, the executable is not yet code-signed, meaning that Windows and Mac users will have to bypass code safety checks.
-
-Go to the latest [release page](https://github.com/lstein/PhotoMapAI/releases) and look under **assets**. There you will find the following files, where X.X.X is replaced by the current released version number:
-
-| Name                              | Platform            | GPU Acceleration |
-|-----------------------------------|---------------------|--------------|
-| photomap-linux-x64-cpu-vX.X.X.zip | Linux | none |
-| photomap-linux-x64-cu129-vX.X.X.zip | Linux | CUDA 12.9 |
-| photomap-macos-x64-cpu-vX.X.X.zip | Macintosh | built-in acceleration|
-| photomap-windows-x64-cpu-vX.X.X.zip | Windows | none|
-| photomap-windows-x64-cu129-vX.X.X.zip | Windows | CUDA 12.9|
-
-If you have an Nvidia card and any of the CUDA 12.X libraries installed, you can take advantage of accelerated image indexing by choosing one of the `cu129` packages. Download the zip file for your platform and unpack it. Then follow these instructions to bypass the operating system's code-checking:
-
-#### Mac
-
-Using the command-line terminal, navigate to the unpacked folder `photomap-macos-x64-cpu-vX.X.X` and run this command:
+Download and unpack the source from the [release page](https://github.com/lstein/PhotoMapAI/releases), then:
 
 ```bash
-xattr -d com.apple.quarantine ./photomap-macos-x64-cpu-vX.X.X`
+cd PhotoMapAI
+python -m venv .venv --prompt photomap
+source .venv/bin/activate             # Windows: .venv\Scripts\activate
+pip install --upgrade pip
+pip install .
+start_photomap
 ```
-(Use the actual version number, not X.X.X). This step only has to be done once.
 
-Now you can double-click on the package and the PhotoMapAI server will launch in a terminal window after a brief delay.
-
-#### Windows
-
-After unpacking, navigate into the folder and double-click on `photomap.exe`. You will be warned that you are trying to run untrusted code. Click on the `More info` link, and choose `Run anyway`. After a short delay, a new terminal window will open up with the output from the PhotoMapAI server.
-
-You'll need to override the untrusted code check each time you launch PhotoMapAI. 
-
-#### Linux
-
-Using the terminal/command-line shell, navigate to the unpacked folder and run `./photomap`. No trusted code workarounds are needed. If you prefer to double-click an icon, there is a `run_photomap.sh` script in the folder that will launch a terminal for you and run PhotoMapAI inside it.
+If you have an NVidia card on Windows and want GPU acceleration, install a CUDA build of PyTorch first (see [CUDA](installation/cuda.md)); on Linux and macOS this is handled automatically. To start the server again later, re-run `start_photomap` from the activated environment.

--- a/launcher/README.md
+++ b/launcher/README.md
@@ -1,0 +1,106 @@
+# PhotoMapAI desktop launcher
+
+A small native launcher (Go) that gives non-technical users a single signed
+double-click install. On first run it uses [uv](https://docs.astral.sh/uv/) to
+install a managed CPython and the `photomapai` package into a per-user runtime
+directory, streaming progress to the console. On every run it starts the server
+and opens the browser once it's accepting connections.
+
+The launcher deliberately does **not** bundle PyTorch — that multi-GB stack is
+fetched by uv at first run. This keeps the signed/notarized artifact tiny.
+
+## What it manages, and where
+
+Everything lives under one runtime root so uninstall is a single delete:
+
+| OS      | Runtime root                                              |
+|---------|----------------------------------------------------------|
+| Windows | `%LOCALAPPDATA%\PhotoMapAI\runtime`                       |
+| macOS   | `~/Library/Application Support/PhotoMapAI/runtime`        |
+| Linux   | `$XDG_DATA_HOME/PhotoMapAI/runtime` (`~/.local/share/…`)  |
+
+The existing app **config** directory (`photomap`, via platformdirs) is left
+untouched, so albums carry over for existing users.
+
+## Flags
+
+```
+--gpu              re-detect and use an NVIDIA GPU if available, then run
+--cpu              force the CPU-only build, then run
+--torch-backend X  advanced: uv torch backend (auto|cpu|cu130|cu129|…)
+--reinstall        force a clean reinstall, then run
+--uninstall        remove the install and all runtime files, then exit
+--no-browser       start the server but don't open a browser
+--version          print the launcher version and exit
+```
+
+First run with no flags uses `uv tool install --torch-backend auto`: uv detects
+an NVIDIA GPU and installs the matching CUDA wheels, falling back to CPU when
+there's no GPU — so the common case needs no choice and there's no CUDA index
+version to maintain. `--cpu` forces CPU (e.g. to avoid a flaky driver); `--gpu`
+re-detects after adding a GPU; `--torch-backend` pins a specific backend.
+
+### Passing options to the server
+
+The launcher inherits the environment, so the server's env vars work as usual:
+
+```
+PHOTOMAP_PORT=9000 photomap        # run on a different port
+PHOTOMAP_HOST=0.0.0.0 photomap     # bind all interfaces (LAN access)
+PHOTOMAP_CONFIG=/path/config.yaml photomap
+```
+
+The launcher reads `PHOTOMAP_PORT` / `PHOTOMAP_HOST` itself too, so its readiness
+check and the browser it opens follow the server. For other server flags, put
+them after a `--` separator:
+
+```
+photomap -- --album-locked vacation
+```
+
+### Where things live
+
+- **Config / albums:** the app's normal config dir (unchanged by the launcher):
+  `~/.config/photomap/config.yaml` (Linux), `~/Library/Application
+  Support/photomap/config.yaml` (macOS), `%APPDATA%\photomap\photomap\config.yaml`
+  (Windows). Override with `PHOTOMAP_CONFIG`.
+- **Runtime** (managed Python, venv, uv cache): see the table above; removed by
+  `--uninstall`.
+
+## Building
+
+Plain build (no embedded uv — falls back to a uv on `PATH`, else downloads one
+at first run). Good for local development:
+
+```bash
+cd launcher
+go build -o photomap .
+go test ./...            # add -short to skip the network integration test
+```
+
+Release build with uv embedded (what CI does). Fetch the matching uv release
+binary into `assets/uv-bin` first, then build with the `embed_uv` tag:
+
+```bash
+# example for the host platform; CI does this per OS/arch
+curl -L -o /tmp/uv.tar.gz \
+  https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-unknown-linux-gnu.tar.gz
+tar -xzf /tmp/uv.tar.gz --strip-components=1 -C assets   # yields assets/uv
+mv assets/uv assets/uv-bin                               # assets/uv-bin(.exe on Windows)
+
+go build -tags embed_uv -ldflags "-X main.version=$VERSION" -o photomap .
+```
+
+`assets/` is gitignored except this note — the uv binary is never committed.
+
+## Maintenance notes
+
+- **torch backend:** the launcher passes `--torch-backend auto`; uv selects the
+  CPU/CUDA wheels per machine, so there's no CUDA index version to track. Requires
+  a uv new enough to support `--torch-backend` on `uv tool install` (uv ≥ 0.8;
+  verified on 0.11.x).
+- **uv version:** the embedded uv is whatever CI fetched (`latest`). Pin the URL
+  to a specific uv release tag if you want reproducible builds.
+- **Package pin:** `pkgName` in `uv.go` is unpinned (`photomapai`), so users get
+  the latest on install and via `uv tool upgrade`. Pin to `photomapai==X.Y.Z`
+  for first-run reproducibility tied to a launcher release.

--- a/launcher/browser.go
+++ b/launcher/browser.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// openBrowser opens url in the user's default browser, per platform.
+func openBrowser(url string) error {
+	switch runtime.GOOS {
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		return exec.Command("open", url).Start()
+	default:
+		return exec.Command("xdg-open", url).Start()
+	}
+}
+
+// waitForServer blocks until host:port accepts a TCP connection or timeout elapses.
+func waitForServer(host, port string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	addr := net.JoinHostPort(host, port)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return false
+}
+
+// openWhenReady waits for the server, then opens the browser. Intended to run in
+// a goroutine while the server process is supervised in the foreground.
+func openWhenReady(host, port string, noBrowser bool) {
+	if !waitForServer(host, port, 60*time.Second) {
+		fmt.Println("Server did not become ready in time; open it manually once it starts.")
+		return
+	}
+	url := fmt.Sprintf("http://%s:%s", host, port)
+	if noBrowser {
+		fmt.Printf("\nPhotoMapAI is running. Open %s in your browser.\n", url)
+		return
+	}
+	fmt.Printf("\nPhotoMapAI is running. Opening %s ...\n", url)
+	if err := openBrowser(url); err != nil {
+		fmt.Printf("Could not open a browser automatically. Open %s manually.\n", url)
+	}
+}

--- a/launcher/embed_off.go
+++ b/launcher/embed_off.go
@@ -1,0 +1,9 @@
+//go:build !embed_uv
+
+package main
+
+// embeddedUV is empty in normal builds. `go build ./...` works without any
+// vendored binary, and the launcher falls back to a uv on PATH or a download.
+// Release builds pass `-tags embed_uv` after CI drops the real binary into
+// assets/ (see embed_on.go and launcher/README.md).
+var embeddedUV []byte

--- a/launcher/embed_on.go
+++ b/launcher/embed_on.go
@@ -1,0 +1,14 @@
+//go:build embed_uv
+
+package main
+
+import _ "embed"
+
+// embeddedUV is the uv binary for the target platform, baked into the launcher
+// at build time. CI downloads the matching uv release into assets/uv-bin
+// (assets/uv-bin.exe on Windows is copied to this same name) before building
+// with `-tags embed_uv`. Bundling keeps uv inside the code-signing boundary and
+// removes a network dependency from the most fragile (first-run) step.
+//
+//go:embed assets/uv-bin
+var embeddedUV []byte

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -1,0 +1,3 @@
+module github.com/lstein/PhotoMapAI/launcher
+
+go 1.22

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -1,0 +1,178 @@
+// Command photomap is the PhotoMapAI desktop launcher.
+//
+// On first run it uses a bundled (or downloaded) uv to install a managed CPython
+// and the photomapai package into a per-user runtime directory, streaming
+// progress to the console. On every run it starts the server and opens the
+// browser once the server is accepting connections.
+//
+// Flags:
+//
+//	--gpu         install / switch to the CUDA (NVIDIA) torch build, then run
+//	--cpu         install / switch to the CPU torch build, then run
+//	--reinstall   force a clean reinstall, then run
+//	--uninstall   remove the photomapai install and all runtime files, then exit
+//	--no-browser  start the server but don't open a browser
+//	--version     print the launcher version and exit
+//
+// Anything after a "--" separator is passed straight through to start_photomap,
+// e.g. `photomap -- --album-locked vacation`. The server port/host come from the
+// PHOTOMAP_PORT / PHOTOMAP_HOST environment variables (the launcher reads them
+// too, so its readiness check and the browser it opens stay in sync).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+)
+
+// version is stamped at build time via -ldflags "-X main.version=...".
+var version = "dev"
+
+const (
+	defaultServerHost = "127.0.0.1"
+	defaultServerPort = "8050"
+)
+
+// envOr returns the environment value for key, or def when unset/empty.
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func main() {
+	var (
+		gpu          = flag.Bool("gpu", false, "re-detect and use an NVIDIA GPU if available")
+		cpu          = flag.Bool("cpu", false, "force the CPU-only build")
+		torchBackend = flag.String("torch-backend", "", "advanced: uv torch backend (auto|cpu|cu130|cu129|…)")
+		reinstall    = flag.Bool("reinstall", false, "force a clean reinstall before running")
+		doUninst     = flag.Bool("uninstall", false, "remove PhotoMapAI and all runtime files")
+		noBrowser    = flag.Bool("no-browser", false, "do not open a web browser on startup")
+		showVer      = flag.Bool("version", false, "print the launcher version and exit")
+	)
+	flag.Parse()
+
+	if *showVer {
+		fmt.Printf("PhotoMapAI launcher %s\n", version)
+		return
+	}
+
+	// Anything after "--" is forwarded verbatim to start_photomap.
+	serverArgs := flag.Args()
+
+	if err := run(*gpu, *cpu, *torchBackend, *reinstall, *doUninst, *noBrowser, serverArgs); err != nil {
+		fmt.Fprintf(os.Stderr, "\nError: %v\n", err)
+		pause()
+		os.Exit(1)
+	}
+}
+
+func run(gpu, cpu bool, torchBackend string, reinstall, doUninst, noBrowser bool, serverArgs []string) error {
+	l, err := newLayout()
+	if err != nil {
+		return err
+	}
+	if err := l.mkdirs(); err != nil {
+		return err
+	}
+
+	if doUninst {
+		return uninstall(l)
+	}
+
+	if err := ensureUV(l); err != nil {
+		return fmt.Errorf("setting up uv: %w", err)
+	}
+
+	// Decide the torch backend and whether (re)install is needed.
+	current := installedBackend(l)
+	target := current
+	switch {
+	case torchBackend != "":
+		target = torchBackend // explicit advanced override
+	case gpu:
+		target = "auto" // re-detect; uv picks CUDA when a GPU is present
+	case cpu:
+		target = "cpu"
+	case current == "":
+		target = defaultTorchBackend // first run: auto-detect GPU, else CPU
+	}
+
+	needInstall := reinstall || current == "" || target != current
+	if needInstall {
+		force := reinstall || (current != "" && target != current)
+		if err := install(l, target, force); err != nil {
+			return err
+		}
+		fmt.Println("\nSetup complete.")
+	}
+
+	return launchServer(l, noBrowser, serverArgs)
+}
+
+// launchServer starts the server (with --no-browser so the launcher owns the
+// browser open), opens the browser when it's ready, and forwards Ctrl+C.
+func launchServer(l layout, noBrowser bool, serverArgs []string) error {
+	bin := l.startPhotomap()
+	if !fileExists(bin) {
+		return fmt.Errorf("start_photomap not found at %s; try --reinstall", bin)
+	}
+
+	cmd := exec.Command(bin, serverArgs...)
+	// Run from a neutral directory: the server re-spawns itself with
+	// `python -m photomap...`, which puts the current directory first on sys.path.
+	// If the launcher were started from a folder containing a `photomap/` package
+	// (e.g. a source checkout), that stray copy would shadow the installed one.
+	cmd.Dir = l.root
+	// Suppress the server's own browser-opening via env rather than a CLI flag, so
+	// the launcher works with any photomapai version: older releases have no
+	// auto-open and ignore it, newer releases honor it. The launcher opens the
+	// browser itself once the port is accepting connections.
+	cmd.Env = append(os.Environ(), "PHOTOMAP_NO_BROWSER=1")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting server: %w", err)
+	}
+
+	// Read host/port from the same env the server uses, so the readiness poll and
+	// the browser we open match where the server actually binds. A wildcard bind
+	// is browsed via loopback.
+	host := envOr("PHOTOMAP_HOST", defaultServerHost)
+	port := envOr("PHOTOMAP_PORT", defaultServerPort)
+	if host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	go openWhenReady(host, port, noBrowser)
+
+	// Forward interrupts to the server so Ctrl+C shuts it down cleanly. A shutdown
+	// we initiated is not an error, so we don't want to show the error/pause path.
+	var shuttingDown atomic.Bool
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigc
+		shuttingDown.Store(true)
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+	}()
+
+	err := cmd.Wait()
+	if shuttingDown.Load() {
+		return nil
+	}
+	return err
+}
+
+// pause keeps the console window open on error so the user can read the message.
+func pause() {
+	fmt.Print("\nPress Enter to close...")
+	fmt.Scanln()
+}

--- a/launcher/paths.go
+++ b/launcher/paths.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// appName is the per-user directory name for all launcher-managed state.
+const appName = "PhotoMapAI"
+
+// layout describes every path the launcher cares about. Everything lives under a
+// single runtime root so that "uninstall" is a single directory removal.
+type layout struct {
+	root      string // <dataDir>/PhotoMapAI/runtime
+	uvBin     string // the uv executable itself
+	pythonDir string // UV_PYTHON_INSTALL_DIR (managed CPython)
+	toolDir   string // UV_TOOL_DIR (the photomapai tool venv)
+	toolBin   string // UV_TOOL_BIN_DIR (start_photomap entry point lands here)
+	cacheDir  string // UV_CACHE_DIR (kept inside root so it's cleaned on uninstall)
+	marker    string // records that install completed and which torch backend
+}
+
+// dataDir returns the per-user data directory, following each platform's
+// convention (mirrors what the Python app does with platformdirs):
+//
+//	Windows  %LOCALAPPDATA%
+//	macOS    ~/Library/Application Support
+//	Linux    $XDG_DATA_HOME or ~/.local/share
+func dataDir() (string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		if d := os.Getenv("LOCALAPPDATA"); d != "" {
+			return d, nil
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, "AppData", "Local"), nil
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, "Library", "Application Support"), nil
+	default: // linux and friends
+		if d := os.Getenv("XDG_DATA_HOME"); d != "" {
+			return d, nil
+		}
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".local", "share"), nil
+	}
+}
+
+func exeName(base string) string {
+	if runtime.GOOS == "windows" {
+		return base + ".exe"
+	}
+	return base
+}
+
+func newLayout() (layout, error) {
+	data, err := dataDir()
+	if err != nil {
+		return layout{}, err
+	}
+	root := filepath.Join(data, appName, "runtime")
+	return layout{
+		root:      root,
+		uvBin:     filepath.Join(root, "bin", exeName("uv")),
+		pythonDir: filepath.Join(root, "python"),
+		toolDir:   filepath.Join(root, "tools"),
+		toolBin:   filepath.Join(root, "toolbin"),
+		cacheDir:  filepath.Join(root, "cache"),
+		marker:    filepath.Join(root, ".installed"),
+	}, nil
+}
+
+// mkdirs creates every directory the launcher writes into.
+func (l layout) mkdirs() error {
+	for _, d := range []string{
+		filepath.Dir(l.uvBin), l.pythonDir, l.toolDir, l.toolBin, l.cacheDir,
+	} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// startPhotomap is the path to the installed server entry point.
+func (l layout) startPhotomap() string {
+	return filepath.Join(l.toolBin, exeName("start_photomap"))
+}

--- a/launcher/uv.go
+++ b/launcher/uv.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	// pinned interpreter — uv downloads a managed CPython of this version.
+	pythonVersion = "3.12"
+
+	// PyPI package to install. Left unpinned so `uv tool upgrade` can move users
+	// forward; pin to e.g. "photomapai==1.2.3" here if you want first-run
+	// reproducibility tied to a launcher release.
+	pkgName = "photomapai"
+
+	// Default PyTorch backend passed to `uv tool install --torch-backend`.
+	// "auto" lets uv detect an NVIDIA GPU and install the matching CUDA wheels,
+	// falling back to CPU when there's no GPU — so the common case needs no manual
+	// choice and there's no CUDA index version to keep up to date. Override with
+	// --cpu or --torch-backend (auto|cpu|cu130|cu129|…).
+	defaultTorchBackend = "auto"
+
+	uvLatestBase = "https://github.com/astral-sh/uv/releases/latest/download/"
+)
+
+// uvEnv returns the process environment with all uv state redirected under the
+// runtime root, so nothing leaks into the user's global uv cache/tools.
+func (l layout) uvEnv() []string {
+	env := os.Environ()
+	env = append(env,
+		"UV_PYTHON_INSTALL_DIR="+l.pythonDir,
+		"UV_TOOL_DIR="+l.toolDir,
+		"UV_TOOL_BIN_DIR="+l.toolBin,
+		"UV_CACHE_DIR="+l.cacheDir,
+		// Don't let a managed-Python download be disabled by inherited config.
+		"UV_PYTHON_DOWNLOADS=automatic",
+	)
+	return env
+}
+
+// runUV runs uv with the given arguments, streaming its output to our console.
+func (l layout) runUV(args ...string) error {
+	cmd := exec.Command(l.uvBin, args...)
+	cmd.Env = l.uvEnv()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+// ensureUV makes sure a usable uv binary exists at l.uvBin. It prefers an
+// already-materialized copy, then the embedded binary (release builds), then a
+// download. A uv that happens to be on PATH is deliberately NOT used: it may be
+// too old to support flags we rely on (e.g. `--torch-backend`), and the whole
+// point of bundling is to pin a uv version we've tested against.
+func ensureUV(l layout) error {
+	if fileExists(l.uvBin) {
+		return nil
+	}
+	if len(embeddedUV) > 0 {
+		fmt.Println("Setting up the package manager...")
+		return writeExecutable(l.uvBin, embeddedUV)
+	}
+	fmt.Println("Downloading the package manager (uv)...")
+	return downloadUV(l)
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	return err == nil && !info.IsDir()
+}
+
+func writeExecutable(dst string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(dst, data, 0o755); err != nil {
+		return err
+	}
+	return os.Chmod(dst, 0o755)
+}
+
+// uvAsset returns the uv release asset filename for the running platform and
+// whether it is a zip (Windows) versus a tar.gz (Unix).
+func uvAsset() (name string, isZip bool, err error) {
+	var triple string
+	switch runtime.GOOS {
+	case "linux":
+		switch runtime.GOARCH {
+		case "amd64":
+			triple = "x86_64-unknown-linux-gnu"
+		case "arm64":
+			triple = "aarch64-unknown-linux-gnu"
+		}
+	case "darwin":
+		switch runtime.GOARCH {
+		case "amd64":
+			triple = "x86_64-apple-darwin"
+		case "arm64":
+			triple = "aarch64-apple-darwin"
+		}
+	case "windows":
+		switch runtime.GOARCH {
+		case "amd64":
+			return "uv-x86_64-pc-windows-msvc.zip", true, nil
+		case "arm64":
+			return "uv-aarch64-pc-windows-msvc.zip", true, nil
+		}
+	}
+	if triple == "" {
+		return "", false, fmt.Errorf("unsupported platform %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	return "uv-" + triple + ".tar.gz", false, nil
+}
+
+func downloadUV(l layout) error {
+	asset, isZip, err := uvAsset()
+	if err != nil {
+		return err
+	}
+	resp, err := http.Get(uvLatestBase + asset)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("downloading uv: HTTP %d", resp.StatusCode)
+	}
+	if isZip {
+		return extractUVFromZip(resp.Body, l.uvBin)
+	}
+	return extractUVFromTarGz(resp.Body, l.uvBin)
+}
+
+// isUVBinary reports whether an archive member is the uv executable itself.
+func isUVBinary(name string) bool {
+	base := path.Base(name)
+	return base == "uv" || base == "uv.exe"
+}
+
+func extractUVFromTarGz(r io.Reader, dst string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if hdr.Typeflag == tar.TypeReg && isUVBinary(hdr.Name) {
+			data, err := io.ReadAll(tr)
+			if err != nil {
+				return err
+			}
+			return writeExecutable(dst, data)
+		}
+	}
+	return fmt.Errorf("uv binary not found in archive")
+}
+
+func extractUVFromZip(r io.Reader, dst string) error {
+	// zip requires a ReaderAt; buffer the (small) archive into memory.
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	zr, err := zip.NewReader(asReaderAt(data), int64(len(data)))
+	if err != nil {
+		return err
+	}
+	for _, f := range zr.File {
+		if isUVBinary(f.Name) {
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+			out, err := io.ReadAll(rc)
+			if err != nil {
+				return err
+			}
+			return writeExecutable(dst, out)
+		}
+	}
+	return fmt.Errorf("uv binary not found in archive")
+}
+
+// asReaderAt adapts a byte slice to io.ReaderAt for archive/zip.
+type byteReaderAt []byte
+
+func (b byteReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(b)) {
+		return 0, io.EOF
+	}
+	n := copy(p, b[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func asReaderAt(data []byte) io.ReaderAt { return byteReaderAt(data) }
+
+// installedBackend reads the marker file (the torch backend used for the current
+// install), returning "" if photomapai isn't installed yet.
+func installedBackend(l layout) string {
+	data, err := os.ReadFile(l.marker)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func writeMarker(l layout, torchBackend string) error {
+	return os.WriteFile(l.marker, []byte(torchBackend+"\n"), 0o644)
+}
+
+// install runs the uv steps to put photomapai on disk with the requested torch
+// backend. reinstall forces uv to replace an existing install (used when
+// switching backend or recovering a broken install).
+func install(l layout, torchBackend string, reinstall bool) error {
+	fmt.Printf("\nFirst-time setup: downloading Python and the PhotoMapAI libraries.\n")
+	fmt.Printf("This is a multi-GB download and runs once; it can take several minutes.\n\n")
+
+	if err := l.runUV("python", "install", pythonVersion); err != nil {
+		return fmt.Errorf("installing Python: %w", err)
+	}
+
+	args := []string{
+		"tool", "install", pkgName,
+		"--python", pythonVersion,
+		"--torch-backend", torchBackend,
+	}
+	if reinstall {
+		args = append(args, "--reinstall")
+	}
+	if err := l.runUV(args...); err != nil {
+		return fmt.Errorf("installing %s: %w", pkgName, err)
+	}
+	return writeMarker(l, torchBackend)
+}
+
+// uninstall removes the photomapai tool and the entire runtime root.
+func uninstall(l layout) error {
+	if fileExists(l.uvBin) {
+		// Best effort; ignore errors since we're about to delete the tree anyway.
+		_ = l.runUV("tool", "uninstall", pkgName)
+	}
+	fmt.Printf("Removing %s...\n", l.root)
+	return os.RemoveAll(l.root)
+}

--- a/launcher/uv_test.go
+++ b/launcher/uv_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnvOr(t *testing.T) {
+	const key = "PHOTOMAP_TEST_ENVOR"
+	t.Setenv(key, "")
+	if got := envOr(key, "fallback"); got != "fallback" {
+		t.Errorf("empty env = %q, want fallback", got)
+	}
+	t.Setenv(key, "9000")
+	if got := envOr(key, "fallback"); got != "9000" {
+		t.Errorf("set env = %q, want 9000", got)
+	}
+}
+
+func TestIsUVBinary(t *testing.T) {
+	cases := map[string]bool{
+		"uv":                             true,
+		"uv.exe":                         true,
+		"uv-x86_64-unknown-linux-gnu/uv": true,
+		"uvx":                            false,
+		"uvx.exe":                        false,
+		"README.md":                      false,
+	}
+	for name, want := range cases {
+		if got := isUVBinary(name); got != want {
+			t.Errorf("isUVBinary(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestMarkerRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	l := layout{marker: filepath.Join(dir, ".installed")}
+
+	if b := installedBackend(l); b != "" {
+		t.Fatalf("fresh marker = %q, want empty", b)
+	}
+	if err := writeMarker(l, "auto"); err != nil {
+		t.Fatal(err)
+	}
+	if b := installedBackend(l); b != "auto" {
+		t.Fatalf("after write = %q, want %q", b, "auto")
+	}
+}
+
+// TestDownloadUVIntegration exercises the download + archive-extraction + exec
+// path against the real uv release (~30 MB, no torch). Skipped with -short.
+func TestDownloadUVIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("network integration test; run without -short")
+	}
+	dir := t.TempDir()
+	l := layout{uvBin: filepath.Join(dir, "bin", exeName("uv"))}
+	if err := os.MkdirAll(filepath.Dir(l.uvBin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := downloadUV(l); err != nil {
+		t.Fatalf("downloadUV: %v", err)
+	}
+	out, err := exec.Command(l.uvBin, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("running extracted uv: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "uv ") {
+		t.Fatalf("unexpected uv --version output: %s", out)
+	}
+}

--- a/photomap/backend/args.py
+++ b/photomap/backend/args.py
@@ -69,6 +69,12 @@ def get_args() -> argparse.Namespace:
         "--once", action="store_true", help="Run server once; do not respawn"
     )
     parser.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not automatically open a web browser on startup (default: open). "
+        "Also controlled by the PHOTOMAP_NO_BROWSER environment variable.",
+    )
+    parser.add_argument(
         "--inline-upgrade",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/photomap/backend/browser.py
+++ b/photomap/backend/browser.py
@@ -1,0 +1,104 @@
+"""Auto-open the user's web browser once the server is accepting connections.
+
+The desktop experience should land the user on the running app without making them
+copy a URL out of a terminal. We only do this for an interactive, local, non-dev
+server; remote/headless/Docker deployments and the dev ``--reload`` loop are left
+alone. See :func:`should_open_browser` for the exact guards.
+"""
+
+import logging
+import os
+import socket
+import sys
+import threading
+import time
+import webbrowser
+
+logger = logging.getLogger(__name__)
+
+# Hosts that mean "this machine" — the only ones we'll pop a browser for.
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+# Wildcard binds; reachable locally via loopback even though we never auto-open for them.
+_WILDCARD_HOSTS = {"0.0.0.0", "::"}
+
+_FALSEY = {"", "0", "false", "no", "off"}
+
+
+def _env_truthy(value: str | None) -> bool:
+    """Return True for a set-and-non-falsey environment value."""
+    return value is not None and value.strip().lower() not in _FALSEY
+
+
+def _is_docker() -> bool:
+    """Best-effort detection of running inside a Docker container."""
+    return os.path.exists("/.dockerenv")
+
+
+def _is_headless() -> bool:
+    """True when there is no graphical display to open a browser into.
+
+    Only Linux/BSD can be headless in practice; macOS and Windows always have a
+    window server when a user is running the app.
+    """
+    if sys.platform.startswith(("linux", "freebsd")):
+        return not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    return False
+
+
+def should_open_browser(host: str, *, no_browser: bool, reload: bool) -> bool:
+    """Decide whether to auto-open a browser for a freshly started server.
+
+    Suppressed when:
+    - explicitly disabled via ``--no-browser`` or the ``PHOTOMAP_NO_BROWSER`` env var,
+    - running under uvicorn ``--reload`` (a dev workflow that also spawns reloader children),
+    - bound to a non-loopback interface (a remote/headless server, e.g. ``0.0.0.0``),
+    - running headless or inside Docker.
+    """
+    if no_browser or _env_truthy(os.environ.get("PHOTOMAP_NO_BROWSER")):
+        return False
+    if reload:
+        return False
+    if host not in _LOOPBACK_HOSTS:
+        return False
+    if _is_docker() or _is_headless():
+        return False
+    return True
+
+
+def open_browser_when_ready(host: str, port: int, *, timeout: float = 30.0) -> threading.Thread:
+    """Spawn a daemon thread that opens the browser once ``port`` accepts a connection.
+
+    Polling for an accepted TCP connection (rather than sleeping a fixed delay) means
+    we open exactly when uvicorn is ready, and never open at all if the server fails to
+    come up within ``timeout`` seconds.
+    """
+    thread = threading.Thread(
+        target=_wait_and_open,
+        args=(host, port, timeout),
+        name="photomap-browser-opener",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _wait_and_open(host: str, port: int, timeout: float) -> None:
+    connect_host = "127.0.0.1" if host in _WILDCARD_HOSTS else host
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((connect_host, port), timeout=0.5):
+                break
+        except OSError:
+            time.sleep(0.25)
+    else:
+        logger.debug("Server not reachable within %ss; not opening a browser", timeout)
+        return
+
+    url = f"http://{connect_host}:{port}"
+    try:
+        webbrowser.open(url)
+        logger.info("Opened %s in your default browser", url)
+    except Exception as exc:  # webbrowser can raise on misconfigured/headless systems
+        logger.debug("Could not open a browser automatically: %s", exc)

--- a/photomap/backend/photomap_server.py
+++ b/photomap/backend/photomap_server.py
@@ -17,6 +17,7 @@ from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from photomap.backend.args import get_args, get_version
+from photomap.backend.browser import open_browser_when_ready, should_open_browser
 from photomap.backend.config import get_config_manager
 from photomap.backend.constants import get_package_resource_path
 from photomap.backend.encoders import start_idle_watcher, stop_idle_watcher
@@ -163,14 +164,32 @@ async def get_root(
 
 
 def start_photomap_loop():
-    """Start the PhotoMapAI server loop."""
+    """Supervise the server, respawning the worker if it crashes.
+
+    The browser is opened here (once), not in the respawned worker: the worker is
+    re-launched on every crash, so opening it there would reopen a tab on each
+    restart. Workers are therefore always spawned with ``--no-browser``.
+    """
+    args = get_args()
+    host = args.host or os.environ.get("PHOTOMAP_HOST", "127.0.0.1")
+    port = args.port or int(os.environ.get("PHOTOMAP_PORT", "8050"))
+    if should_open_browser(host, no_browser=args.no_browser, reload=args.reload):
+        open_browser_when_ready(host, port)
+
     running = True
-    args = [sys.executable] + ["-m", "photomap.backend.photomap_server"] + sys.argv[1:] + ["--once"]
+    child_argv = [
+        sys.executable,
+        "-m",
+        "photomap.backend.photomap_server",
+        *sys.argv[1:],
+        "--once",
+        "--no-browser",
+    ]
 
     while running:
         try:
             logger.info("Loading...")
-            subprocess.run(args, check=True)
+            subprocess.run(child_argv, check=True)
         except KeyboardInterrupt:
             logger.warning("Shutting down server...")
             running = False
@@ -266,6 +285,9 @@ def main():
     logger.info(
         f"Please open your browser to \033[1m{app_url}\033[0m to access the PhotoMapAI application"
     )
+
+    if should_open_browser(host, no_browser=args.no_browser, reload=args.reload):
+        open_browser_when_ready(host, port)
 
     uvicorn.run(
         "photomap.backend.photomap_server:app",

--- a/tests/backend/test_browser.py
+++ b/tests/backend/test_browser.py
@@ -1,0 +1,59 @@
+"""
+test_browser.py
+Tests for the auto-open-browser guard logic in photomap.backend.browser.
+
+These cover should_open_browser()'s suppression rules; the actual
+open_browser_when_ready() thread is not exercised (it would pop a real browser).
+"""
+
+import pytest
+
+from photomap.backend import browser
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Default to a non-headless, non-Docker, no-env-override environment."""
+    monkeypatch.delenv("PHOTOMAP_NO_BROWSER", raising=False)
+    monkeypatch.setattr(browser, "_is_docker", lambda: False)
+    monkeypatch.setattr(browser, "_is_headless", lambda: False)
+
+
+def test_opens_for_loopback_by_default():
+    assert browser.should_open_browser("127.0.0.1", no_browser=False, reload=False) is True
+    assert browser.should_open_browser("localhost", no_browser=False, reload=False) is True
+
+
+def test_suppressed_by_no_browser_flag():
+    assert browser.should_open_browser("127.0.0.1", no_browser=True, reload=False) is False
+
+
+def test_suppressed_under_reload():
+    assert browser.should_open_browser("127.0.0.1", no_browser=False, reload=True) is False
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "192.168.1.50", "example.com"])
+def test_suppressed_for_non_loopback_hosts(host):
+    assert browser.should_open_browser(host, no_browser=False, reload=False) is False
+
+
+def test_suppressed_in_docker(monkeypatch):
+    monkeypatch.setattr(browser, "_is_docker", lambda: True)
+    assert browser.should_open_browser("127.0.0.1", no_browser=False, reload=False) is False
+
+
+def test_suppressed_when_headless(monkeypatch):
+    monkeypatch.setattr(browser, "_is_headless", lambda: True)
+    assert browser.should_open_browser("127.0.0.1", no_browser=False, reload=False) is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "anything"])
+def test_env_var_suppresses(monkeypatch, value):
+    monkeypatch.setenv("PHOTOMAP_NO_BROWSER", value)
+    assert browser.should_open_browser("127.0.0.1", no_browser=False, reload=False) is False
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_falsey_env_var_does_not_suppress(monkeypatch, value):
+    monkeypatch.setenv("PHOTOMAP_NO_BROWSER", value)
+    assert browser.should_open_browser("127.0.0.1", no_browser=False, reload=False) is True


### PR DESCRIPTION
## Summary

Makes installing PhotoMapAI on Windows/macOS one-click by replacing the fragile shell-script and PyInstaller paths with a small **native launcher** that bootstraps [uv](https://docs.astral.sh/uv/) on first run. Because the launcher bundles no torch, code-signing/notarization is fast and cheap.

### Launcher (`launcher/`, Go)
- Embeds the `uv` binary (`-tags embed_uv`); on first run installs a managed CPython + `photomapai` into a per-user runtime dir, then starts the server and opens the browser.
- Torch backend via `uv tool install --torch-backend auto` — GPU auto-detected, no CUDA index version to maintain. `--cpu`/`--gpu`/`--torch-backend` override; `--reinstall`/`--uninstall` for lifecycle.
- Honors `PHOTOMAP_PORT`/`PHOTOMAP_HOST` for its readiness poll and the browser it opens; forwards extra `start_photomap` args after a `--` separator.
- Runs the server from a neutral working dir so a stray `./photomap` source tree can't shadow the installed package.

### Browser auto-launch (quick win)
- New `photomap/backend/browser.py` + `--no-browser` / `PHOTOMAP_NO_BROWSER`, wired into the `--once` worker and the supervisor (opens once; guarded for `--reload`, non-loopback, Docker, headless). Dockerfile sets `PHOTOMAP_NO_BROWSER=1`.

### CI / signing
- `.github/workflows/deploy-launcher.yml`: per-OS build → sign → package → upload. macOS notarized/stapled `.dmg`; Windows Azure Trusted Signing + Inno Setup `setup.exe`; Linux AppImage. No torch matrix, no disk-space hacks. Signing steps skip gracefully when secrets are absent.
- Replaces `deploy-pyinstaller.yml` (now deprecated) in `deploy.yml`; `upload-artifacts.yml` attaches the new artifacts. Packaging helpers under `INSTALL/launcher/`.
- `make appimage` builds the Linux artifact on demand.

### Other quick wins
- `install_linux_mac.sh`: `pip install -e .` → `pip install .` (fixes the move-the-folder footgun); Info.plist version stamped from the package instead of hardcoded `0.3.0`.
- Docs (`installation.md`, `README.md`, `docs/index.md`) rewritten to lead with the three signed installers.

## Testing
- Full launcher → uv → install (CPU **and** CUDA) → server → browser verified end-to-end locally; reproduced and fixed the cwd-shadowing crash.
- 363 backend tests pass; new `tests/backend/test_browser.py`; ruff clean. Go launcher `gofmt`/`vet`/tests clean; cross-compiles for win/mac/linux.
- **Not** verifiable locally: actual signing/notarization (needs runners + certs) and native macOS/Windows launch.

## Before a signed release
Set GitHub **secrets** (`MACOS_CERT_P12_BASE64`, `MACOS_CERT_PASSWORD`, `MACOS_KEYCHAIN_PASSWORD`, `APPLE_API_KEY_P8_BASE64`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`) and **variables** (`AZURE_CODESIGN_ENDPOINT`, `AZURE_CODESIGN_ACCOUNT`, `AZURE_CODESIGN_PROFILE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)