### PR TITLE
test(e2e): real-browser slideshow smoke harness (Playwright)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ help:
 	@echo "backend-lint     Run Python backend linting with Ruff."
 	@echo "frontend-lint    Run JavaScript frontend linting with ESLint and Prettier."
 	@echo "lint             Run both backend and frontend linting."
+	@echo "e2e-test         Run end-to-end Playwright tests (requires: pip install -e .[e2e] && playwright install chromium)."
 
 # Run the unit tests
 test:
@@ -122,3 +123,9 @@ frontend-lint:
 # Run both backend and frontend linting
 .PHONY: lint
 lint: backend-lint frontend-lint
+
+# Run end-to-end Playwright tests
+# Requires: pip install -e .[e2e] && playwright install chromium
+.PHONY: e2e-test
+e2e-test:
+	RUN_E2E=1 pytest tests/e2e -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,12 @@ development = [
     "twine",
     "ruff",
 ]
+# Real-browser end-to-end tests. Heavy (pulls Playwright + a browser), kept out
+# of the default `testing` extra. After install, run `playwright install
+# chromium` once, then `RUN_E2E=1 pytest tests/e2e`. See tests/e2e/README.md.
+e2e = [
+    "playwright",
+]
 [tool.setuptools.packages.find]
 where = ["."]  # Look in the current directory (repo root)
 include = ["photomap*"]  # Include photomap package and subpackages

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ testpaths = tests
 addopts = --cov=photomap --cov-report=term-missing:skip-covered
 markers =
     slow: tests that load real ML weights or otherwise take many seconds; excluded from CI via `-m "not slow"`
