### PR TITLE
feat: Append to InvokeAI reference image + capability-gated recall buttons

### DIFF
--- a/photomap/backend/metadata_modules/invoke_formatter.py
+++ b/photomap/backend/metadata_modules/invoke_formatter.py
@@ -87,10 +87,34 @@ _USE_REF_SVG = (
 )
 
 
+# The use-ref photo-frame icon with a plus sign in place of the sun and
+# mountain, signalling "add to the existing reference images".
+_APPEND_REF_SVG = (
+    '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" '
+    'stroke="currentColor" stroke-width="2.2" stroke-linecap="round" '
+    'stroke-linejoin="round" aria-hidden="true">'
+    '<rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>'
+    '<line x1="12" y1="8" x2="12" y2="16"/>'
+    '<line x1="8" y1="12" x2="16" y2="12"/>'
+    "</svg>"
+)
+
+
 _USE_REF_BUTTON_HTML = (
     '<button type="button" class="invoke-recall-btn" data-recall-mode="use_ref" '
     'title="Upload this image to InvokeAI and use it as a reference image">'
     f'{_USE_REF_SVG}<span class="invoke-recall-label">Send to InvokeAI</span>'
+    '<span class="invoke-recall-status" aria-live="polite"></span>'
+    "</button>"
+)
+
+# "Append" variant: same upload flow, but InvokeAI adds the image to the
+# existing reference-image list instead of replacing it. Requires an
+# InvokeAI backend whose recall endpoint understands ``?append=true``.
+_APPEND_REF_BUTTON_HTML = (
+    '<button type="button" class="invoke-recall-btn" data-recall-mode="append_ref" '
+    'title="Upload this image to InvokeAI and append it to the existing reference images">'
+    f'{_APPEND_REF_SVG}<span class="invoke-recall-label">Append to InvokeAI</span>'
     '<span class="invoke-recall-status" aria-live="polite"></span>'
     "</button>"
 )
