### PR TITLE
ci(launcher): cap macOS job at 120m for slow notarization

### DIFF
--- a/.github/workflows/deploy-launcher.yml
+++ b/.github/workflows/deploy-launcher.yml
@@ -102,6 +102,11 @@ jobs:
   macos:
     needs: version
     runs-on: macos-latest
+    # Apple notarization (`notarytool --wait`) is the long pole and can sit in
+    # Apple's queue for ~45+ min with no incident; cap the job well above that so
+    # a genuinely stuck submission fails at 2h instead of GitHub's 6h default,
+    # without false-failing a slow-but-valid notarization.
+    timeout-minutes: 120
     env:
       VERSION: ${{ needs.version.outputs.version }}
       # 'true' when the signing/notarization secrets are configured.


### PR DESCRIPTION
Follow-up to the signed-launcher work. The first successful signed run notarized fine but Apple's queue took ~49 min with no posted incident.

Adds `timeout-minutes: 120` to the macOS job so a genuinely stuck submission fails at 2h instead of GitHub's 6h default — while leaving comfortable margin over real-world notarization latency.

Deliberately **not** using `notarytool --timeout`: that abandons the local wait without cancelling the submission, so a tight value (e.g. 30m) would have *false-failed* today's valid 49-min notarization and left an unstapled DMG. A generous job-level cap is the safer backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)