### PR TITLE
fix(launcher): warn about macOS Xcode CLT prompt instead of forcing managed Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ For PyPI, Docker, and manual install instructions, see the [Installation guide](
 If you already have Python 3.10–3.14 and prefer the command line:
 
 ```bash
-uv tool install photomapai --python 3.12 --python-preference only-managed --torch-backend auto
+uv tool install photomapai --torch-backend auto   # or: pip install photomapai
 start_photomap
-# (or simply: pip install photomapai && start_photomap)
 ```
 
 Then open your browser to [http://127.0.0.1:8050](http://127.0.0.1:8050) (it opens automatically) and follow the prompts to create your first album.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -101,9 +101,8 @@ PhotoMapAI 也支援多相簿管理、依時間瀏覽照片、簡潔的全螢幕
 如果你已經安裝 Python 3.10–3.14，並偏好使用命令列：
 
 ```bash
-uv tool install photomapai --python 3.12 --python-preference only-managed --torch-backend auto
+uv tool install photomapai --torch-backend auto   # 或：pip install photomapai
 start_photomap
-# （或改用 pip：pip install photomapai && start_photomap）
 ```
 
 接著開啟瀏覽器，前往 [http://127.0.0.1:8050](http://127.0.0.1:8050)（會自動開啟），並依照畫面提示建立你的第一個相簿。

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,9 +90,8 @@ See the [Installation guide](installation.md) for PyPI, Docker, source, GPU over
 If you already have Python 3.10–3.14:
 
 ```bash
-uv tool install photomapai --python 3.12 --python-preference only-managed --torch-backend auto
+uv tool install photomapai --torch-backend auto   # or: pip install photomapai
 start_photomap
-# (or simply: pip install photomapai && start_photomap)
 ```
 
 After the startup messages your browser opens to http://localhost:8050 automatically.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,14 +74,11 @@ To also remove the downloaded Python/libraries, run `photomap --uninstall` (path
 If you are comfortable with the command line and already have Python 3.10–3.14, you can install the package directly. We recommend [uv](https://docs.astral.sh/uv/):
 
 ```bash
-uv tool install photomapai --python 3.12 --python-preference only-managed --torch-backend auto
+uv tool install photomapai --torch-backend auto
 start_photomap
 ```
 
-`--torch-backend auto` picks GPU or CPU PyTorch automatically. `--python 3.12
---python-preference only-managed` tells `uv` to use its own managed Python build
-rather than a system one; on macOS this avoids a pop-up that asks to install the
-Xcode command-line tools. Or with plain `pip` in a virtual environment:
+`--torch-backend auto` picks GPU or CPU PyTorch automatically. Or with plain `pip` in a virtual environment:
 
 ```bash
 python -m venv photomap --prompt photomap
@@ -131,4 +128,4 @@ start_photomap
 
 Both create an isolated virtual environment in `./.venv`; the difference is only which tool builds it. If you intend to *modify* the source, add `-e` to do an editable install (`uv pip install -e .` or `pip install -e .`) — but then the environment is tied to this folder's location, so don't move or rename it afterwards.
 
-GPU acceleration needs only a recent **NVIDIA driver** — *not* the CUDA Toolkit (see [NVIDIA GPU Acceleration](installation/cuda.md)). On Linux and macOS the default `pip install .` already pulls a GPU-capable build of PyTorch, so there's nothing extra to do. On Windows the default PyTorch from PyPI is CPU-only; to enable the GPU, install the CUDA build of PyTorch from PyTorch's [official index](https://pytorch.org/get-started/locally/), or use the `uv tool install` recipe above, which selects the right build automatically. To start the server again later, re-run `start_photomap` from the activated environment.
+GPU acceleration needs only a recent **NVIDIA driver** — *not* the CUDA Toolkit (see [NVIDIA GPU Acceleration](installation/cuda.md)). On Linux and macOS the default `pip install .` already pulls a GPU-capable build of PyTorch, so there's nothing extra to do. On Windows the default PyTorch from PyPI is CPU-only; to enable the GPU, install the CUDA build of PyTorch from PyTorch's [official index](https://pytorch.org/get-started/locally/), or use the `uv tool install photomapai --torch-backend auto` recipe above, which selects the right build automatically. To start the server again later, re-run `start_photomap` from the activated environment.

--- a/docs/installation/cuda.md
+++ b/docs/installation/cuda.md
@@ -89,8 +89,8 @@ installs the *driver*, not the CUDA Toolkit.
   (or want to force a re-detect), launch with the `--gpu` flag — see
   [GPU acceleration](../installation.md#gpu-acceleration) in the main installation
   guide.
-- **PyPI / `uv`:** `uv tool install photomapai --python 3.12 --python-preference only-managed --torch-backend auto`
-  picks the GPU or CPU build of PyTorch automatically based on what `nvidia-smi` reports.
+- **PyPI / `uv`:** `uv tool install photomapai --torch-backend auto` picks the GPU
+  or CPU build of PyTorch automatically based on what `nvidia-smi` reports.
 
 To confirm GPU support is active, watch for a console message about GPU
 acceleration when PhotoMapAI starts up.

--- a/launcher/uv.go
+++ b/launcher/uv.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const (
@@ -45,15 +46,6 @@ func (l layout) uvEnv() []string {
 		"UV_CACHE_DIR="+l.cacheDir,
 		// Don't let a managed-Python download be disabled by inherited config.
 		"UV_PYTHON_DOWNLOADS=automatic",
-		// Only ever use uv's managed (python-build-standalone) interpreters,
-		// never a system/framework CPython. uv's default preference ("managed")
-		// will still fall back to a system interpreter if it finds a matching
-		// version — on macOS that's the non-relocatable python.org framework
-		// build at /Library/Frameworks/Python.framework. Building a venv from it
-		// makes uv rewrite Mach-O load paths with `install_name_tool`, which
-		// triggers the Xcode Command Line Tools install prompt. Managed builds
-		// are relocatable, so forcing only-managed avoids that prompt entirely.
-		"UV_PYTHON_PREFERENCE=only-managed",
 	)
 	return env
 }
@@ -241,6 +233,26 @@ func writeMarker(l layout, torchBackend string) error {
 	return os.WriteFile(l.marker, []byte(torchBackend+"\n"), 0o644)
 }
 
+// warnIfXcodeToolsMissing gives macOS users a heads-up before uv runs for the
+// first time. When uv builds the tool's virtualenv it has macOS rewrite the
+// Python executable's library paths with `install_name_tool`; if the Xcode
+// Command Line Tools aren't installed, macOS pops a dialog offering to install
+// them. The tools are NOT actually needed — PhotoMapAI installs fine whether the
+// user accepts or cancels — and there's no clean way to suppress the dialog, so
+// we just warn, pause long enough to read it, and continue. No-op off macOS, or
+// when the Command Line Tools are already present (then no dialog appears).
+func warnIfXcodeToolsMissing() {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	// `xcode-select -p` exits non-zero when the Command Line Tools are absent.
+	if err := exec.Command("xcode-select", "-p").Run(); err == nil {
+		return
+	}
+	fmt.Println("\nMacOS will ask you to install the XCode Command Line Tools. Either cancel or accept this request -- it makes no difference.")
+	time.Sleep(5 * time.Second)
+}
+
 // install runs the uv steps to put photomapai on disk with the requested torch
 // backend. pkgSpec is the argument passed to `uv tool install` — usually the bare
 // pkgName, or pkgName=="<version>" when --pkg-version pins a release (an explicit
@@ -250,6 +262,8 @@ func writeMarker(l layout, torchBackend string) error {
 func install(l layout, pkgSpec, torchBackend string, reinstall bool) error {
 	fmt.Printf("\nFirst-time setup: downloading Python and the PhotoMapAI libraries.\n")
 	fmt.Printf("This is a multi-GB download and runs once; it can take several minutes.\n\n")
+
+	warnIfXcodeToolsMissing()
 
 	if err := l.runUV("python", "install", pythonVersion); err != nil {
 		return fmt.Errorf("installing Python: %w", err)

--- a/launcher/uv_test.go
+++ b/launcher/uv_test.go
@@ -51,21 +51,20 @@ func TestMarkerRoundTrip(t *testing.T) {
 	}
 }
 
-func TestUVEnvForcesManagedPython(t *testing.T) {
+func TestUVEnvRedirectsState(t *testing.T) {
 	l := layout{
 		pythonDir: "/tmp/pm/python",
 		toolDir:   "/tmp/pm/tools",
 		toolBin:   "/tmp/pm/bin",
 		cacheDir:  "/tmp/pm/cache",
 	}
+	// All uv state must be redirected under the runtime root so nothing leaks
+	// into the user's global uv cache/tools.
 	want := map[string]string{
 		"UV_PYTHON_INSTALL_DIR": l.pythonDir,
 		"UV_TOOL_DIR":           l.toolDir,
 		"UV_TOOL_BIN_DIR":       l.toolBin,
 		"UV_CACHE_DIR":          l.cacheDir,
-		// only-managed keeps uv off the non-relocatable macOS framework Python,
-		// which would otherwise trigger the Xcode install_name_tool prompt.
-		"UV_PYTHON_PREFERENCE": "only-managed",
 	}
 	got := map[string]string{}
 	for _, kv := range l.uvEnv() {


### PR DESCRIPTION
## Background

PR #322 (already merged) tried to suppress the macOS **"install Xcode Command Line Tools"** dialog during first-run setup by forcing uv to use a managed CPython (`UV_PYTHON_PREFERENCE=only-managed`). The theory: the python.org **framework** Python is non-relocatable, so uv runs `install_name_tool` (an Xcode CLT) when copying it into the tool venv, triggering the prompt.

**Testing on a cold Mac disproved that.** uv runs `install_name_tool` while building the tool virtualenv **regardless of which interpreter it uses**, so the dialog fires immediately either way. The managed-Python approach doesn't help, and there's no clean way to suppress the prompt.

Crucially, the Command Line Tools **aren't actually needed** — PhotoMapAI installs fine whether the user accepts or cancels the dialog.

## This change

Revert the `only-managed` approach and instead **set the right expectation**: before uv runs on macOS, if `xcode-select -p` reports the Command Line Tools are absent, print a short warning that the (harmless) dialog will appear, pause ~5s so it's read, then proceed.

The printed message:

> MacOS will ask you to install the XCode Command Line Tools. Either cancel or accept this request -- it makes no difference.

### Contents

- **`launcher/uv.go`** — drop `UV_PYTHON_PREFERENCE=only-managed` from `uvEnv()`; add `warnIfXcodeToolsMissing()` (no-op off macOS / when CLT already present) and call it at the top of `install()`, right before the first uv invocation.
- **`launcher/uv_test.go`** — `TestUVEnvForcesManagedPython` → `TestUVEnvRedirectsState`; keeps the dir-redirect coverage, drops the only-managed assertion.
- **docs / READMEs** — revert the `uv tool install photomapai --python 3.12 --python-preference only-managed --torch-backend auto` recipe back to `uv tool install photomapai --torch-backend auto`, and remove the now-false note that those flags avoid the macOS prompt.

## Notes

- This effectively reverts the user-facing behavior of #322 (which shipped on `master` but is part of the not-yet-released 1.1.0). No released version regresses.
- Unrelated to the open Windows/OneDrive `install_name_tool`… er, junction (error 448) investigation — that's a separate managed-Python-on-Windows issue still pending hardware testing.

## Tests

`go build` / `go vet` / `go test` / `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