@@ -101,6 +125,7 @@ def _recall_buttons_html() -> str:
     return (
         '<div class="invoke-recall-controls" data-invoke-recall="1">'
         f"{_USE_REF_BUTTON_HTML}"
+        f"{_APPEND_REF_BUTTON_HTML}"
         '<button type="button" class="invoke-recall-btn" data-recall-mode="remix" '
         'title="Remix (recall parameters without the seed) to InvokeAI">'
         f'{_REMIX_SVG}<span class="invoke-recall-label">Remix</span>'
@@ -126,6 +151,7 @@ def use_ref_button_html() -> str:
     return (
         '<div class="invoke-recall-controls" data-invoke-recall="1">'
         f"{_USE_REF_BUTTON_HTML}"
+        f"{_APPEND_REF_BUTTON_HTML}"
         "</div>"
     )
 

--- a/photomap/backend/routers/invoke.py
+++ b/photomap/backend/routers/invoke.py
@@ -140,10 +140,17 @@ class RecallRequest(BaseModel):
 
 
 class UseRefImageRequest(BaseModel):
-    """Payload posted by the drawer's "Use Ref Image" button."""
+    """Payload posted by the drawer's "Send to InvokeAI" / "Append to InvokeAI" buttons."""
 
     album_key: str = Field(..., description="Album containing the image")
     index: int = Field(..., ge=0, description="Image index within the album")
+    append: bool = Field(
+        False,
+        description=(
+            "If True, ask InvokeAI to append the image to its existing "
+            "reference-image list instead of replacing it"
+        ),
+    )
     queue_id: str = Field(
         "default",
         description="InvokeAI queue id to target",
@@ -498,6 +505,10 @@ async def use_ref_image(request: UseRefImageRequest) -> dict:
     InvokeAI knows the file, then ``POST /api/v1/recall/{queue_id}`` with the
     returned ``image_name`` in ``reference_images`` so the next generation
     picks it up as visual guidance.
+
+    With ``append=True`` the recall is sent with ``?append=true``, which asks
+    InvokeAI to add the image to its existing reference-image list instead of
+    replacing it (the drawer's "Append to InvokeAI" button).
     """
     settings = config_manager.get_invokeai_settings()
     base_url = settings["url"]
@@ -556,9 +567,12 @@ async def use_ref_image(request: UseRefImageRequest) -> dict:
             # set up in InvokeAI rather than resetting every other
             # parameter back to defaults.
             payload = {"reference_images": [{"image_name": image_name}]}
+            recall_params = {"append": "true"} if request.append else None
 
             async def _do_recall(headers: dict[str, str]) -> httpx.Response:
-                return await client.post(recall_url, json=payload, headers=headers)
+                return await client.post(
+                    recall_url, json=payload, params=recall_params, headers=headers
+                )
 
             response = await _request_with_auth_fallback(
                 base_url, username, password, _do_recall

--- a/photomap/backend/routers/invoke.py
+++ b/photomap/backend/routers/invoke.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import logging
 import mimetypes
 import re
+import time
 from pathlib import Path
 
 import httpx
@@ -50,6 +51,46 @@ logger = logging.getLogger(__name__)
 invoke_router = APIRouter(prefix="/invokeai", tags=["InvokeAI"])
 
 config_manager = get_config_manager()
+
+# ── InvokeAI capability cache ─────────────────────────────────────────
+#
+# Whether the configured backend supports the recall API at all, and the
+# ``append`` reference-image option, is probed from its OpenAPI schema (or,
+# failing that, inferred from its version).  The result gates which recall
+# buttons the frontend reveals.  A successful probe is cached for several
+# minutes; a failed one only briefly, so a backend that comes up (or gets
+# upgraded) is noticed quickly.
+_CAPS_TTL_OK = 300.0
+_CAPS_TTL_ERROR = 30.0
+# Version fallbacks, used only when the OpenAPI schema can't be fetched:
+# the recall router shipped in 6.13.0, the append option in 6.13.5.
+_RECALL_MIN_VERSION = (6, 13, 0)
+_APPEND_MIN_VERSION = (6, 13, 5)
+
+_caps_cache: dict | None = None
+_caps_expires_at: float = 0.0
+_caps_base_url: str | None = None
+
+
+def _invalidate_capabilities_cache() -> None:
+    """Clear the cached capabilities so the next request re-probes."""
+    global _caps_cache, _caps_expires_at, _caps_base_url  # noqa: PLW0603
+    _caps_cache = None
+    _caps_expires_at = 0.0
+    _caps_base_url = None
+
+
+def _parse_version_tuple(version: str) -> tuple[int, ...] | None:
+    """Extract the leading dotted-numeric part of a version string.
+
+    Handles plain releases ("6.13.0"), post/dev suffixes ("6.13.0.post1",
+    "6.14.0.dev5+g1a2b3c") and release candidates ("6.13.5rc1") by simply
+    stopping at the first non-numeric component.
+    """
+    match = re.match(r"(\d+(?:\.\d+)*)", version.strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
 
 
 # InvokeAI stores images on disk as ``{uuid}.{ext}``; a filename matching this
@@ -184,6 +225,7 @@ async def set_invokeai_config(settings: InvokeAISettings) -> dict:
     """
     url = _validate_invokeai_url(settings.url)
     _invalidate_token_cache()
+    _invalidate_capabilities_cache()
     existing = config_manager.get_invokeai_settings()
     password = settings.password if settings.password is not None else existing["password"]
     board_id = settings.board_id if settings.board_id is not None else existing["board_id"]
@@ -215,6 +257,130 @@ async def invokeai_status() -> dict:
     """
     settings = config_manager.get_invokeai_settings()
     return await invokeai_client.check_status(settings["url"])
+
+
+async def _probe_capabilities(
+    client: httpx.AsyncClient,
+    base_url: str,
+    username: str | None,
+    password: str | None,
+) -> dict:
+    """Determine which recall features the backend supports.
+
+    Primary signal is the backend's OpenAPI schema: the presence of the
+    ``/api/v1/recall/{queue_id}`` POST operation means the recall router
+    exists, and an ``append`` entry in its query parameters means the
+    append option is understood.  Probing the schema rather than comparing
+    versions keeps development builds working — a backend running from a
+    feature branch advertises the capability the moment the route exists,
+    whatever its version string says.
+
+    If the schema can't be fetched (older deployments may not serve it, or
+    a proxy may block it), fall back to version thresholds via
+    ``/api/v1/app/version``: recall shipped in 6.13.0, append in 6.13.5.
+
+    Returns ``{"reachable": bool, "recall": bool, "append": bool,
+    "source": "openapi" | "version" | "unreachable"}``.
+    """
+    openapi_url = f"{base_url.rstrip('/')}/openapi.json"
+
+    async def _do(headers: dict[str, str]) -> httpx.Response:
+        return await client.get(openapi_url, headers=headers)
+
+    try:
+        resp = await _request_with_auth_fallback(base_url, username, password, _do)
+        if resp.status_code == 200:
+            spec = resp.json()
+            recall_post = (
+                spec.get("paths", {}).get("/api/v1/recall/{queue_id}", {}).get("post")
+            )
+            if recall_post is None:
+                return {
+                    "reachable": True,
+                    "recall": False,
+                    "append": False,
+                    "source": "openapi",
+                }
+            params = {
+                param.get("name") for param in recall_post.get("parameters", [])
+            }
+            return {
+                "reachable": True,
+                "recall": True,
+                "append": "append" in params,
+                "source": "openapi",
+            }
+    except (httpx.RequestError, HTTPException, ValueError) as exc:
+        logger.debug("InvokeAI OpenAPI capability probe failed: %s", exc)
+
+    # Fallback: infer support from the version number.
+    version_url = f"{base_url.rstrip('/')}/api/v1/app/version"
+    version: str | None = None
+    try:
+        resp = await client.get(version_url)
+        if resp.status_code == 200:
+            version = resp.json().get("version")
+    except (httpx.RequestError, ValueError) as exc:
+        logger.debug("InvokeAI version capability probe failed: %s", exc)
+
+    version_tuple = _parse_version_tuple(version) if version else None
+    if version_tuple:
+        return {
+            "reachable": True,
+            "recall": version_tuple >= _RECALL_MIN_VERSION,
+            "append": version_tuple >= _APPEND_MIN_VERSION,
+            "source": "version",
+            "version": version,
+        }
+    return {"reachable": False, "recall": False, "append": False, "source": "unreachable"}
+
+
+@invoke_router.get("/capabilities")
+async def invokeai_capabilities(refresh: bool = False) -> dict:
+    """Report which recall features the configured backend supports.
+
+    The frontend calls this once at startup (and after the InvokeAI settings
+    change) and reveals only the recall buttons the backend can honor:
+
+    * no recall router — no recall buttons at all;
+    * recall without append — Send to InvokeAI / Remix / Recall, but no
+      Append (an old backend would silently treat append as replace);
+    * recall with append — all buttons.
+
+    Results are cached per configured URL; pass ``?refresh=true`` to force a
+    re-probe (used right after the settings are saved).
+    """
+    global _caps_cache, _caps_expires_at, _caps_base_url  # noqa: PLW0603
+
+    settings = config_manager.get_invokeai_settings()
+    base_url = settings["url"]
+    if not base_url:
+        return {
+            "configured": False,
+            "reachable": False,
+            "recall": False,
+            "append": False,
+        }
+
+    now = time.monotonic()
+    if (
+        not refresh
+        and _caps_cache is not None
+        and _caps_base_url == base_url
+        and now < _caps_expires_at
+    ):
+        return _caps_cache
+
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        probed = await _probe_capabilities(
+            client, base_url, settings["username"], settings["password"]
+        )
+
+    capabilities = {"configured": True, **probed}
+    _caps_cache = capabilities
+    _caps_base_url = base_url
+    _caps_expires_at = now + (_CAPS_TTL_OK if probed["reachable"] else _CAPS_TTL_ERROR)
+    return capabilities
 
 
 @invoke_router.get("/boards")

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -67,7 +67,6 @@
   text-align: left;
   cursor: auto;
 }
-}
 
 #filepathText {
   color: #ccc;
@@ -188,7 +187,7 @@
 }
 
 .details-link-cell {
-  text-align: right;
+  text-align: left;
   /* Pin the link to the bottom of the scrollable description area so it
      remains visible even when reference-image thumbnails push the table
      past the 40vh scroll cap. Solid background keeps preceding rows from
@@ -209,7 +208,7 @@
 
 #metadataLinkContainer {
   padding: 0.4em 2em 0.8em;
-  text-align: right;
+  text-align: left;
 }
 
 .invoke-recall-controls {

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -218,6 +218,18 @@
   align-items: center;
 }
 
+/* Capability gating (see invoke-capabilities.js): every recall button stays
+   hidden until the backend confirms the configured InvokeAI instance
+   supports the recall API; the Append button additionally requires the
+   append option, which older backends would silently treat as replace. */
+body:not(.invoke-recall-supported) .invoke-recall-controls {
+  display: none;
+}
+
+body:not(.invoke-append-supported) .invoke-recall-btn[data-recall-mode="append_ref"] {
+  display: none;
+}
+
 .invoke-recall-btn {
   display: inline-flex;
   align-items: center;

--- a/photomap/frontend/static/javascript/events.js
+++ b/photomap/frontend/static/javascript/events.js
@@ -8,6 +8,7 @@ import { backStack } from "./back-stack.js";
 import { toggleCurrentBookmark } from "./bookmarks.js";
 import { initializeControlPanel, toggleFullscreen } from "./control-panel.js";
 import { initializeGridSwiper } from "./grid-view.js";
+import { refreshInvokeCapabilities } from "./invoke-capabilities.js";
 import {
   hideMetadataOverlay,
   initializeMetadataDrawer,
@@ -40,6 +41,10 @@ async function initializeEvents() {
   setupAccessibility();
   checkAlbumIndex(); // Check if the album index exists before proceeding
   positionMetadataDrawer();
+  // Fire-and-forget: reveals the InvokeAI recall buttons the backend
+  // supports. Nothing downstream depends on the answer, so don't block
+  // initialization on a (possibly slow) network probe.
+  refreshInvokeCapabilities();
 
   await initializeSwipers();
   await toggleGridSwiperView(state.gridViewActive);

--- a/photomap/frontend/static/javascript/invoke-capabilities.js
+++ b/photomap/frontend/static/javascript/invoke-capabilities.js
@@ -1,0 +1,23 @@
+// invoke-capabilities.js
+// Asks the PhotoMap backend which recall features the configured InvokeAI
+// instance supports and reflects the answer as classes on <body>. The CSS in
+// metadata-drawer.css keeps every recall button hidden until support is
+// positively confirmed, so a backend without the recall router shows no
+// buttons at all, and one without the append option hides only
+// "Append to InvokeAI".
+
+import { fetchJson } from "./utils.js";
+
+export async function refreshInvokeCapabilities({ refresh = false } = {}) {
+  let caps = { recall: false, append: false };
+  try {
+    caps = await fetchJson(refresh ? "invokeai/capabilities?refresh=true" : "invokeai/capabilities");
+  } catch (err) {
+    // Unknown is treated as unsupported — a button that can't work is worse
+    // than a missing one. The backend retries failed probes quickly.
+    console.warn("Could not determine InvokeAI capabilities:", err);
+  }
+  document.body.classList.toggle("invoke-recall-supported", caps.recall === true);
+  document.body.classList.toggle("invoke-append-supported", caps.append === true);
+  return caps;
+}

--- a/photomap/frontend/static/javascript/invoke-recall.js
+++ b/photomap/frontend/static/javascript/invoke-recall.js
@@ -101,10 +101,10 @@ export async function sendRecall({ albumKey, index, includeSeed }) {
   }
 }
 
-export async function sendUseRefImage({ albumKey, index }) {
+export async function sendUseRefImage({ albumKey, index, append = false }) {
   try {
     return await fetchJson("invokeai/use_ref_image", {
-      json: { album_key: albumKey, index },
+      json: { album_key: albumKey, index, append },
     });
   } catch (err) {
     throw _withDetailMessage(err);
@@ -138,8 +138,10 @@ async function handleRecallClick(button) {
 
   button.disabled = true;
   try {
-    if (mode === "use_ref") {
-      await sendUseRefImage({ albumKey, index: parsed.index });
+    if (mode === "use_ref" || mode === "append_ref") {
+      // append_ref adds the image to InvokeAI's existing reference-image
+      // list; use_ref replaces it.
+      await sendUseRefImage({ albumKey, index: parsed.index, append: mode === "append_ref" });
     } else {
       await sendRecall({
         albumKey,
@@ -151,7 +153,12 @@ async function handleRecallClick(button) {
   } catch (err) {
     console.error("InvokeAI recall failed:", err);
     showStatus(button, "error");
-    const fallback = mode === "use_ref" ? "Use as Ref Image failed" : "Recall failed";
+    let fallback = "Recall failed";
+    if (mode === "use_ref") {
+      fallback = "Send to InvokeAI failed";
+    } else if (mode === "append_ref") {
+      fallback = "Append to InvokeAI failed";
+    }
     showErrorMessage(button, err && err.message ? err.message : fallback);
   } finally {
     button.disabled = false;

--- a/photomap/frontend/static/javascript/settings.js
+++ b/photomap/frontend/static/javascript/settings.js
@@ -12,6 +12,7 @@ import {
   state,
 } from "./state.js";
 import { clearImageLabelCache, setClusterLabels } from "./cluster-utils.js";
+import { refreshInvokeCapabilities } from "./invoke-capabilities.js";
 import { fetchJson, hideSpinner, showSpinner } from "./utils.js";
 
 // Constants
@@ -573,6 +574,9 @@ function setupInvokeAISettingsControls() {
     setInvokeAIUrlError(error);
     if (!error) {
       await refreshInvokeAIStatus();
+      // The configured backend may have changed — re-probe which recall
+      // buttons it supports (force past the backend's capability cache).
+      await refreshInvokeCapabilities({ refresh: true });
     }
   };
   const debouncedSaveAndRefresh = debounced(saveAndRefresh);

--- a/tests/backend/test_invoke_metadata.py
+++ b/tests/backend/test_invoke_metadata.py
@@ -1082,8 +1082,10 @@ class TestFormatInvokeRecallButtons:
         assert 'data-recall-mode="recall"' in html
         assert 'data-recall-mode="remix"' in html
         assert 'data-recall-mode="use_ref"' in html
+        assert 'data-recall-mode="append_ref"' in html
         assert "Send to InvokeAI" in html
-        assert html.count('class="invoke-recall-btn"') == 3
+        assert "Append to InvokeAI" in html
+        assert html.count('class="invoke-recall-btn"') == 4
 
     def test_scalar_only_metadata_appends_use_ref_button_when_enabled(self):
         """A flat-scalars custom-workflow image carries no recallable
@@ -1094,10 +1096,11 @@ class TestFormatInvokeRecallButtons:
             _slide(), metadata, show_recall_buttons=True
         ).description
         assert 'data-recall-mode="use_ref"' in html
+        assert 'data-recall-mode="append_ref"' in html
         # Recall and Remix make no sense without parsed parameters.
         assert 'data-recall-mode="recall"' not in html
         assert 'data-recall-mode="remix"' not in html
-        assert html.count('class="invoke-recall-btn"') == 1
+        assert html.count('class="invoke-recall-btn"') == 2
 
     def test_scalar_only_metadata_no_buttons_when_disabled(self):
         metadata = {"Custom Field": "value"}
@@ -1150,9 +1153,11 @@ class TestFormatInvokeRecallButtons:
         # Use-as-ref button still appended.
         assert 'data-recall-mode="use_ref"' in html
 
-    def test_use_ref_button_html_renders_single_button(self):
+    def test_use_ref_button_html_renders_send_and_append_buttons(self):
         html = use_ref_button_html()
         assert 'class="invoke-recall-controls"' in html
         assert 'data-recall-mode="use_ref"' in html
+        assert 'data-recall-mode="append_ref"' in html
         assert "Send to InvokeAI" in html
-        assert html.count('class="invoke-recall-btn"') == 1
+        assert "Append to InvokeAI" in html
+        assert html.count('class="invoke-recall-btn"') == 2

--- a/tests/backend/test_invoke_router.py
+++ b/tests/backend/test_invoke_router.py
@@ -313,6 +313,80 @@ def test_use_ref_image_uploads_then_calls_recall_without_strict(
     }
 
 
+def test_use_ref_image_append_passes_append_param(
+    client, clear_invokeai_config, monkeypatch, tmp_path
+):
+    """``append: true`` must reach the recall call as ``?append=true`` so
+    InvokeAI adds to its reference-image list instead of replacing it."""
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+
+    image_file = tmp_path / "pic.png"
+    image_file.write_bytes(b"\x89PNG\r\n\x1a\nfakebytes")
+
+    from photomap.backend.routers import invoke as invoke_module
+
+    monkeypatch.setattr(
+        invoke_module, "_load_image_path", lambda album_key, index: image_file
+    )
+    monkeypatch.setattr(
+        invoke_module, "_load_raw_metadata", lambda album_key, index: {}
+    )
+
+    calls: list[dict] = []
+
+    class _UploadResponse:
+        status_code = 200
+        text = ""
+
+        def json(self):
+            return {"image_name": "uploaded-abc.png"}
+
+    class _RecallResponse:
+        status_code = 200
+        text = "{}"
+
+        def json(self):
+            return {"status": "success"}
+
+    class _StubClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, url, **kwargs):
+            call = {"url": url, "params": kwargs.get("params")}
+            if "files" in kwargs:
+                call["kind"] = "upload"
+                kwargs["files"]["file"][1].read()
+                calls.append(call)
+                return _UploadResponse()
+            call["kind"] = "recall"
+            call["json"] = kwargs.get("json")
+            calls.append(call)
+            return _RecallResponse()
+
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", _StubClient)
+
+    response = client.post(
+        "/invokeai/use_ref_image",
+        json={"album_key": "any", "index": 0, "append": True},
+    )
+    assert response.status_code == 200, response.text
+
+    assert len(calls) == 2
+    # The upload is unaffected by append mode.
+    assert calls[0]["kind"] == "upload"
+    assert "append" not in (calls[0]["params"] or {})
+    # The recall carries append=true and still no strict.
+    assert calls[1]["kind"] == "recall"
+    assert calls[1]["params"] == {"append": "true"}
+
+
 def test_use_ref_image_upload_failure_returns_502(
     client, clear_invokeai_config, monkeypatch, tmp_path
 ):

