### PR TITLE
fix(launcher): reassure users during the post-install wait before the server starts

### DIFF
--- a/launcher/main.go
+++ b/launcher/main.go
@@ -121,7 +121,7 @@ func run(gpu, cpu bool, torchBackend string, reinstall, doUninst, noBrowser bool
 		if err := install(l, pkgSpec, target, force); err != nil {
 			return err
 		}
-		fmt.Println("\nSetup complete.")
+		fmt.Println("\nSetup complete. Please wait while the PhotoMapAI server launches...")
 	}
 
 	return launchServer(l, noBrowser, serverArgs)


### PR DESCRIPTION
## Summary

After first-time setup, the launcher printed `Setup complete.` and then sat quietly for up to ~a minute while the server cold-started (Defender/AV scanning, torch import, etc.). During that silence a user could reasonably assume it was finished and **close the terminal window**, killing the launch.

This makes the wait explicit:

> `Setup complete. Please wait while the PhotoMapAI server launches...`

## Changes

- `launcher/main.go` — one-line message change.

## Testing

- `go build ./...` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)