### PR TITLE
fix(launcher): retry uv install steps to survive transient first-run 448 (Windows/OneDrive)

### DIFF
--- a/launcher/uv.go
+++ b/launcher/uv.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const (
@@ -56,6 +57,45 @@ func (l layout) uvEnv() []string {
 		"UV_PYTHON_PREFERENCE=only-managed",
 	)
 	return env
+}
+
+// installStepAttempts is how many times each uv install command is tried before
+// giving up. On Windows with OneDrive Files-On-Demand, the cloud-filter driver
+// (cldflt) can transiently fail uv's creation of the managed-Python
+// minor-version junction with "untrusted mount point" (os error 448) while it
+// engages a freshly created folder tree on the very first run. The failure
+// clears itself once the filter settles, so a short retry turns what was a hard
+// first-run abort into a brief pause. Retrying is cheap: uv caches its
+// downloads, so a second attempt reuses the already-fetched Python/wheels.
+const installStepAttempts = 3
+
+// withRetry calls fn up to attempts times, returning nil on the first success
+// and the last error once attempts are exhausted. Between failed tries it calls
+// backoff(attempt) (1-based) so callers control the delay (and tests can make it
+// a no-op). Pulled out as a free function so the retry logic is unit-testable
+// without spawning a real uv.
+func withRetry(attempts int, backoff func(attempt int), fn func() error) error {
+	var err error
+	for attempt := 1; ; attempt++ {
+		if err = fn(); err == nil || attempt >= attempts {
+			return err
+		}
+		backoff(attempt)
+	}
+}
+
+// runUVRetry runs uv like runUV but retries a few times with a short, growing
+// backoff so a transient first-run filesystem error (see installStepAttempts)
+// self-heals instead of aborting setup.
+func (l layout) runUVRetry(args ...string) error {
+	return withRetry(installStepAttempts, func(attempt int) {
+		delay := time.Duration(attempt*3) * time.Second
+		fmt.Printf("\nThat step didn't complete (attempt %d of %d). Retrying in %s...\n",
+			attempt, installStepAttempts, delay)
+		time.Sleep(delay)
+	}, func() error {
+		return l.runUV(args...)
+	})
 }
 
 // runUV runs uv with the given arguments, streaming its output to our console.
@@ -251,7 +291,11 @@ func install(l layout, pkgSpec, torchBackend string, reinstall bool) error {
 	fmt.Printf("\nFirst-time setup: downloading Python and the PhotoMapAI libraries.\n")
 	fmt.Printf("This is a multi-GB download and runs once; it can take several minutes.\n\n")
 
-	if err := l.runUV("python", "install", pythonVersion); err != nil {
+	// --no-bin: the launcher runs start_photomap from the tool venv directly, so
+	// we don't need uv to drop a python3.12 shim into the user's ~/.local/bin
+	// (which it can't manage on reinstall, and which is one more cross-folder
+	// write outside our runtime root).
+	if err := l.runUVRetry("python", "install", pythonVersion, "--no-bin"); err != nil {
 		return fmt.Errorf("installing Python: %w", err)
 	}
 
@@ -263,7 +307,7 @@ func install(l layout, pkgSpec, torchBackend string, reinstall bool) error {
 	if reinstall {
 		args = append(args, "--reinstall")
 	}
-	if err := l.runUV(args...); err != nil {
+	if err := l.runUVRetry(args...); err != nil {
 		return fmt.Errorf("installing %s: %w", pkgSpec, err)
 	}
 	return writeMarker(l, torchBackend)

--- a/launcher/uv_test.go
+++ b/launcher/uv_test.go
@@ -1,12 +1,62 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestWithRetrySucceedsAfterTransientFailures(t *testing.T) {
+	calls, backoffs := 0, 0
+	err := withRetry(3, func(int) { backoffs++ }, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient 448")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withRetry = %v, want nil after recovering", err)
+	}
+	if calls != 3 {
+		t.Errorf("fn called %d times, want 3", calls)
+	}
+	if backoffs != 2 {
+		t.Errorf("backoff called %d times, want 2 (between the 3 tries)", backoffs)
+	}
+}
+
+func TestWithRetryReturnsLastErrorWhenExhausted(t *testing.T) {
+	calls := 0
+	want := errors.New("persistent failure")
+	err := withRetry(3, func(int) {}, func() error {
+		calls++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("withRetry = %v, want %v", err, want)
+	}
+	if calls != 3 {
+		t.Errorf("fn called %d times, want 3", calls)
+	}
+}
+
+func TestWithRetryStopsOnFirstSuccess(t *testing.T) {
+	calls := 0
+	err := withRetry(3, func(int) { t.Error("backoff should not be called on immediate success") }, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("withRetry = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("fn called %d times, want 1", calls)
+	}
+}
 
 func TestEnvOr(t *testing.T) {
 	const key = "PHOTOMAP_TEST_ENVOR"


### PR DESCRIPTION
## Problem

On a Windows machine with **OneDrive Files-On-Demand** active, the very first run of the launcher aborted with:

```
error: Failed to create Python minor version link directory
  Caused by: ... untrusted mount point. (os error 448)
```

After extensive isolation (same uv binary, flags, env, folder, elevation, cwd, and environment all tested), the failure proved to be a **transient first-run race**: OneDrive's cloud-filter driver (`cldflt`) briefly returns `STATUS_UNTRUSTED_MOUNT_POINT` (448) on uv's managed-Python *minor-version junction* creation while the filter engages the freshly-created folder tree. Re-running the exact same uv command moments later — from bash, cmd, or even the Explorer shortcut — succeeds every time. uv has **no flag** to skip that junction (`ensure_minor_version_link` is unconditional and fatal in uv's source), so we can't avoid creating it; we can only survive a one-time failure.

## Fix

Wrap the two `uv` install commands in a short, growing-backoff **retry** (`installStepAttempts = 3`, 3s then 6s). A one-time 448 self-heals on the next attempt instead of hard-aborting the user's first run — the moment it actually bites. Retrying is cheap: uv caches downloads, so a retry reuses the already-fetched Python/wheels. The retry logic is factored into a pure, unit-tested `withRetry(attempts, backoff, fn)` helper.

Also pass `--no-bin` to `uv python install` so uv stops dropping a `python3.12.exe` shim into the user's `~/.local/bin` (which it can't manage on reinstall, and is one more cross-folder write outside our self-contained runtime root). The launcher runs `start_photomap` from the tool venv directly and never needs Python on `PATH`.

## Tests

- `withRetry`: recovers after transient failures, returns the last error when exhausted, stops on first success (no backoff). Pure helper — no real uv spawned.
- `go build`, `go vet`, `go test`, `gofmt -l` all clean.

## Notes

- Independent of #322 (the macOS `only-managed` fix), which is already merged.
- The retry is a best-effort mitigation for a heisenbug we can't reproduce on demand; it does not change behavior on the happy path (single attempt, no delay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