--- a/tests/backend/test_invoke_router.py
+++ b/tests/backend/test_invoke_router.py
@@ -1751,3 +1751,227 @@ def test_probe_boards_never_pairs_settings_password_with_other_username(
     # Exactly one upstream call: the boards GET. No login was attempted.
     assert len(stub.calls) == 1
     assert stub.calls[0]["url"].endswith("/api/v1/boards/")
+
+
+# ---------------------------------------------------------------------------
+# GET /invokeai/capabilities — feature detection for the recall buttons
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clear_caps_cache():
+    """Wipe the module-level capabilities cache before and after each test."""
+    from photomap.backend.routers import invoke as invoke_module
+
+    invoke_module._invalidate_capabilities_cache()
+    yield
+    invoke_module._invalidate_capabilities_cache()
+
+
+def _openapi_spec(recall: bool, append: bool) -> dict:
+    """Build a minimal OpenAPI document advertising the recall endpoint."""
+    if not recall:
+        return {"paths": {"/api/v1/images/upload": {"post": {}}}}
+    params = [
+        {"name": "queue_id", "in": "path"},
+        {"name": "strict", "in": "query"},
+    ]
+    if append:
+        params.append({"name": "append", "in": "query"})
+    return {"paths": {"/api/v1/recall/{queue_id}": {"post": {"parameters": params}}}}
+
+
+def _install_caps_stub(
+    monkeypatch,
+    *,
+    openapi: dict | None = None,
+    version: str | None = None,
+    network_error: bool = False,
+) -> list[str]:
+    """Stub httpx.AsyncClient for the capability probe.
+
+    ``openapi=None`` serves a 404 for /openapi.json (forcing the version
+    fallback); ``version=None`` 404s the version endpoint too.  Returns the
+    list of probed URLs so tests can assert caching behaviour.
+    """
+    from photomap.backend.routers import invoke as invoke_module
+
+    calls: list[str] = []
+
+    class _Resp:
+        def __init__(self, status_code: int, payload):
+            self.status_code = status_code
+            self._payload = payload
+            self.text = ""
+
+        def json(self):
+            if self._payload is None:
+                raise ValueError("no JSON body")
+            return self._payload
+
+    class _StubClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def get(self, url, **kwargs):
+            calls.append(url)
+            if network_error:
+                raise httpx.ConnectError("probe refused")
+            if url.endswith("/openapi.json"):
+                if openapi is None:
+                    return _Resp(404, None)
+                return _Resp(200, openapi)
+            if url.endswith("/api/v1/app/version"):
+                if version is None:
+                    return _Resp(404, None)
+                return _Resp(200, {"version": version})
+            return _Resp(404, None)
+
+    monkeypatch.setattr(invoke_module.httpx, "AsyncClient", _StubClient)
+    return calls
+
+
+def test_capabilities_unconfigured(client, clear_invokeai_config, clear_caps_cache):
+    response = client.get("/invokeai/capabilities")
+    assert response.status_code == 200
+    assert response.json() == {
+        "configured": False,
+        "reachable": False,
+        "recall": False,
+        "append": False,
+    }
+
+
+def test_capabilities_openapi_recall_and_append(
+    client, clear_invokeai_config, clear_caps_cache, monkeypatch
+):
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    _install_caps_stub(monkeypatch, openapi=_openapi_spec(recall=True, append=True))
+
+    body = client.get("/invokeai/capabilities").json()
+    assert body["configured"] is True
+    assert body["reachable"] is True
+    assert body["recall"] is True
+    assert body["append"] is True
+    assert body["source"] == "openapi"
+
+
+def test_capabilities_openapi_recall_without_append(
+    client, clear_invokeai_config, clear_caps_cache, monkeypatch
+):
+    """A 6.13.0-era backend: recall route present, no append query param."""
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    _install_caps_stub(monkeypatch, openapi=_openapi_spec(recall=True, append=False))
+
+    body = client.get("/invokeai/capabilities").json()
+    assert body["recall"] is True
+    assert body["append"] is False
+    assert body["source"] == "openapi"
+
+
+def test_capabilities_openapi_without_recall_route(
+    client, clear_invokeai_config, clear_caps_cache, monkeypatch
+):
+    """A pre-6.13 backend: reachable, but no recall router at all."""
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    _install_caps_stub(monkeypatch, openapi=_openapi_spec(recall=False, append=False))
+
+    body = client.get("/invokeai/capabilities").json()
+    assert body["reachable"] is True
+    assert body["recall"] is False
+    assert body["append"] is False
+
+
+@pytest.mark.parametrize(
+    ("version", "recall", "append"),
+    [
+        ("6.12.9", False, False),
+        ("6.13.0.post1", True, False),
+        ("6.13.4", True, False),
+        ("6.13.5", True, True),
+        ("6.14.0.dev5+g1a2b3c", True, True),
+    ],
+)
+def test_capabilities_version_fallback(
+    client, clear_invokeai_config, clear_caps_cache, monkeypatch, version, recall, append
+):
+    """When /openapi.json is unavailable, fall back to version thresholds."""
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    _install_caps_stub(monkeypatch, openapi=None, version=version)
+
+    body = client.get("/invokeai/capabilities").json()
+    assert body["source"] == "version"
+    assert body["recall"] is recall
+    assert body["append"] is append
+
+
+def test_capabilities_unreachable_backend(
+    client, clear_invokeai_config, clear_caps_cache, monkeypatch
+):
+    """A backend that's down yields no capabilities — buttons stay hidden."""
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    _install_caps_stub(monkeypatch, network_error=True)
+
+    body = client.get("/invokeai/capabilities").json()
+    assert body == {
+        "configured": True,
+        "reachable": False,
+        "recall": False,
+        "append": False,
+        "source": "unreachable",
+    }
+
+
+def test_capabilities_cached_until_refresh(
+    client, clear_invokeai_config, clear_caps_cache, monkeypatch
+):
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    calls = _install_caps_stub(monkeypatch, openapi=_openapi_spec(recall=True, append=True))
+
+    client.get("/invokeai/capabilities")
+    probes_after_first = len(calls)
+    client.get("/invokeai/capabilities")
+    assert len(calls) == probes_after_first  # served from cache
+
+    client.get("/invokeai/capabilities?refresh=true")
+    assert len(calls) > probes_after_first  # forced re-probe
+
+
+def test_capabilities_cache_invalidated_by_config_change(
+    client, clear_invokeai_config, clear_caps_cache, monkeypatch
+):
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    calls = _install_caps_stub(monkeypatch, openapi=_openapi_spec(recall=True, append=True))
+
+    client.get("/invokeai/capabilities")
+    probes_after_first = len(calls)
+
+    # Saving settings (even the same URL) must drop the cache: the user may
+    # have just pointed PhotoMap at an upgraded backend.
+    client.post("/invokeai/config", json={"url": "http://localhost:9090"})
+    client.get("/invokeai/capabilities")
+    assert len(calls) > probes_after_first
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("6.13.0", (6, 13, 0)),
+        ("6.13.0.post1", (6, 13, 0)),
+        ("6.14.0.dev5+g1a2b3c", (6, 14, 0)),
+        ("6.13.5rc1", (6, 13, 5)),
+        (" 6.13.5 ", (6, 13, 5)),
+        ("garbage", None),
+        ("", None),
+    ],
+)
+def test_parse_version_tuple(raw, expected):
+    from photomap.backend.routers.invoke import _parse_version_tuple
+
+    assert _parse_version_tuple(raw) == expected

