### PR TITLE
fix(slideshow): keep shuffle autoplay alive after high-water-mark trim

### DIFF
--- a/photomap/frontend/static/javascript/swiper.js
+++ b/photomap/frontend/static/javascript/swiper.js
@@ -49,6 +49,10 @@ class SwiperManager {
     this._resetInFlight = null;
     this._resetPending = false;
 
+    // Set while trimShuffleBacklog is restarting autoplay after a trim, so the
+    // autoplay event handlers don't flicker the play/pause icon (see below).
+    this._suppressAutoplayIcon = false;
+
     // Store event listeners for cleanup
     this.eventListeners = [];
 
@@ -100,6 +104,11 @@ class SwiperManager {
         // album's first image). The primary end-of-list handling lives in the
         // slideNextTransitionStart handler below, which stops autoplay the
         // instant resolveOffset(+1) reports there is no next slide.
+        //
+        // This applies to *linear* mode only. resumeSlideshow() flips it off
+        // for shuffle mode, which has no end of list and must never auto-stop
+        // at a buffer boundary. We default it on here so a linear slideshow
+        // started before resumeSlideshow ever runs still has the backstop.
         stopOnLastSlide: true,
       },
       loop: false,
@@ -144,29 +153,23 @@ class SwiperManager {
       return;
     }
 
-    this.swiper.on("autoplayStart", () => {
+    // trimShuffleBacklog stops+restarts autoplay internally (see its comment);
+    // that churn would otherwise flip the play/pause icon on nearly every shuffle
+    // advance, so it sets _suppressAutoplayIcon to mute these handlers while it
+    // works. The slideshow's true running state is unchanged across a trim.
+    const refreshSlideshowIcon = () => {
+      if (this._suppressAutoplayIcon) {
+        return;
+      }
       if (!state.gridViewActive) {
         updateSlideshowButtonIcon();
       }
-    });
+    };
 
-    this.swiper.on("autoplayResume", () => {
-      if (!state.gridViewActive) {
-        updateSlideshowButtonIcon();
-      }
-    });
-
-    this.swiper.on("autoplayStop", () => {
-      if (!state.gridViewActive) {
-        updateSlideshowButtonIcon();
-      }
-    });
-
-    this.swiper.on("autoplayPause", () => {
-      if (!state.gridViewActive) {
-        updateSlideshowButtonIcon();
-      }
-    });
+    this.swiper.on("autoplayStart", refreshSlideshowIcon);
+    this.swiper.on("autoplayResume", refreshSlideshowIcon);
+    this.swiper.on("autoplayStop", refreshSlideshowIcon);
+    this.swiper.on("autoplayPause", refreshSlideshowIcon);
 
     this.swiper.on("scrollbarDragStart", () => {
       if (!state.gridViewActive) {
@@ -383,6 +386,14 @@ class SwiperManager {
 
   resumeSlideshow() {
     if (this.swiper) {
+      // stopOnLastSlide is a *linear-mode* backstop only (see the autoplay
+      // config comment). Shuffle has no end of list: its look-ahead append
+      // keeps a slide past the active one, but once trimShuffleBacklog starts
+      // dropping front slides at the high-water mark the index churn can briefly
+      // expose Swiper's isEnd, and a global stopOnLastSlide would then freeze
+      // autoplay (the "pauses after the 18th shuffled image" regression). Keep
+      // it off whenever we're starting in random mode.
+      this.swiper.params.autoplay.stopOnLastSlide = state.mode !== "random";
       this.swiper.autoplay.stop();
       setTimeout(() => {
         this.swiper.autoplay.start();
@@ -672,17 +683,36 @@ class SwiperManager {
   /**
    * Keep the shuffle buffer bounded. The active slide and its single look-ahead
    * live at the tail, so dropping the oldest (front) slides never disturbs what
-   * is on screen or about to be shown. Unlike enforceHighWaterMark this does not
-   * stop/start autoplay, so it won't flicker the play/pause icon on every
-   * advance — important because shuffle trims on (nearly) every slide.
+   * is on screen or about to be shown.
+   *
+   * swiper.removeSlide() internally calls slideTo(), which emits
+   * beforeTransitionStart; Swiper's autoplay treats that programmatic move like
+   * a user interaction and (with disableOnInteraction) *stops* autoplay. So the
+   * very first trim — when the buffer first exceeds the high-water mark, ~18
+   * slides into a shuffle run — would silently kill the slideshow. We therefore
+   * restart autoplay after trimming, mirroring enforceHighWaterMark. The
+   * stop+restart is muted via _suppressAutoplayIcon so it doesn't flicker the
+   * play/pause icon on every advance (shuffle trims on nearly every slide).
    */
   trimShuffleBacklog() {
     if (!this.swiper) {
       return;
     }
     const maxSlides = state.highWaterMark || 50;
-    while (this.swiper.slides.length > maxSlides) {
-      this.swiper.removeSlide(0);
+    if (this.swiper.slides.length <= maxSlides) {
+      return;
+    }
+    const wasRunning = this.swiper.autoplay?.running;
+    this._suppressAutoplayIcon = true;
+    try {
+      while (this.swiper.slides.length > maxSlides) {
+        this.swiper.removeSlide(0);
+      }
+      if (wasRunning && this.swiper.autoplay && !this.swiper.autoplay.running) {
+        this.swiper.autoplay.start();
+      }
+    } finally {
+      this._suppressAutoplayIcon = false;
     }
   }
 

--- a/tests/frontend/swiper-shuffle.test.js
+++ b/tests/frontend/swiper-shuffle.test.js
@@ -128,11 +128,27 @@ describe("swiper.js shuffle mode", () => {
     mockSwiper = {
       slides: [],
       activeIndex: 0,
-      autoplay: { running: true, stop: jest.fn(), start: jest.fn() },
+      params: { autoplay: { stopOnLastSlide: true } },
+      autoplay: {
+        running: true,
+        stop: jest.fn(() => {
+          mockSwiper.autoplay.running = false;
+        }),
+        start: jest.fn(() => {
+          mockSwiper.autoplay.running = true;
+        }),
+      },
       allowSlideNext: true,
       allowSlidePrev: true,
       appendSlide: jest.fn((slide) => mockSwiper.slides.push(slide)),
       prependSlide: jest.fn((slide) => mockSwiper.slides.unshift(slide)),
+      // Mirror Swiper: removeSlide() calls slideTo(), whose beforeTransitionStart
+      // (with disableOnInteraction) stops autoplay. The mock reproduces that side
+      // effect so the trim-restart logic is actually exercised.
+      removeSlide: jest.fn(() => {
+        mockSwiper.slides.shift();
+        mockSwiper.autoplay.running = false;
+      }),
       removeAllSlides: jest.fn(() => {
         mockSwiper.slides = [];
       }),
@@ -261,6 +277,72 @@ describe("swiper.js shuffle mode", () => {
       const swiperConfig = global.Swiper.mock.calls[0][1];
       expect(swiperConfig.loop).toBe(false);
       expect(swiperConfig.autoplay.stopOnLastSlide).toBe(true);
+    });
+
+    // Regression: shuffle mode froze after ~highWaterMark slides because the
+    // linear-mode stopOnLastSlide backstop is a global autoplay option and so
+    // also fired in shuffle, where there is no end of list. resumeSlideshow
+    // must flip it off for random mode and back on for sequential mode.
+    it("disables stopOnLastSlide when resuming in shuffle mode", async () => {
+      const { initializeSingleSwiper } = await import("../../photomap/frontend/static/javascript/swiper.js");
+      const manager = await initializeSingleSwiper();
+
+      mockState.mode = "random";
+      mockSwiper.params.autoplay.stopOnLastSlide = true;
+
+      manager.resumeSlideshow();
+
+      expect(mockSwiper.params.autoplay.stopOnLastSlide).toBe(false);
+    });
+
+    it("enables stopOnLastSlide when resuming in sequential mode", async () => {
+      const { initializeSingleSwiper } = await import("../../photomap/frontend/static/javascript/swiper.js");
+      const manager = await initializeSingleSwiper();
+
+      mockState.mode = "chronological";
+      mockSwiper.params.autoplay.stopOnLastSlide = false;
+
+      manager.resumeSlideshow();
+
+      expect(mockSwiper.params.autoplay.stopOnLastSlide).toBe(true);
+    });
+
+    // Regression (the real cause of the "freezes after ~18 shuffled slides"
+    // report): swiper.removeSlide() stops autoplay as a side effect (its internal
+    // slideTo fires beforeTransitionStart, which with disableOnInteraction halts
+    // autoplay). trimShuffleBacklog must restart autoplay or the slideshow dies
+    // the first time the buffer is trimmed past the high-water mark.
+    it("restarts autoplay after trimming the shuffle backlog", async () => {
+      const { initializeSingleSwiper } = await import("../../photomap/frontend/static/javascript/swiper.js");
+      const manager = await initializeSingleSwiper();
+
+      // Buffer well over the high-water mark, autoplay running.
+      const over = mockState.highWaterMark + 3;
+      mockSwiper.slides = Array.from({ length: over }, (_, i) => createMockSlide(i));
+      mockSwiper.autoplay.running = true;
+
+      manager.trimShuffleBacklog();
+
+      // Buffer trimmed down to the cap and autoplay left running.
+      expect(mockSwiper.slides.length).toBe(mockState.highWaterMark);
+      expect(mockSwiper.removeSlide).toHaveBeenCalled();
+      expect(mockSwiper.autoplay.start).toHaveBeenCalled();
+      expect(mockSwiper.autoplay.running).toBe(true);
+    });
+
+    it("does not restart autoplay when trimming while the slideshow is paused", async () => {
+      const { initializeSingleSwiper } = await import("../../photomap/frontend/static/javascript/swiper.js");
+      const manager = await initializeSingleSwiper();
+
+      const over = mockState.highWaterMark + 3;
+      mockSwiper.slides = Array.from({ length: over }, (_, i) => createMockSlide(i));
+      mockSwiper.autoplay.running = false; // paused before the trim
+
+      manager.trimShuffleBacklog();
+
+      expect(mockSwiper.slides.length).toBe(mockState.highWaterMark);
+      expect(mockSwiper.autoplay.start).not.toHaveBeenCalled();
+      expect(mockSwiper.autoplay.running).toBe(false);
     });
 
     it("stops autoplay and appends nothing at the genuine last image (wrap off)", async () => {


### PR DESCRIPTION
## Problem

In **shuffle mode**, the slideshow consistently froze after ~19 slides. Pressing play ran another ~19, then froze again.

## Root cause

Once the slide buffer first exceeded `highWaterMark` (20), `trimShuffleBacklog` called `swiper.removeSlide()`. In Swiper 11, `removeSlide()` internally calls `slideTo()`, which emits `beforeTransitionStart`. Autoplay binds that event and, because the move isn't flagged internal and the config sets `disableOnInteraction: true`, treats it like a user interaction and **stops autoplay outright** (`running → false`).

`trimShuffleBacklog` (added in #293) had deliberately dropped the pause/resume that `enforceHighWaterMark` wraps around `removeSlide` "to avoid icon flicker" — not realizing `removeSlide` itself kills autoplay. So the very first trim silently stopped the show. The buffer starts at ~2 slides and grows by one per advance, so it first trims at advance ~19, which is exactly where it died; pressing play rebuilt the buffer to ~2 and it ran another ~19.

## Fix

- `trimShuffleBacklog` now **restarts autoplay after trimming** (mirroring `enforceHighWaterMark`), muting the play/pause icon churn via a new `_suppressAutoplayIcon` flag so the stop+restart doesn't flicker the icon on nearly every advance.
- `resumeSlideshow` gates the linear-mode `stopOnLastSlide` backstop to non-random mode — shuffle has no end of list and must never auto-stop at a buffer boundary. (Not the root cause, but a correct defensive change.)

## Verification

Diagnosed and verified by driving the **real app headless with Playwright** (earlier reasoning-only attempts misdiagnosed it twice). With the fix, shuffle runs **indefinitely** at the default 5 s delay in random mode — healthy steady state past slides 19, 20, 30+.

Adds regression tests: trim restarts autoplay (and its no-op when paused), plus the mode-gated `stopOnLastSlide`. Full frontend suite (356 tests), lint, and format all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)