### PR TITLE
fix(installer): install VC++ runtime when missing

### DIFF
--- a/.github/workflows/deploy-launcher.yml
+++ b/.github/workflows/deploy-launcher.yml
@@ -246,13 +246,19 @@ jobs:
         shell: pwsh
         run: |
           choco install innosetup --no-progress -y
+          # Bundle the VC++ runtime installer so torch's c10.dll has its deps on
+          # clean machines; the installer only runs it when the runtime is absent.
+          Invoke-WebRequest -Uri https://aka.ms/vs/17/release/vc_redist.x64.exe `
+            -OutFile dist\vc_redist.x64.exe -MaximumRetryCount 5 -RetryIntervalSec 5
           # Inno resolves relative paths against the .iss file's folder, so pass
           # absolute paths for the source exe and the output dir (repo-root dist).
           $exe = (Resolve-Path dist\photomap.exe).Path
+          $vc  = (Resolve-Path dist\vc_redist.x64.exe).Path
           $out = (Resolve-Path dist).Path
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" `
             "/DAppVersion=$env:VERSION" `
             "/DSourceExe=$exe" `
+            "/DVCRedist=$vc" `
             "/O$out" `
             INSTALL\launcher\windows\photomap.iss
 

--- a/INSTALL/launcher/windows/photomap.iss
+++ b/INSTALL/launcher/windows/photomap.iss
@@ -12,6 +12,9 @@
 #ifndef SourceExe
   #define SourceExe "dist\photomap.exe"
 #endif
+#ifndef VCRedist
+  #define VCRedist "dist\vc_redist.x64.exe"
+#endif
 
 #define AppName "PhotoMapAI"
 #define AppExe "photomap.exe"
@@ -44,6 +47,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "{#SourceExe}"; DestDir: "{app}"; DestName: "{#AppExe}"; Flags: ignoreversion
+; Bundled VC++ runtime installer; only extracted when the runtime is missing.
+Source: "{#VCRedist}"; DestDir: "{tmp}"; Flags: deleteafterinstall; Check: VCRedistNeeded
 
 [Icons]
 Name: "{group}\{#AppName}"; Filename: "{app}\{#AppExe}"
@@ -51,4 +56,18 @@ Name: "{group}\Uninstall {#AppName}"; Filename: "{uninstallexe}"
 Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppExe}"; Tasks: desktopicon
 
 [Run]
+; PyTorch needs the Microsoft Visual C++ runtime (vcruntime140.dll, etc.).
+; Install it silently only when absent (one UAC prompt; skipped otherwise).
+Filename: "{tmp}\vc_redist.x64.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "Installing Microsoft Visual C++ Runtime..."; Check: VCRedistNeeded; Flags: waituntilterminated
 Filename: "{app}\{#AppExe}"; Description: "{cm:LaunchProgram,{#AppName}}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+function VCRedistNeeded(): Boolean;
+var
+  Installed: Cardinal;
+begin
+  // Read the native 64-bit view for the VC++ 2015-2022 x64 runtime key.
+  Result := True;
+  if RegQueryDWordValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64', 'Installed', Installed) then
+    Result := (Installed <> 1);
+end;


### PR DESCRIPTION
## Problem
On a clean Windows 10 VM, the launcher installed fine but crashed at first launch:

```
OSError: [WinError 126] ... Error loading "...\torch\lib\c10.dll" or one of its dependencies.
```

PyTorch's `c10.dll` depends on the Microsoft Visual C++ runtime (`vcruntime140.dll`, `msvcp140.dll`), which isn't present on a fresh Windows install. The old `windows.ps1` installer used to download `vc_redist`; the new Inno installer didn't.

## Fix
- Bundle `vc_redist.x64.exe` in the Inno installer and run it **silently only when the runtime is absent** — detected via the VC++ 2015–2022 x64 registry key (`HKLM64`). Machines that already have it (the majority) see no extra prompt; clean machines get one UAC prompt for the (inherently machine-wide) runtime.
- CI downloads `vc_redist.x64.exe` and passes it to ISCC via `/DVCRedist`.

## Notes
- Adds ~25 MB to the Windows installer.
- macOS/Linux unaffected. The PyPI/`uv tool` path is unchanged (power users provide their own runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)