--- a/tests/frontend/invoke-capabilities.test.js
+++ b/tests/frontend/invoke-capabilities.test.js
@@ -1,0 +1,98 @@
+// Unit tests for invoke-capabilities.js — the body-class gating that reveals
+// only the InvokeAI recall buttons the configured backend supports.
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+// Provide a real fetchJson implementation that delegates to global.fetch so
+// the tests can stub global.fetch and control what the backend reports.
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/utils.js", () => ({
+  async fetchJson(url, options = {}) {
+    const response = await global.fetch(url, options);
+    if (!response.ok) {
+      const err = new Error(`HTTP ${response.status}`);
+      err.name = "HttpError";
+      err.status = response.status;
+      throw err;
+    }
+    return await response.json();
+  },
+}));
+
+const { refreshInvokeCapabilities } = await import("../../photomap/frontend/static/javascript/invoke-capabilities.js");
+
+function mockCapabilities(caps) {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(caps),
+    })
+  );
+  global.fetch = fetchMock;
+  return fetchMock;
+}
+
+describe("invoke-capabilities.js", () => {
+  beforeEach(() => {
+    document.body.className = "";
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+    document.body.className = "";
+  });
+
+  it("sets both body classes when recall and append are supported", async () => {
+    mockCapabilities({ configured: true, reachable: true, recall: true, append: true });
+
+    await refreshInvokeCapabilities();
+
+    expect(document.body.classList.contains("invoke-recall-supported")).toBe(true);
+    expect(document.body.classList.contains("invoke-append-supported")).toBe(true);
+  });
+
+  it("sets only the recall class when append is unsupported", async () => {
+    mockCapabilities({ configured: true, reachable: true, recall: true, append: false });
+
+    await refreshInvokeCapabilities();
+
+    expect(document.body.classList.contains("invoke-recall-supported")).toBe(true);
+    expect(document.body.classList.contains("invoke-append-supported")).toBe(false);
+  });
+
+  it("removes previously-set classes when support disappears", async () => {
+    document.body.classList.add("invoke-recall-supported", "invoke-append-supported");
+    mockCapabilities({ configured: true, reachable: true, recall: false, append: false });
+
+    await refreshInvokeCapabilities();
+
+    expect(document.body.classList.contains("invoke-recall-supported")).toBe(false);
+    expect(document.body.classList.contains("invoke-append-supported")).toBe(false);
+  });
+
+  it("treats a failed capabilities fetch as unsupported", async () => {
+    document.body.classList.add("invoke-recall-supported", "invoke-append-supported");
+    global.fetch = jest.fn(() => Promise.resolve({ ok: false, status: 502 }));
+
+    const caps = await refreshInvokeCapabilities();
+
+    expect(caps).toEqual({ recall: false, append: false });
+    expect(document.body.classList.contains("invoke-recall-supported")).toBe(false);
+    expect(document.body.classList.contains("invoke-append-supported")).toBe(false);
+  });
+
+  it("requests a forced re-probe with refresh: true", async () => {
+    const fetchMock = mockCapabilities({ recall: true, append: true });
+
+    await refreshInvokeCapabilities({ refresh: true });
+
+    expect(fetchMock.mock.calls[0][0]).toBe("invokeai/capabilities?refresh=true");
+  });
+
+  it("hits the plain endpoint by default", async () => {
+    const fetchMock = mockCapabilities({ recall: true, append: true });
+
+    await refreshInvokeCapabilities();
+
+    expect(fetchMock.mock.calls[0][0]).toBe("invokeai/capabilities");
+  });
+});