+    e2e: real-browser end-to-end tests (Playwright); opt-in, run only when RUN_E2E=1. See tests/e2e/README.md
 filterwarnings =
     # clip-anytorch loads its archive via torch.jit.load, which warns under
     # Python 3.14+. Third-party; the underlying call still works, so just

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,53 @@
+# End-to-end (real browser) smoke tests
+
+These tests launch the **actual** PhotoMapAI server and drive it with a headless
+Chromium via [Playwright](https://playwright.dev/python/). They exist to catch
+integration regressions the jsdom unit tests **cannot** — anything in the real
+interaction between our code and Swiper.js (autoplay, slide buffering,
+transitions).
+
+The motivating bug: shuffle slideshow froze after ~19 slides because trimming
+the slide buffer at the high-water mark stopped Swiper's autoplay. The unit
+tests mock Swiper, so they were blind to it; it only reproduced in a real
+browser. `test_shuffle_runs_past_high_water_mark` is the regression guard.
+
+## Running
+
+E2E tests are **opt-in** — they're skipped unless `RUN_E2E=1` is set, so the
+default `pytest tests` stays fast and browser-free.
+
+```bash
+# one-time setup
+pip install -e ".[testing,e2e]"
+playwright install chromium        # browser binary (cached under ~/.cache/ms-playwright)
+
+# run them
+RUN_E2E=1 pytest tests/e2e -m e2e
+```
+
+Without `RUN_E2E=1` they report as skipped:
+
+```bash
+pytest tests/e2e          # -> 2 skipped
+```
+
+## How the fixture works
+
+No CLIP model or network is required. `conftest.py`:
+
+1. Builds a throwaway **fake `.npz` index** at runtime pointing at the committed
+   images in `tests/backend/test_images/` (random embedding vectors — the
+   slideshow path never loads the encoder, so only the on-disk filenames and the
+   image count matter). The real index stores **absolute** paths, so it can't be
+   committed as a portable fixture; building at runtime sidesteps that.
+2. Writes a one-album `config.yaml` and launches `start_photomap` on a free port
+   with `--no-browser --once`.
+3. Provides Playwright `browser`/`page` fixtures.
+
+## Adding a test
+
+Mark it `@pytest.mark.e2e` (module-level `pytestmark = pytest.mark.e2e` is fine),
+take the `page` and `e2e_server` fixtures, and drive the UI. The native
+`#albumSelect` is hidden behind a custom dropdown, so set its value and dispatch
+a `change` event via `page.evaluate` rather than clicking. Reach the live Swiper
+instance with `document.getElementById('singleSwiper').swiper`.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,185 @@
+"""Fixtures for the end-to-end (real browser) smoke tests.
+
+These tests launch the actual PhotoMapAI server against a throwaway album and
+drive it with a headless Chromium via Playwright. They exist to catch
+integration regressions that the jsdom unit tests cannot — anything that lives
+in the real interaction between our code and Swiper.js (autoplay, slide
+buffering, transitions). The shuffle-slideshow freeze that motivated this
+harness was exactly such a bug: it only reproduced in a real browser.
+
+The album index is a *fake* ``.npz`` built at fixture time (random vectors,
+real on-disk image paths) so the suite needs neither the CLIP model nor any
+network — just the committed test images under ``tests/backend/test_images``.
+
+E2E tests are opt-in: they only run when ``RUN_E2E=1`` is set (see
+``pytest_collection_modifyitems``), so ``pytest tests`` stays fast and
+browser-free for everyone else and in the default CI job.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_IMAGES_DIR = REPO_ROOT / "tests" / "backend" / "test_images"
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
+EMBED_DIM = 512
+
+
+def _collect_test_images() -> list[Path]:
+    images = sorted(p for p in TEST_IMAGES_DIR.iterdir() if p.suffix.lower() in IMAGE_EXTS)
+    if not images:
+        raise RuntimeError(f"No test images found under {TEST_IMAGES_DIR}")
+    return images
+
+
+def _build_fake_index(image_paths: list[Path], out_npz: Path) -> None:
+    """Write a minimal ``.npz`` matching Embeddings._save_embeddings's schema.
+
+    The slideshow path never loads the encoder, so the embedding *values* are
+    irrelevant — only the filenames (absolute, on-disk) and the image count
+    matter. Built at runtime so the paths resolve on whatever machine runs the
+    suite (the real index stores absolute paths and is therefore not portable
+    as a committed fixture).
+    """
+    paths = [p.resolve() for p in image_paths]
+    rng = np.random.default_rng(0)
+    np.savez(
+        out_npz,
+        embeddings=rng.standard_normal((len(paths), EMBED_DIM)).astype("float32"),
+        filenames=np.array([p.as_posix() for p in paths]),
+        modification_times=np.array([p.stat().st_mtime for p in paths], dtype="float64"),
+        metadata=np.array([{} for _ in paths], dtype=object),
+        model_id=np.array("hf-hub:laion/CLIP-ViT-B-32-laion2B-s34B-b79K"),
+        embedding_dim=np.array(EMBED_DIM),
+    )
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_http(base_url: str, timeout: float = 60.0) -> None:
+    import urllib.error
+    import urllib.request
+
+    deadline = time.time() + timeout
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(base_url, timeout=2) as resp:
+                if resp.status == 200:
+                    return
+        except (urllib.error.URLError, OSError) as exc:  # not up yet
+            last_err = exc
+        time.sleep(0.4)
+    raise RuntimeError(f"server at {base_url} did not become ready in {timeout}s (last: {last_err})")
+
+
+@pytest.fixture(scope="session")
+def e2e_server(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """Launch the real server against a throwaway one-album config; yield base URL."""
+    workdir = tmp_path_factory.mktemp("e2e_album")
+    index_path = workdir / "embeddings.npz"
+    _build_fake_index(_collect_test_images(), index_path)
+
+    config_path = workdir / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "config_version": "1.0.0",
+                "albums": {
+                    "e2e": {
+                        "name": "E2E Test Album",
+                        "description": "throwaway album for e2e smoke tests",
+                        "image_paths": [str(TEST_IMAGES_DIR)],
+                        "index": str(index_path),
+                        "umap_eps": 0.13,
+                    }
+                },
+            }
+        )
+    )
+
+    port = _free_port()
+    base_url = f"http://127.0.0.1:{port}/"
+    start_photomap = Path(sys.executable).with_name("start_photomap")
+
+    env = {**os.environ, "PHOTOMAP_NO_BROWSER": "1"}
+    proc = subprocess.Popen(
+        [
+            str(start_photomap),
+            "--config", str(config_path),
+            "--host", "127.0.0.1",
+            "--port", str(port),
+            "--no-browser",
+            "--once",
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        _wait_for_http(base_url)
+        yield base_url
+    finally:
+        # Kill the whole process group; the server may spawn child workers.
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            proc.wait(timeout=5)
+
+
+@pytest.fixture(scope="session")
+def _playwright():
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        yield p
+
+
+@pytest.fixture(scope="session")
+def browser(_playwright):
+    browser = _playwright.chromium.launch()
+    try:
+        yield browser
+    finally:
+        browser.close()
+
+
+@pytest.fixture
+def page(browser):
+    context = browser.new_context()
+    page = context.new_page()
+    try:
+        yield page
+    finally:
+        context.close()
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip e2e tests unless RUN_E2E=1 — keeps the default suite fast/browser-free."""
+    if os.environ.get("RUN_E2E") == "1":
+        return
+    skip = pytest.mark.skip(reason="e2e tests are opt-in; set RUN_E2E=1 to run them")
+    for item in items:
+        if "e2e" in item.keywords:
+            item.add_marker(skip)

--- a/tests/e2e/test_slideshow_smoke.py
+++ b/tests/e2e/test_slideshow_smoke.py
@@ -1,0 +1,114 @@
+"""End-to-end smoke tests for the slideshow, driven through a real browser.
+
+Run with:  RUN_E2E=1 pytest tests/e2e -m e2e
+
+The shuffle test is a regression guard for the freeze fixed in the
+"keep shuffle autoplay alive after high-water-mark trim" change: trimming the
+slide buffer at the high-water mark stopped Swiper autoplay, so shuffle froze
+after ~19 slides. That bug was invisible to the jsdom unit tests (they mock
+Swiper) and only reproduced in a real browser — exactly what this guards.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.e2e
+
+# Cross the slide buffer's high-water mark (20) so the trim path runs. With the
+# autoplay-restart fix the show sails past this; without it, it freezes here.
+SHUFFLE_TARGET_ADVANCES = 25
+AUTOPLAY_DELAY_MS = 250
+
+
+def _select_album(page, album_key: str = "e2e") -> None:
+    # The native <select> is hidden behind a custom dropdown, so wait for the
+    # album option to be populated (async fetch) rather than for visibility, and
+    # drive it via the change event the app listens for.
+    page.wait_for_function(
+        """(key) => {
+            const sel = document.getElementById('albumSelect');
+            return sel && Array.from(sel.options).some((o) => o.value === key);
+        }""",
+        arg=album_key,
+        timeout=20_000,
+    )
+    page.evaluate(
+        """(key) => {
+            const sel = document.getElementById('albumSelect');
+            sel.value = key;
+            sel.dispatchEvent(new Event('change', { bubbles: true }));
+        }""",
+        album_key,
+    )
+    # Wait until the swiper has the album loaded (at least one real slide).
+    page.wait_for_function(
+        "() => { const sw = document.getElementById('singleSwiper')?.swiper;"
+        " return sw && sw.slides && sw.slides.length >= 1; }",
+        timeout=15_000,
+    )
+
+
+def test_app_loads_and_album_has_images(page, e2e_server):
+    """Baseline: the app boots, the album loads, and slides are served."""
+    page.goto(e2e_server, wait_until="networkidle")
+    _select_album(page)
+    slide_count = page.evaluate("() => document.getElementById('singleSwiper').swiper.slides.length")
+    assert slide_count >= 1
+
+
+def test_shuffle_runs_past_high_water_mark(page, e2e_server):
+    """Shuffle autoplay must keep advancing past the buffer high-water mark."""
+    page.goto(e2e_server, wait_until="networkidle")
+    _select_album(page)
+
+    # Switch to shuffle, instrument advance counting, then start the show.
+    page.evaluate(
+        """(delay) => {
+            const random = document.getElementById('modeRandom');
+            random.checked = true;
+            random.dispatchEvent(new Event('change', { bubbles: true }));
+
+            const sw = document.getElementById('singleSwiper').swiper;
+            window.__advances = 0;
+            sw.on('slideNextTransitionStart', () => { window.__advances += 1; });
+
+            document.getElementById('startStopSlideshowBtn').click();
+            // Shrink the live autoplay delay so the test runs quickly.
+            const tick = () => { sw.params.autoplay.delay = delay; };
+            tick();
+            setTimeout(tick, 250);
+            setTimeout(tick, 1000);
+        }""",
+        AUTOPLAY_DELAY_MS,
+    )
+
+    try:
+        page.wait_for_function(
+            "(target) => (window.__advances || 0) >= target",
+            arg=SHUFFLE_TARGET_ADVANCES,
+            timeout=30_000,
+        )
+    except Exception:  # surface a useful diagnostic instead of a bare timeout
+        state = page.evaluate(
+            """() => {
+                const sw = document.getElementById('singleSwiper').swiper;
+                return {
+                    advances: window.__advances || 0,
+                    running: !!(sw.autoplay && sw.autoplay.running),
+                    activeIndex: sw.activeIndex,
+                    slides: sw.slides.length,
+                };
+            }"""
+        )
+        pytest.fail(
+            "shuffle slideshow stalled before "
+            f"{SHUFFLE_TARGET_ADVANCES} advances: {state} "
+            "(autoplay likely stopped at the high-water-mark trim)"
+        )
+
+    running = page.evaluate(
+        "() => { const sw = document.getElementById('singleSwiper').swiper;"
+        " return !!(sw.autoplay && sw.autoplay.running); }"
+    )
+    assert running, "autoplay should still be running after crossing the high-water mark"


### PR DESCRIPTION
Adds an opt-in **end-to-end** test layer that launches the real server and drives it with headless Chromium — the layer that would have caught the shuffle freeze (#313) automatically.

> **Stacked on #313.** Based on `lstein/fix/shuffle-slideshow-freeze` so its tests pass (the fix is present). GitHub will retarget this to `master` once #313 merges.

### Why
The shuffle freeze lived entirely in the interaction between our code and Swiper's autoplay. The jsdom unit tests **mock Swiper**, so they were structurally blind to it — it only reproduced in a real browser. This harness covers that gap.

### What's here
- **`tests/e2e/conftest.py`** — builds a throwaway album with a **fake `.npz` index** (random vectors, real on-disk image paths) so no CLIP model or network is needed; launches `start_photomap` on a free port (`--no-browser --once`); provides Playwright `browser`/`page` fixtures. (The real index stores absolute paths, so it can't be a committed fixture — hence building at runtime.)
- **`tests/e2e/test_slideshow_smoke.py`** — `test_app_loads_and_album_has_images` (baseline) and `test_shuffle_runs_past_high_water_mark` (the regression guard: shuffle must advance past the buffer high-water mark of 20).
- **Opt-in**: skipped unless `RUN_E2E=1`, so `pytest tests` stays fast and browser-free. New `e2e` marker + `[e2e]` extra (Playwright).
- **`tests/e2e/README.md`** — setup and how-to.

### Verification
- With the fix present: **2 passed**.
- With the autoplay-restart removed: the guard **fails** with
  `stalled before 25 advances: advances=19, running=False, activeIndex=18, slides=20` — i.e. it reproduces the exact freeze, at exactly the slide it died on before.
- `RUN_E2E` unset → `2 skipped in 0.01s`. `ruff` clean.

### Follow-up (not in this PR)
A dedicated CI job (`pip install -e .[testing,e2e]` + `playwright install chromium` + `RUN_E2E=1 pytest tests/e2e`). Left out so CI config changes get their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)