### PR TITLE
feat: reformat InvokeAI drawer buttons into a labeled two-row table

### DIFF
--- a/photomap/backend/metadata_modules/invoke_formatter.py
+++ b/photomap/backend/metadata_modules/invoke_formatter.py
@@ -103,7 +103,7 @@ _APPEND_REF_SVG = (
 _USE_REF_BUTTON_HTML = (
     '<button type="button" class="invoke-recall-btn" data-recall-mode="use_ref" '
     'title="Upload this image to InvokeAI and use it as a reference image">'
-    f'{_USE_REF_SVG}<span class="invoke-recall-label">Send to InvokeAI</span>'
+    f'{_USE_REF_SVG}<span class="invoke-recall-label">Send Image</span>'
     '<span class="invoke-recall-status" aria-live="polite"></span>'
     "</button>"
 )
@@ -114,16 +114,33 @@ _USE_REF_BUTTON_HTML = (
 _APPEND_REF_BUTTON_HTML = (
     '<button type="button" class="invoke-recall-btn" data-recall-mode="append_ref" '
     'title="Upload this image to InvokeAI and append it to the existing reference images">'
-    f'{_APPEND_REF_SVG}<span class="invoke-recall-label">Append to InvokeAI</span>'
+    f'{_APPEND_REF_SVG}<span class="invoke-recall-label">Append Image</span>'
     '<span class="invoke-recall-status" aria-live="polite"></span>'
     "</button>"
 )
 
 
+def _recall_controls_table(buttons_html: str) -> str:
+    """Wrap a set of recall buttons in a two-row table styled like the Image
+    Details table: an "InvokeAI" header row above a row holding the buttons.
+
+    The whole table carries the ``invoke-recall-controls`` class so the
+    capability gating in ``invoke-capabilities.js`` can hide it wholesale when
+    no InvokeAI backend is configured. It deliberately does *not* reuse the
+    ``invoke-metadata`` class (which the drawer's "Path" row injection targets);
+    its styling is mirrored in CSS instead.
+    """
+    return (
+        '<table class="invoke-recall-controls" data-invoke-recall="1">'
+        '<tr><th class="invoke-recall-heading">InvokeAI</th></tr>'
+        f'<tr><td><div class="invoke-recall-buttons">{buttons_html}</div></td></tr>'
+        "</table>"
+    )
+
+
 def _recall_buttons_html() -> str:
     """Render the recall / remix / use-ref button group shown at the bottom of the drawer."""
-    return (
-        '<div class="invoke-recall-controls" data-invoke-recall="1">'
+    return _recall_controls_table(
         f"{_USE_REF_BUTTON_HTML}"
         f"{_APPEND_REF_BUTTON_HTML}"
         '<button type="button" class="invoke-recall-btn" data-recall-mode="remix" '
@@ -136,7 +153,6 @@ def _recall_buttons_html() -> str:
         f'{_RECALL_SVG}<span class="invoke-recall-label">Recall</span>'
         '<span class="invoke-recall-status" aria-live="polite"></span>'
         "</button>"
-        "</div>"
     )
 
 
@@ -148,11 +164,8 @@ def use_ref_button_html() -> str:
     so it is appended to non-Invoke metadata views as well, whenever an
     InvokeAI backend is configured.
     """
-    return (
-        '<div class="invoke-recall-controls" data-invoke-recall="1">'
-        f"{_USE_REF_BUTTON_HTML}"
-        f"{_APPEND_REF_BUTTON_HTML}"
-        "</div>"
+    return _recall_controls_table(
+        f"{_USE_REF_BUTTON_HTML}{_APPEND_REF_BUTTON_HTML}"
     )
 
 

--- a/photomap/frontend/static/css/metadata-drawer.css
+++ b/photomap/frontend/static/css/metadata-drawer.css
@@ -211,11 +211,39 @@
   text-align: left;
 }
 
+/* The recall controls are a two-row table styled to match the Image Details
+   table (.invoke-metadata): an "InvokeAI" header row above a row of buttons.
+   The borders/width/padding are mirrored here rather than via the shared class
+   because the drawer's "Path" row injection targets .invoke-metadata. The
+   table is relocated out of #descriptionText (see metadata-drawer.js), so the
+   foreground color the field headers inherit (#ccc) is set explicitly. */
 .invoke-recall-controls {
+  border-collapse: collapse;
+  border: 1px solid #bbb;
+  width: 100%;
+  margin: 0.5em 0 4px;
+}
+
+.invoke-recall-controls th,
+.invoke-recall-controls td {
+  border: 1px solid #555;
+  padding: 6px 10px;
+}
+
+/* Header cell ("InvokeAI"): bold and left-aligned to match the Image Details
+   field headers (e.g. "Path"). */
+.invoke-recall-heading {
+  color: #ccc;
+  font-weight: bold;
+  text-align: left;
+}
+
+/* The button row itself: lay the buttons out horizontally inside the cell. */
+.invoke-recall-buttons {
   display: flex;
   gap: 12px;
-  margin: 2px 0 4px 0;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 /* Capability gating (see invoke-capabilities.js): every recall button stays

--- a/tests/backend/test_invoke_metadata.py
+++ b/tests/backend/test_invoke_metadata.py
@@ -1083,8 +1083,9 @@ class TestFormatInvokeRecallButtons:
         assert 'data-recall-mode="remix"' in html
         assert 'data-recall-mode="use_ref"' in html
         assert 'data-recall-mode="append_ref"' in html
-        assert "Send to InvokeAI" in html
-        assert "Append to InvokeAI" in html
+        assert 'class="invoke-recall-heading">InvokeAI</th>' in html
+        assert "Send Image" in html
+        assert "Append Image" in html
         assert html.count('class="invoke-recall-btn"') == 4
 
     def test_scalar_only_metadata_appends_use_ref_button_when_enabled(self):
@@ -1158,6 +1159,7 @@ class TestFormatInvokeRecallButtons:
         assert 'class="invoke-recall-controls"' in html
         assert 'data-recall-mode="use_ref"' in html
         assert 'data-recall-mode="append_ref"' in html
-        assert "Send to InvokeAI" in html
-        assert "Append to InvokeAI" in html
+        assert 'class="invoke-recall-heading">InvokeAI</th>' in html
+        assert "Send Image" in html
+        assert "Append Image" in html
         assert html.count('class="invoke-recall-btn"') == 2


### PR DESCRIPTION
## Summary

The row of InvokeAI buttons (Send / Append / Remix / Recall) in the metadata drawer was getting too wide. This reformats it into a two-row table styled to match the Image Details table:

```
+----------------------------------------------------+
| InvokeAI                                           |
+----------------------------------------------------+
| [Send Image] [Append Image] [Remix] [Recall]       |
+----------------------------------------------------+
```

- An **"InvokeAI"** header row (bold, left-aligned, `#ccc`) above a row of buttons — matching the Image Details field headers (e.g. "Path").
- The redundant "InvokeAI" word is hoisted out of the button labels: "Send to InvokeAI" → **Send Image**, "Append to InvokeAI" → **Append Image** (Remix/Recall unchanged).

## Implementation notes

- The table uses its own `.invoke-recall-controls` class rather than reusing `.invoke-metadata`. The drawer's "Path" row injection (`metadata-drawer.js`) targets `#descriptionText .invoke-metadata`, so reusing that class would have stuck a stray "Path" row into the recall table (notably in the unknown-format fallback path, where no real Image Details table exists). The table styling is mirrored in CSS instead.
- The header color is set explicitly (`#ccc`) because the table is relocated out of `#descriptionText` by `metadata-drawer.js`, so it can't inherit that color the way the real field headers do.
- Existing capability gating (`body:not(.invoke-recall-supported) .invoke-recall-controls`) now hides the entire table, so when no InvokeAI backend is configured the whole table disappears.

## Testing

- `pytest tests/backend/test_invoke_metadata.py` — 56 passed (assertions updated for the new `<th>` heading and shortened labels)
- `jest tests/frontend/invoke-recall.test.js` — 13 passed
- `ruff check` and `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)