### PR TITLE
fix(cluster-labels): content-based vocab cache invalidation (survive reinstall)

### DIFF
--- a/photomap/backend/cluster_labels.py
+++ b/photomap/backend/cluster_labels.py
@@ -247,10 +247,18 @@ def _read_cached_vocab(
     vocab_path: Path,
     encoder_spec: str,
 ) -> tuple[list[str], np.ndarray] | None:
-    """Return cached (phrases, embeddings) if valid, else None to signal rebuild."""
+    """Return cached (phrases, embeddings) if valid, else None to signal rebuild.
+
+    Invalidation is purely content-based: the encoder spec, template count, and
+    the exact phrase set are all stamped in the cache and compared here. We
+    deliberately do NOT compare file mtimes — a reinstall (or any `touch`)
+    rewrites the bundled `cluster_vocab.txt` with a newer mtime even when its
+    contents are byte-for-byte identical, and an mtime gate would then discard a
+    perfectly valid cache and force a multi-second CLIP re-encode on first
+    startup. Content comparison reuses the cache across reinstalls and only
+    rebuilds when the vocabulary actually changed.
+    """
     if not cache_path.exists():
-        return None
-    if cache_path.stat().st_mtime < _vocab_sources_max_mtime(vocab_path):
         return None
     try:
         data = np.load(cache_path, allow_pickle=False)
@@ -274,11 +282,10 @@ def _read_cached_vocab(
         )
         return None
     phrases = [str(p) for p in data["phrases"]]
