### PR TITLE
chore(release): bump version to 1.1.0 [DO NOT MERGE until release]

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,86 @@
+# Release Notes
+
+Notable changes to PhotoMapAI, newest first. For the full commit-level history,
+see the [GitHub releases page](https://github.com/lstein/PhotoMapAI/releases).
+
+## 1.1.0
+
+This is a big feature release — the highlight is a **brand-new, signed desktop
+installer** that removes the old "install Python and CUDA first" friction. Since
+1.0.5 there are 22 new features and dozens of fixes, with no breaking changes.
+
+### ⭐ New install experience
+
+- **Signed, double-clickable desktop installer for macOS, Windows, and Linux**
+  (#300). No need to install Python, CUDA, or anything else first — on first
+  launch it downloads a private Python plus the AI libraries, starts the server,
+  and opens your browser automatically. Later launches start in seconds.
+    - Code-signed on macOS and Windows, so no more Gatekeeper/quarantine dances.
+    - Custom app icons across all three platforms (#304).
+    - Advanced `--pkg-version` flag to install a specific release (#310).
+- **GPU "just works":** an NVIDIA GPU is detected and used automatically. You no
+  longer need to install the CUDA Toolkit — only a recent NVIDIA driver. Apple
+  Silicon acceleration is automatic too.
+- **Python 3.14 support** (#258).
+
+### 🗺️ Semantic map (UMAP)
+
+- **Automatic cluster labeling** — clusters are now named by content (#234).
+- **Per-image tags in the hover popup** (#262).
+- **Album switcher** built into the semantic-map titlebar (#287).
+- **Smooth zoom everywhere:** custom scroll-wheel and pinch-to-zoom that work
+  across all browsers, including Safari and iOS touch (#312).
+
+### 🔎 Search & discovery
+
+- **In-app Back button + browser back/forward** for navigating your slide
+  history (#241).
+- **Encoder model download progress** is now surfaced in the album UI during
+  indexing (#308).
+- **Platform-aware default encoder** for new albums (#307).
+- Broader **auto-tagging vocabulary**, with an opt-out toggle (#251).
+- Search and other server errors now appear as **toast notifications** instead of
+  failing silently (#278, #288).
+
+### 🖼️ Slideshow
+
+- Smarter end-of-show behavior: sequential mode stops cleanly on the last slide
+  (with the play button grayed out), while shuffle mode reshuffles endlessly
+  (#293, #296).
+- Shuffle autoplay stays alive through long runs and buffer rebuilds (#297, #313).
+
+### 🎯 Curation
+
+- **Grid view** plus an automatic UMAP on completion, and a **~200× speedup** in
+  BLOCKS curation (#281).
+
+### 🏷️ Metadata
+
+- EXIF drawer now shows **DateTimeOriginal, Orientation, and image dimensions**
+  (#279).
+- **Clickable reference-image thumbnails** in the metadata drawer (#238).
+- Better handling of InvokeAI v5 metadata and assorted format edge cases (#267,
+  #268).
+
+### ⚙️ Preferences & quality of life
+
+- **Per-device, server-side UI preferences** — your layout choices persist per
+  device (#284).
+- **Move to Trash / Recycle Bin** option for image deletion, instead of permanent
+  removal (#273).
+- An **update badge** on the About button when a newer version is available
+  (#280).
+- Cached reverse-geocoding for faster GPS location lookups (#272).
+
+### 🔒 Notable fixes
+
+- Closed **XSS, path-traversal, and partial-write** security risks (#242).
+- Resolved indexing/concurrency race conditions and VRAM-release issues (#243,
+  #271).
+- Numerous UI leak and stability fixes across the slideshow, curation, and grid
+  views.
+
+Plus internal refactors, CI repairs, and frontend cleanups under the hood.
+
+!!! note "Upgrading from the `1.0.6rc1` prerelease"
+    The `1.0.6rc1` prerelease line is superseded — please move to `1.1.0`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,13 +1,18 @@
 # Release Notes
 
-Notable changes to PhotoMapAI, newest first. For the full commit-level history,
-see the [GitHub releases page](https://github.com/lstein/PhotoMapAI/releases).
+Welcome to PhotoMapAI, an AI-based image manager. See
+[Features](https://lstein.github.io/PhotoMapAI/) for a quick
+introduction,
+[Installation](https://lstein.github.io/PhotoMapAI/installation) to
+get PhotoMapAI installed on your home computer, and [User
+Guide](https://lstein.github.io/PhotoMapAI/user-guide/basic-usage/)
+for usage and configuration.
 
-## 1.1.0
+## PhotoMapAI Version 1.1.0
 
-This is a big feature release — the highlight is a **brand-new, signed desktop
-installer** that removes the old "install Python and CUDA first" friction. Since
-1.0.5 there are 22 new features and dozens of fixes, with no breaking changes.
+This is a big feature release — the highlight is a **much smoother install experience**
+on Macintoshes, Windows machines and Linux boxes. In addition, since the previous
+1.0.5 release there are 22 new features and dozens of fixes large and small.
 
 ### ⭐ New install experience
 
@@ -15,16 +20,9 @@ installer** that removes the old "install Python and CUDA first" friction. Since
   (#300). No need to install Python, CUDA, or anything else first — on first
   launch it downloads a private Python plus the AI libraries, starts the server,
   and opens your browser automatically. Later launches start in seconds.
-    - Code-signed on macOS and Windows, so no more Gatekeeper/quarantine dances.
-    - Custom app icons across all three platforms (#304).
-    - Advanced `--pkg-version` flag to install a specific release (#310).
-- **Reliable first-run setup, everywhere.** The launcher installs its private
-  Python by handing `uv` the downloaded interpreter directly, so first-run setup
-  completes cleanly even on Windows machines running OneDrive "Files On-Demand" —
-  which previously could block installation with an "untrusted mount point"
-  error (#326). On macOS, the launcher now explains up front that the one-time
-  Xcode Command Line Tools prompt is harmless and can be accepted *or* cancelled
-  (#324).
+- **Reliable first-run setup, everywhere.** The launcher installs its
+  private Python and required libraries, avoiding interfering with
+  other software installed on the machine.
 - **GPU "just works":** an NVIDIA GPU is detected and used automatically. You no
   longer need to install the CUDA Toolkit — only a recent NVIDIA driver. Apple
   Silicon acceleration is automatic too.
@@ -89,5 +87,6 @@ installer** that removes the old "install Python and CUDA first" friction. Since
 
 Plus internal refactors, CI repairs, and frontend cleanups under the hood.
 
-!!! note "Upgrading from the `1.0.6rc1` prerelease"
-    The `1.0.6rc1` prerelease line is superseded — please move to `1.1.0`.
+For the full commit-level history, see the [GitHub releases
+page](https://github.com/lstein/PhotoMapAI/releases).
+

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -18,6 +18,13 @@ installer** that removes the old "install Python and CUDA first" friction. Since
     - Code-signed on macOS and Windows, so no more Gatekeeper/quarantine dances.
     - Custom app icons across all three platforms (#304).
     - Advanced `--pkg-version` flag to install a specific release (#310).
+- **Reliable first-run setup, everywhere.** The launcher installs its private
+  Python by handing `uv` the downloaded interpreter directly, so first-run setup
+  completes cleanly even on Windows machines running OneDrive "Files On-Demand" —
+  which previously could block installation with an "untrusted mount point"
+  error (#326). On macOS, the launcher now explains up front that the one-time
+  Xcode Command Line Tools prompt is harmless and can be accepted *or* cancelled
+  (#324).
 - **GPU "just works":** an NVIDIA GPU is detected and used automatically. You no
   longer need to install the CUDA Toolkit — only a recent NVIDIA driver. Apple
   Silicon acceleration is automatic too.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
       - Architecture: developer/architecture.md
       - API: developer/api.md
       - Frontend: developer/frontend.md
+  - Release Notes: release-notes.md
   - Troubleshooting: troubleshooting.md
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "photomapai"
-version = "1.0.6rc1"
+version = "1.1.0"
 description = "AI-based image clustering and exploration tool"
 authors = [
     { name = "Lincoln Stein", email = "lincoln.stein@gmail.com" }


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until just before cutting the 1.1.0 release

This PR bumps `pyproject.toml` to `1.1.0` **and** adds the 1.1.0 release notes. **Merge it last**, immediately before tagging/releasing — and only *after* the docs and deprecation PRs have landed, so that 1.1.0 actually contains them:

- #318 — docs(installation): NVIDIA driver vs CUDA Toolkit clarification
- #319 — chore(install): deprecate legacy installer scripts

Merging this early would leave `master` claiming to be a released `1.1.0` while still missing those changes.

## What & why

Go directly to **1.1.0**, skipping `1.0.6` and `1.1.0rc1`. Since 1.0.5 there have been **22 features and no breaking changes** — a minor bump, not a patch. Headline items: the signed uv-bootstrap desktop launcher (#300), UMAP cluster auto-labeling (#234), per-device UI preferences (#284), Move-to-Trash deletion (#273), and Python 3.14 support (#258). The small user base (~70 stars) and the fact that the new install system was the gate on wider publicity make an `rc` unnecessary.

The `1.0.6rc1` prerelease tag becomes a dead-end; testers on it should move to the `1.1.0` line.

## Changes

- `pyproject.toml`: `1.0.6rc1` → `1.1.0` (single-sourced; `get_version()` in `args.py` reads `importlib.metadata`).
- `docs/release-notes.md` (new): changelog-style page, newest version first, summarizing 1.1.0 grouped by theme. Wired into the mkdocs nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
