### PR TITLE
feat(server): print startup banner before heavy imports load

### DIFF
--- a/photomap/backend/launch.py
+++ b/photomap/backend/launch.py
@@ -1,0 +1,20 @@
+"""Lightweight console-script launcher for ``start_photomap``.
+
+Importing :mod:`photomap.backend.photomap_server` pulls in FastAPI, the routers
+and (transitively) CLIP/torch, which can take 10-30s. Because the console-script
+entry point has to import its target module before calling it, a banner printed
+inside ``photomap_server.main`` only appears after that whole import finishes,
+leaving the terminal silent during startup.
+
+This module deliberately imports nothing heavy at module scope so the banner is
+printed immediately, then defers the expensive import until inside ``main``.
+"""
+
+import sys
+
+
+def main() -> None:
+    print("PhotoMapAI server initializing…", file=sys.stderr, flush=True)
+    from photomap.backend.photomap_server import main as _serve
+
+    _serve()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ search_images = "photomap.backend.imagetool:main"
 search_text = "photomap.backend.imagetool:main"
 find_duplicate_images = "photomap.backend.imagetool:main"
 rebuild_cluster_labels = "photomap.backend.imagetool:main"
-start_photomap = "photomap.backend.photomap_server:main"
+start_photomap = "photomap.backend.launch:main"
 
 [tool.ruff]
 # Set line length to match the project's style


### PR DESCRIPTION
## Problem

Running `start_photomap` leaves the terminal silent for ~10-30s (platform-dependent) before any status message appears. The console script maps to `photomap.backend.photomap_server:main`, so Python must **import** that module — which pulls in FastAPI, the routers, and transitively CLIP/torch — before a single line of `main()` runs. Any banner printed inside `main()` is therefore too late.

## Fix

Add a lightweight `photomap/backend/launch.py` shim that imports nothing heavy at module scope. It prints `PhotoMapAI server initializing…` immediately, then defers the expensive `from photomap.backend.photomap_server import main` until inside its own `main()`. Repoint the `start_photomap` console script at `photomap.backend.launch:main`.

## Relaunch loop / inline-update safety

The supervisor relaunch loop and the inline-update restart are **unaffected**: they respawn workers via `python -m photomap.backend.photomap_server … --once`, which never goes through `launch.py`. The banner prints once in the parent; each respawn still logs `Loading...` via the existing supervisor loop.

## Verification

- Banner appears within ~1s, before the heavy import completes.
- End-to-end: supervisor spawns a worker (HTTP 200) → `SIGTERM` the worker to simulate an inline-update restart → supervisor respawns a fresh worker (HTTP 200 again).
- `ruff check` passes on the new module.

> [!NOTE]
> Changing the entry-point target regenerates the `start_photomap` console script, so existing checkouts need a `pip install -e .` to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)