--- a/tests/frontend/invoke-recall.test.js
+++ b/tests/frontend/invoke-recall.test.js
@@ -146,8 +146,24 @@ describe("invoke-recall.js", () => {
       expect(JSON.parse(opts.body)).toEqual({
         album_key: "vacation",
         index: 3,
+        append: false,
       });
       expect(result.uploaded_image_name).toBe("abc.png");
+    });
+
+    it("passes append: true through to the backend", async () => {
+      const fetchMock = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ success: true }),
+        })
+      );
+      global.fetch = fetchMock;
+
+      await sendUseRefImage({ albumKey: "vacation", index: 3, append: true });
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.append).toBe(true);
     });
   });
 
@@ -164,6 +180,9 @@ describe("invoke-recall.js", () => {
             <span class="invoke-recall-status"></span>
           </button>
           <button type="button" class="invoke-recall-btn" data-recall-mode="use_ref">
+            <span class="invoke-recall-status"></span>
+          </button>
+          <button type="button" class="invoke-recall-btn" data-recall-mode="append_ref">
             <span class="invoke-recall-status"></span>
           </button>
         </div>
@@ -238,6 +257,28 @@ describe("invoke-recall.js", () => {
       const body = JSON.parse(opts.body);
       expect(body.album_key).toBe("my-album");
       expect(body.index).toBe(5);
+      expect(body.append).toBe(false);
+      expect(body.include_seed).toBeUndefined();
+    });
+
+    it("posts append: true when the append_ref button is clicked", async () => {
+      const fetchMock = jest.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ success: true }),
+        })
+      );
+      global.fetch = fetchMock;
+
+      document.querySelector('[data-recall-mode="append_ref"]').click();
+      await flushPromises();
+
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe("invokeai/use_ref_image");
+      const body = JSON.parse(opts.body);
+      expect(body.album_key).toBe("my-album");
+      expect(body.index).toBe(5);
+      expect(body.append).toBe(true);
       expect(body.include_seed).toBeUndefined();
     });
 


