### PR TITLE
feat(launcher): add --pkg-version to install a specific photomapai release

### DIFF
--- a/launcher/README.md
+++ b/launcher/README.md
@@ -31,6 +31,7 @@ untouched, so albums carry over for existing users.
 --reinstall        force a clean reinstall, then run
 --uninstall        remove the install and all runtime files, then exit
 --no-browser       start the server but don't open a browser
+--pkg-version X    advanced: install a specific photomapai version/spec (implies --reinstall)
 --version          print the launcher version and exit
 ```
 
@@ -39,6 +40,13 @@ an NVIDIA GPU and installs the matching CUDA wheels, falling back to CPU when
 there's no GPU — so the common case needs no choice and there's no CUDA index
 version to maintain. `--cpu` forces CPU (e.g. to avoid a flaky driver); `--gpu`
 re-detects after adding a GPU; `--torch-backend` pins a specific backend.
+
+`--pkg-version` is a maintainer/testing aid: by default the launcher installs the
+latest stable photomapai from PyPI (uv skips pre-releases for the bare package
+name). To test a pre-release or pin an exact version, pass e.g.
+`--pkg-version 1.0.6rc1` — it installs `photomapai==<spec>` (the explicit `==`
+lets uv resolve a pre-release) and forces a reinstall so it takes effect even
+when a version is already installed.
 
 ### Passing options to the server
 

--- a/launcher/main.go
+++ b/launcher/main.go
@@ -12,6 +12,7 @@
 //	--reinstall   force a clean reinstall, then run
 //	--uninstall   remove the photomapai install and all runtime files, then exit
 //	--no-browser  start the server but don't open a browser
+//	--pkg-version install a specific photomapai version/spec, e.g. 1.0.6rc1 (implies reinstall)
 //	--version     print the launcher version and exit
 //
 // Anything after a "--" separator is passed straight through to start_photomap,
@@ -54,6 +55,7 @@ func main() {
 		reinstall    = flag.Bool("reinstall", false, "force a clean reinstall before running")
 		doUninst     = flag.Bool("uninstall", false, "remove PhotoMapAI and all runtime files")
 		noBrowser    = flag.Bool("no-browser", false, "do not open a web browser on startup")
+		pkgVersion   = flag.String("pkg-version", "", "advanced: install a specific photomapai version/spec, e.g. 1.0.6rc1 (implies --reinstall)")
 		showVer      = flag.Bool("version", false, "print the launcher version and exit")
 	)
 	flag.Parse()
@@ -66,14 +68,14 @@ func main() {
 	// Anything after "--" is forwarded verbatim to start_photomap.
 	serverArgs := flag.Args()
 
-	if err := run(*gpu, *cpu, *torchBackend, *reinstall, *doUninst, *noBrowser, serverArgs); err != nil {
+	if err := run(*gpu, *cpu, *torchBackend, *reinstall, *doUninst, *noBrowser, *pkgVersion, serverArgs); err != nil {
 		fmt.Fprintf(os.Stderr, "\nError: %v\n", err)
 		pause()
 		os.Exit(1)
 	}
 }
 
-func run(gpu, cpu bool, torchBackend string, reinstall, doUninst, noBrowser bool, serverArgs []string) error {
+func run(gpu, cpu bool, torchBackend string, reinstall, doUninst, noBrowser bool, pkgVersion string, serverArgs []string) error {
 	l, err := newLayout()
 	if err != nil {
 		return err
@@ -88,6 +90,15 @@ func run(gpu, cpu bool, torchBackend string, reinstall, doUninst, noBrowser bool
 
 	if err := ensureUV(l); err != nil {
 		return fmt.Errorf("setting up uv: %w", err)
+	}
+
+	// A version override always forces a reinstall: the marker tracks only the
+	// torch backend, not the installed version, so on a machine that already has
+	// photomapai the request would otherwise be silently ignored.
+	pkgSpec := pkgName
+	if pkgVersion != "" {
+		pkgSpec = pkgName + "==" + pkgVersion
+		reinstall = true
 	}
 
 	// Decide the torch backend and whether (re)install is needed.
@@ -107,7 +118,7 @@ func run(gpu, cpu bool, torchBackend string, reinstall, doUninst, noBrowser bool
 	needInstall := reinstall || current == "" || target != current
 	if needInstall {
 		force := reinstall || (current != "" && target != current)
-		if err := install(l, target, force); err != nil {
+		if err := install(l, pkgSpec, target, force); err != nil {
 			return err
 		}
 		fmt.Println("\nSetup complete.")

--- a/launcher/uv.go
+++ b/launcher/uv.go
@@ -233,9 +233,12 @@ func writeMarker(l layout, torchBackend string) error {
 }
 
 // install runs the uv steps to put photomapai on disk with the requested torch
-// backend. reinstall forces uv to replace an existing install (used when
-// switching backend or recovering a broken install).
-func install(l layout, torchBackend string, reinstall bool) error {
+// backend. pkgSpec is the argument passed to `uv tool install` — usually the bare
+// pkgName, or pkgName=="<version>" when --pkg-version pins a release (an explicit
+// "==" lets uv resolve a pre-release the bare name would otherwise skip).
+// reinstall forces uv to replace an existing install (used when switching backend,
+// pinning a version, or recovering a broken install).
+func install(l layout, pkgSpec, torchBackend string, reinstall bool) error {
 	fmt.Printf("\nFirst-time setup: downloading Python and the PhotoMapAI libraries.\n")
 	fmt.Printf("This is a multi-GB download and runs once; it can take several minutes.\n\n")
 
@@ -244,7 +247,7 @@ func install(l layout, torchBackend string, reinstall bool) error {
 	}
 
 	args := []string{
-		"tool", "install", pkgName,
+		"tool", "install", pkgSpec,
 		"--python", pythonVersion,
 		"--torch-backend", torchBackend,
 	}
@@ -252,7 +255,7 @@ func install(l layout, torchBackend string, reinstall bool) error {
 		args = append(args, "--reinstall")
 	}
 	if err := l.runUV(args...); err != nil {
-		return fmt.Errorf("installing %s: %w", pkgName, err)
+		return fmt.Errorf("installing %s: %w", pkgSpec, err)
 	}
 	return writeMarker(l, torchBackend)
 }


### PR DESCRIPTION
## Summary

Adds a `--pkg-version <spec>` flag to the desktop launcher so a maintainer or tester can install a specific photomapai version — including a pre-release — instead of the latest stable.

By default the launcher runs a bare `uv tool install photomapai`, so uv resolves the **latest stable** and skips pre-releases. That means publishing e.g. `1.0.6rc1` to PyPI is invisible to the launcher. `--pkg-version` is the opt-in:

- `photomap --pkg-version 1.0.6rc1` → `uv tool install photomapai==1.0.6rc1 --reinstall`
- The explicit `==` lets uv resolve a pre-release the bare name would skip.
- It forces a reinstall, because the on-disk marker tracks only the torch backend, not the installed version — otherwise an already-installed machine would silently ignore the request.

Without the flag, behavior is unchanged.

This is a terminal-only, maintainer/testing aid (the double-clickable packaged apps pass no args). The dev binary from `make launcher` is the easiest way to use it:

```bash
./dist/photomap --pkg-version 1.0.6rc1
```

## Changes

- `launcher/main.go` — register `--pkg-version`, thread `pkgSpec` through `run()`, force reinstall when set.
- `launcher/uv.go` — `install()` takes a `pkgSpec` argument instead of the bare `pkgName` const.
- `launcher/README.md` — document the flag.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass; `gofmt` clean.
- `--help` lists the flag; default (no-flag) install path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)