-    # Mtime check above can miss two cases:
-    #   - User extras file deleted/renamed: bundled mtime stays the same, but
-    #     the phrase set just shrank.
-    #   - User extras file added back with an mtime older than the cache.
-    # Compare actual phrase sets to catch both.
+    # The stamped phrase set is the sole content signal. Comparing actual sets
+    # (rather than mtimes) catches every real change regardless of mtime
+    # direction: a user extras file deleted/renamed (phrase set shrinks while
+    # the bundled mtime is unchanged), or added back with a back-dated mtime.
     current_phrases = load_vocab_phrases(vocab_path)
     if set(phrases) != set(current_phrases):
         logger.info(
@@ -299,12 +306,13 @@ def get_or_build_vocab_embeddings(
     """Load or build the vocab embeddings cache for `encoder_spec`.
 
     Returns `(phrases, embeddings)` where `embeddings` is `(N, D)` float32 and
-    L2-normalized after template-ensemble mean-pooling. The cache rebuilds when:
+    L2-normalized after template-ensemble mean-pooling. Invalidation is
+    content-based (never mtime-based, so the cache survives reinstalls that
+    rewrite the bundled vocab file without changing it). The cache rebuilds when:
 
     - the file is missing,
-    - either vocab source file has been edited since the cache was written,
-    - the stored phrase set differs from what's on disk now (catches user
-      extras file deletion/rename, which mtime alone misses),
+    - the stored phrase set differs from what's on disk now (catches edits,
+      additions, and user extras file deletion/rename),
     - the stamped encoder spec doesn't match (defensive against filename collisions),
     - `len(PROMPT_TEMPLATES)` has changed since the cache was written.
 
@@ -473,12 +481,10 @@ def _read_cached_labels(
     if cache_mtime < embeddings_path.stat().st_mtime:
         return None
     # Vocab edits change the candidate label strings (and, indirectly, the chosen
-    # top-1 once vocab embeddings rebuild). Without this check, a vocab refresh
-    # would silently leave every album's labels stale until the album reindexes.
-    # Both the bundled vocab and the user extras file count as sources.
-    vocab_path = vocab_file_path()
-    if vocab_path.exists() and cache_mtime < _vocab_sources_max_mtime(vocab_path):
-        return None
+    # top-1 once vocab embeddings rebuild). That signal is the stored
+    # ``vocab_fingerprint`` checked below — a content hash, not an mtime, so a
+    # reinstall that rewrites the bundled vocab without changing it doesn't
+    # needlessly invalidate every album's labels cache.
     try:
         data = np.load(cache_path, allow_pickle=False)
         cluster_ids = [int(c) for c in data["cluster_ids"]]

--- a/tests/backend/test_cluster_labels.py
+++ b/tests/backend/test_cluster_labels.py
@@ -246,10 +246,7 @@ def test_encode_propagates_non_oom_errors(tiny_vocab, monkeypatch):
 def test_vocab_cache_invalidates_on_user_file_edit(
     tiny_vocab, isolated_cache, fake_encoder, monkeypatch, tmp_path
 ):
-    """Touching the user extras file should rebuild the vocab embeddings."""
-    import os
-    import time
-
+    """Editing the user extras file (changing its phrases) should rebuild."""
     user = tmp_path / "extras.txt"
     user.write_text("stadium\n", encoding="utf-8")
     monkeypatch.setattr(cluster_labels, "user_vocab_file_path", lambda: user)
@@ -259,12 +256,43 @@ def test_vocab_cache_invalidates_on_user_file_edit(
     encoder = fake_encoder[spec]
     calls_before = encoder.encode_calls
 
-    # Bump user file mtime forward
+    # Change the content — the phrase set actually differs now.
+    user.write_text("stadium\nlibrary\n", encoding="utf-8")
+
+    phrases, _ = cluster_labels.get_or_build_vocab_embeddings(spec)
+    assert "library" in phrases
+    assert encoder.encode_calls == calls_before + 1
+
+
+def test_vocab_cache_survives_mtime_bump_without_content_change(
+    tiny_vocab, isolated_cache, fake_encoder, monkeypatch, tmp_path
+):
+    """A pure `touch` (newer mtime, identical content) must NOT rebuild.
+
+    This is the reinstall case: `pip install` rewrites the bundled
+    ``cluster_vocab.txt`` with a fresh mtime even when its contents are
+    unchanged. Invalidation is content-based, so the cached embeddings — and
+    the multi-second CLIP encode that produced them — are reused.
+    """
+    import os
+    import time
+
+    user = tmp_path / "extras.txt"
+    user.write_text("stadium\n", encoding="utf-8")
+    monkeypatch.setattr(cluster_labels, "user_vocab_file_path", lambda: user)
+
+    spec = "fake:user-vocab-touch"
+    cluster_labels.get_or_build_vocab_embeddings(spec)
+    encoder = fake_encoder[spec]
+    calls_before = encoder.encode_calls
+
+    # Bump both source files' mtimes forward without changing their contents.
     future = time.time() + 5
     os.utime(user, (future, future))
+    os.utime(cluster_labels.vocab_file_path(), (future, future))
 
     cluster_labels.get_or_build_vocab_embeddings(spec)
-    assert encoder.encode_calls == calls_before + 1
+    assert encoder.encode_calls == calls_before  # cache reused, no rebuild
 
 
 def test_vocab_cache_invalidates_when_user_file_removed(
@@ -448,12 +476,8 @@ def test_cache_invalidates_on_vocab_edit(tiny_vocab, isolated_cache, fake_encode
     encoder = fake_encoder[spec]
     assert encoder.encode_calls == 1
 
-    # Edit the vocab — bump the mtime forward
-    import os
-    import time
+    # Edit the vocab content — the phrase set changes, so the cache rebuilds.
     tiny_vocab.write_text(tiny_vocab.read_text() + "\nstadium\n", encoding="utf-8")
-    future = time.time() + 5
-    os.utime(tiny_vocab, (future, future))
 
     phrases, emb = cluster_labels.get_or_build_vocab_embeddings(spec)
     assert "stadium" in phrases
@@ -716,12 +740,43 @@ def test_get_or_build_invalidates_on_embeddings_touch(synthetic_album, monkeypat
     assert call_count["n"] == 2
 
 
-def test_get_or_build_invalidates_on_vocab_touch(synthetic_album, monkeypatch, tmp_path):
+def test_get_or_build_invalidates_on_vocab_edit(synthetic_album, monkeypatch, tmp_path):
     """Editing cluster_vocab.txt must invalidate every per-album labels cache."""
+    # Synthetic vocab file so we can edit it in isolation.
+    vocab = tmp_path / "vocab.txt"
+    vocab.write_text("abbey\nwedding\nmountain\nkitchen\ncar\n", encoding="utf-8")
+    monkeypatch.setattr(cluster_labels, "vocab_file_path", lambda: vocab)
+
+    call_count = {"n": 0}
+    real_compute = cluster_labels.compute_cluster_labels
+
+    def counting_compute(*args, **kwargs):
+        call_count["n"] += 1
+        return real_compute(*args, **kwargs)
+
+    monkeypatch.setattr(cluster_labels, "compute_cluster_labels", counting_compute)
+
+    cluster_labels.get_or_build_cluster_labels(
+        synthetic_album, cluster_eps=1.0, cluster_min_samples=3
+    )
+    # Change the vocabulary content — the fingerprint changes, so the labels
+    # cache must rebuild.
+    vocab.write_text("abbey\nwedding\nmountain\nkitchen\ncar\nbridge\n", encoding="utf-8")
+    cluster_labels.get_or_build_cluster_labels(
+        synthetic_album, cluster_eps=1.0, cluster_min_samples=3
+    )
+    assert call_count["n"] == 2
+
+
+def test_get_or_build_labels_survives_vocab_mtime_bump(synthetic_album, monkeypatch, tmp_path):
+    """A pure `touch` of the vocab file (same content) must NOT rebuild labels.
+
+    The reinstall case for the per-album labels cache: identical vocabulary,
+    fresher mtime. Content fingerprinting keeps the cache valid.
+    """
     import os
     import time
 
-    # Synthetic vocab file so we can bump its mtime in isolation.
     vocab = tmp_path / "vocab.txt"
     vocab.write_text("abbey\nwedding\nmountain\nkitchen\ncar\n", encoding="utf-8")
     monkeypatch.setattr(cluster_labels, "vocab_file_path", lambda: vocab)
@@ -743,7 +798,7 @@ def test_get_or_build_invalidates_on_vocab_touch(synthetic_album, monkeypatch, t
     cluster_labels.get_or_build_cluster_labels(
         synthetic_album, cluster_eps=1.0, cluster_min_samples=3
     )
-    assert call_count["n"] == 2
+    assert call_count["n"] == 1  # cache reused, no rebuild
 
 
 def test_get_or_build_invalidates_when_user_vocab_removed(


### PR DESCRIPTION
## Problem

The encoded tagging vocabulary was being **rebuilt from scratch on first startup after a reinstall**, even though the cached embeddings were still on disk and valid.

Root cause: both the vocab-embedding cache (`_read_cached_vocab`) and the per-album labels cache (`_read_cached_labels`) invalidated by comparing the cache file's mtime against the source vocab files. A `pip` reinstall rewrites the bundled `cluster_vocab.txt` with a **fresh mtime even when its contents are byte-for-byte identical**, so the mtime gate tripped and forced a multi-second CLIP re-encode of the entire vocabulary — despite the content being unchanged.

(The build was *triggered* legitimately, by a surviving per-device `autotaggingEnabled` preference or a second browser tab — that part is working as designed. This PR fixes the wasteful *rebuild*.)

## Change

Switch both caches to purely **content-based** invalidation:

- **`_read_cached_vocab`** — drop the mtime gate. The exact phrase set is already stamped into the `.npz` and compared (`set(phrases) != set(current_phrases)`), which catches every real change (edits, additions, user-extras deletion/rename) regardless of mtime direction.
- **`_read_cached_labels`** — drop the vocab-mtime gate; rely on the stored `vocab_fingerprint` (sha256 content hash) already compared just below. The `umap.npz` and source-embeddings mtime checks stay, since those track album-local regeneration, not reinstalls.

The per-image in-process LRU (`compute_image_label`) intentionally keeps its mtime key: it's process-scoped, so a reinstall never reuses it anyway, and mtime is cheaper than hashing the vocabulary on that hot path.

Nothing here deletes the cache when autotagging is turned off — once encoded, the vocabulary stays cached across reinstalls for later use.

## Tests

- Repurposed the two tests that asserted "pure mtime bump → rebuild" to assert "**content edit → rebuild**" (the real intent).
- Added regression tests proving a pure `touch` with identical content does **not** rebuild either the vocab-embedding cache or the per-album labels cache.

All green locally: 384 backend + 356 frontend tests pass, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)