### PR DESCRIPTION
## Summary

Adds an **"Append to InvokeAI"** reference-image button to the metadata drawer, a small alignment tweak to the metadata link, and a capability probe so the recall buttons only appear when the configured InvokeAI backend actually supports them.

This is the PhotoMap side of a two-part change. It depends on a matching InvokeAI backend change (`append` query parameter on `POST /api/v1/recall/{queue_id}`); against an older backend the new button is automatically hidden by the capability probe.

## What's in here (three commits)

1. **`fix(ui)`: left-align the "View Metadata (JSON)" link** — both render slots (the standalone row below the recall buttons and the sticky cell at the bottom of the Image Details table) were right-aligned. Also removes a stray `}` in `metadata-drawer.css` that made the stylesheet syntactically invalid.

2. **`feat(invoke)`: "Append to InvokeAI" button** — sits to the right of "Send to InvokeAI". It runs the same upload + recall flow but sends `?append=true` on the recall, asking InvokeAI to *add* the image to its existing reference-image list instead of replacing it. New `append` field on `UseRefImageRequest`; new `append_ref` button mode in `invoke-recall.js`.

3. **`feat(invoke)`: gate the recall buttons on a backend capability probe** — new `GET /invokeai/capabilities` probes the backend's OpenAPI schema for the recall route and its `append` query parameter (falling back to version thresholds — recall ≥ 6.13.0, append ≥ 6.13.5 — when the schema can't be fetched). The frontend reflects the result as `body` classes that CSS uses to reveal the buttons:
   - no recall router → no recall buttons at all
   - recall without append → Send to InvokeAI / Remix / Recall only
   - recall with append → all buttons

   Probing capabilities rather than comparing versions keeps a development backend working the moment the feature lands on its branch. Results are cached (5 min on success, 30 s on failure) and the cache is dropped when the InvokeAI settings are saved.

## Testing

- `make test` green: 436 backend (pytest) + 379 frontend (Jest) tests.
- New coverage: capability tiers (OpenAPI + version fallback, unreachable, cache/refresh/invalidation), the `append` recall parameter, and the body-class gating.
- `ruff`, `eslint`, and `prettier` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
