### PR TITLE
chore(hooks): block edits to the main checkout while on master

### DIFF
--- a/.claude/hooks/guard-master-edits.py
+++ b/.claude/hooks/guard-master-edits.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""PreToolUse guard: block edits to the main checkout while it's on master/main.
+
+PhotoMap work must happen in a dedicated git worktree on a
+lstein/{fix,feature,chore}/<name> branch (see CLAUDE.md "Worktrees are
+mandatory"). It's easy to slide from read-only investigation straight into
+editing files on `master` in the main checkout; this hook makes that a hard
+stop instead of a convention.
+
+Wired up as a PreToolUse hook on Edit|Write|NotebookEdit. It denies the tool
+call (with guidance) only when ALL of these hold:
+  * CLAUDE_PROJECT_DIR is set (the main checkout root),
+  * the file being written lives inside that main checkout,
+  * the main checkout is currently on `master` or `main`.
+
+Edits inside a worktree (which lives outside the main checkout) and edits to
+files elsewhere (memory, /tmp, other repos) are never touched. Set
+PHOTOMAP_ALLOW_MASTER_EDITS=1 to bypass for an intentional master edit.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def allow() -> None:
+    sys.exit(0)
+
+
+def main() -> None:
+    if os.environ.get("PHOTOMAP_ALLOW_MASTER_EDITS"):
+        allow()
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR")
+    if not project_dir:
+        allow()
+
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        allow()
+
+    tool_input = payload.get("tool_input") or {}
+    target = tool_input.get("file_path") or tool_input.get("notebook_path")
+    if not target:
+        allow()
+
+    abs_target = target if os.path.isabs(target) else os.path.join(project_dir, target)
+    project_real = os.path.realpath(project_dir)
+    target_real = os.path.realpath(abs_target)
+
+    inside_main = target_real == project_real or target_real.startswith(project_real + os.sep)
+    if not inside_main:
+        allow()
+
+    try:
+        branch = subprocess.run(
+            ["git", "-C", project_dir, "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        allow()
+
+    if branch not in ("master", "main"):
+        allow()
+
+    reason = (
+        f"Blocked: editing {target} in the main checkout while it is on '{branch}'.\n"
+        "PhotoMap work must happen in a dedicated worktree on a "
+        "lstein/{fix,feature,chore}/<name> branch (see CLAUDE.md "
+        '"Worktrees are mandatory"). Create one, then edit files under it:\n'
+        "  git worktree add -b lstein/fix/<what-it-does> "
+        "../photomap-worktrees/lstein-fix-<what-it-does>\n"
+        "Intentional master edit? Re-run with PHOTOMAP_ALLOW_MASTER_EDITS=1 set."
+    )
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-master-edits.py\"",
+            "statusMessage": "Checking worktree guard..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Encodes the "Worktrees are mandatory" rule (#314) as a **hard gate** instead of a convention an agent can slide past.

### Why
During the shuffle-slideshow fix (#313), edits landed on `master` in the main checkout while the server was tested from a different worktree — so the fix looked broken across several rounds. Docs alone (#314) only help if the agent reads and heeds them. A `PreToolUse` hook runs regardless.

### What
A project-level `PreToolUse` hook on `Edit|Write|NotebookEdit` that **denies** the write when:
- `CLAUDE_PROJECT_DIR` is set (the main checkout root), **and**
- the target file lives inside that main checkout, **and**
- the main checkout is currently on `master` or `main`.

The denial message points the agent at the worktree workflow. Everything else is untouched: worktree edits (they live outside the main checkout), and edits to memory / `/tmp` / other repos. Intentional master edit? Set `PHOTOMAP_ALLOW_MASTER_EDITS=1`.

### Files
- `.claude/hooks/guard-master-edits.py` — the guard (denies via `permissionDecision`, pure stdlib).
- `.claude/settings.json` — wires it up (new file; repo had no `.claude/` before).

### Verification
Pipe-tested across cases: main-checkout file → **deny**; relative path / new file under main checkout → **deny**; worktree path → allow; `/tmp` → allow; `NotebookEdit` outside main → allow; `PHOTOMAP_ALLOW_MASTER_EDITS=1` → allow. `ruff` clean; settings schema validated with `jq`.

### Note on merge
This is the repo's first committed `.claude/settings.json`. After merge, Claude Code will prompt you once to **trust** the project hook before it runs (open `/hooks` to review or disable). Complements the doc change in #314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)