### PR TITLE
fix(ci): Inno Setup launcher exe path

### DIFF
--- a/.github/workflows/deploy-launcher.yml
+++ b/.github/workflows/deploy-launcher.yml
@@ -241,9 +241,14 @@ jobs:
         shell: pwsh
         run: |
           choco install innosetup --no-progress -y
+          # Inno resolves relative paths against the .iss file's folder, so pass
+          # absolute paths for the source exe and the output dir (repo-root dist).
+          $exe = (Resolve-Path dist\photomap.exe).Path
+          $out = (Resolve-Path dist).Path
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
             "/DAppVersion=$env:VERSION" `
-            "/DSourceExe=dist\photomap.exe" `
+            "/DSourceExe=$exe" `
+            "/O$out" `
             INSTALL\launcher\windows\photomap.iss
 
       - name: Sign installer (Azure Trusted Signing)

--- a/.github/workflows/deploy-launcher.yml
+++ b/.github/workflows/deploy-launcher.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Fetch uv ${{ env.UV_VERSION }}
         run: |
           mkdir -p launcher/assets
-          curl -fsSL -o /tmp/uv.tar.gz \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 -o /tmp/uv.tar.gz \
             "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz"
           tar -xzf /tmp/uv.tar.gz --strip-components=1 -C launcher/assets uv-x86_64-unknown-linux-gnu/uv
           mv launcher/assets/uv launcher/assets/uv-bin
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build AppImage
         run: |
-          curl -fsSL -o /tmp/appimagetool \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 -o /tmp/appimagetool \
             "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
           chmod +x /tmp/appimagetool
           export PATH="/tmp:$PATH"
@@ -117,7 +117,7 @@ jobs:
           mkdir -p launcher/assets
           # macos-latest runners are Apple Silicon (arm64). Intel Macs are not
           # covered by this build; add an x86_64 leg / universal2 if needed.
-          curl -fsSL -o /tmp/uv.tar.gz \
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 -o /tmp/uv.tar.gz \
             "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-aarch64-apple-darwin.tar.gz"
           tar -xzf /tmp/uv.tar.gz --strip-components=1 -C launcher/assets uv-aarch64-apple-darwin/uv
           mv launcher/assets/uv launcher/assets/uv-bin


### PR DESCRIPTION
Follow-up to #300. The first signed `Deploy Launcher` run surfaced one CI bug:

- **Windows:** Inno Setup resolves relative `Source`/`OutputDir` paths against the `.iss` file's folder, not the repo root, so it looked for `INSTALL/launcher/windows/dist/photomap.exe` and aborted. Now passes an absolute `SourceExe` and an absolute output dir (`/O`).

Azure Trusted Signing of the exe itself already succeeded in that run, so this is the only Windows blocker.

(The macOS failure in the same run was a cert-side issue — a PKCS#12 exported by OpenSSL 3 that Apple's importer can't read; fixed by re-exporting the `.p12` with `-legacy`, no code change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)