### PR TITLE
Fix: restore all saved boards when editing an InvokeAI board album

### DIFF
--- a/photomap/frontend/static/javascript/album-manager.js
+++ b/photomap/frontend/static/javascript/album-manager.js
@@ -1334,7 +1334,12 @@ export class AlbumManager {
     }
     this._createInvokeRootRow(editForm.querySelector(".edit-album-invoke-root-row"), album.invokeai_root || "");
 
-    const loadBoards = () =>
+    // preferredIds wins when given; otherwise fall back to the album's saved
+    // selection. The initial auto-load must pass the saved ids explicitly: it
+    // can't read them back from the DOM, because the placeholder render below
+    // only paints "Uncategorized" (board names are still unresolved), so a DOM
+    // scrape would collapse an "all boards" selection down to just ["none"].
+    const loadBoards = (preferredIds) =>
       this.connectAndLoadBoards({
         urlInput,
         usernameInput,
@@ -1342,15 +1347,14 @@ export class AlbumManager {
         authSection: null,
         hintElement,
         boardsContainer,
-        selectedIds: collectSelectedBoardIds(boardsContainer).length
-          ? collectSelectedBoardIds(boardsContainer)
-          : album.invokeai_board_ids || [],
+        selectedIds: preferredIds?.length ? preferredIds : album.invokeai_board_ids || [],
         albumKey: album.key,
       });
 
     const connectBtn = editForm.querySelector(".edit-album-invoke-connect-btn");
     if (connectBtn) {
-      connectBtn.onclick = loadBoards;
+      // Manual reconnect keeps whatever the user currently has checked.
+      connectBtn.onclick = () => loadBoards(collectSelectedBoardIds(boardsContainer));
     }
 
     // Show the saved selection immediately (board names unresolved until
@@ -1359,7 +1363,7 @@ export class AlbumManager {
       delete boardsContainer.dataset.loaded;
     }
     renderBoardChecklist(boardsContainer, [], album.invokeai_board_ids || []);
-    loadBoards();
+    loadBoards(album.invokeai_board_ids || []);
   }
 
   // Path field methods

--- a/tests/frontend/invokeai-album-source.test.js
+++ b/tests/frontend/invokeai-album-source.test.js
@@ -481,3 +481,88 @@ describe("AlbumManager edit-save payloads for board albums", () => {
     expect(manager.send_update_index_event).not.toHaveBeenCalled();
   });
 });
+
+describe("AlbumManager board-album edit form population", () => {
+  function buildBoardEditForm() {
+    document.body.innerHTML = `
+      <div class="edit-form">
+        <input class="edit-album-invoke-url" />
+        <input class="edit-album-invoke-username" />
+        <input class="edit-album-invoke-password" />
+        <small class="edit-album-invoke-status-hint"></small>
+        <div class="edit-album-invoke-root-row"></div>
+        <button class="edit-album-invoke-connect-btn"></button>
+        <div class="edit-album-invoke-boards" hidden></div>
+      </div>
+    `;
+    const form = document.querySelector(".edit-form");
+    // jsdom doesn't implement scrollIntoView, which connectAndLoadBoards calls.
+    form.querySelector(".edit-album-invoke-boards").scrollIntoView = () => {};
+    return form;
+  }
+
+  function makeStub() {
+    return {
+      connectAndLoadBoards: AlbumManager.prototype.connectAndLoadBoards,
+      populateBoardAlbumEditForm: AlbumManager.prototype.populateBoardAlbumEditForm,
+      _createInvokeRootRow: AlbumManager.prototype._createInvokeRootRow,
+      _setInvokeHint: AlbumManager.prototype._setInvokeHint,
+    };
+  }
+
+  const album = {
+    key: "board_album",
+    source_type: "invokeai_board",
+    invokeai_url: "http://localhost:9090",
+    invokeai_root: "/srv/invokeai",
+    // "all boards" selection — including Uncategorized ("none").
+    invokeai_board_ids: ["none", "b1", "b2"],
+    has_invokeai_password: true,
+  };
+
+  // Flush the async connectAndLoadBoards() chain populateBoardAlbumEditForm
+  // kicks off but doesn't await.
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  test("checks every saved board on reopen, even when Uncategorized is among them", async () => {
+    // Regression: the placeholder render only paints the (checked)
+    // Uncategorized box, so the auto-load must use the album's saved ids —
+    // not scrape the DOM, which would collapse the selection to just ["none"].
+    const editForm = buildBoardEditForm();
+    const manager = makeStub();
+    fetchJson.mockResolvedValueOnce({ reachable: true }).mockResolvedValueOnce([
+      { board_id: "b1", board_name: "Board One" },
+      { board_id: "b2", board_name: "Board Two" },
+    ]);
+
+    manager.populateBoardAlbumEditForm(editForm, album);
+    await flush();
+
+    const boardsContainer = editForm.querySelector(".edit-album-invoke-boards");
+    expect(collectSelectedBoardIds(boardsContainer)).toEqual(["none", "b1", "b2"]);
+  });
+
+  test("manual reconnect keeps the user's in-progress selection", async () => {
+    const editForm = buildBoardEditForm();
+    const manager = makeStub();
+    fetchJson.mockResolvedValueOnce({ reachable: true }).mockResolvedValueOnce([
+      { board_id: "b1", board_name: "Board One" },
+      { board_id: "b2", board_name: "Board Two" },
+    ]);
+
+    manager.populateBoardAlbumEditForm(editForm, album);
+    await flush();
+
+    const boardsContainer = editForm.querySelector(".edit-album-invoke-boards");
+    // User unchecks b2, then clicks "Connect & Load Boards" again.
+    boardsContainer.querySelector('.board-checkbox[value="b2"]').checked = false;
+    fetchJson.mockResolvedValueOnce({ reachable: true }).mockResolvedValueOnce([
+      { board_id: "b1", board_name: "Board One" },
+      { board_id: "b2", board_name: "Board Two" },
+    ]);
+    editForm.querySelector(".edit-album-invoke-connect-btn").click();
+    await flush();
+
+    expect(collectSelectedBoardIds(boardsContainer)).toEqual(["none", "b1"]);
+  });
+});


### PR DESCRIPTION
## Bug

When editing a previously-saved InvokeAI board-backed album, the board checklist showed **only "Uncategorized" checked**, even though more boards (or all of them) had been selected and indexed successfully.

## Root cause

`populateBoardAlbumEditForm` (album-manager.js) renders a placeholder checklist immediately — but with board names still unresolved, that render only paints the prepended "Uncategorized" box. It then kicks off the async `loadBoards()` to fetch the real list. The trouble was how `loadBoards` chose which boxes to check:

```js
selectedIds: collectSelectedBoardIds(boardsContainer).length
  ? collectSelectedBoardIds(boardsContainer)   // reads the DOM → just ["none"]
  : album.invokeai_board_ids || [],            // the real saved list (skipped!)
```

When the saved selection included Uncategorized (`none`), the placeholder render left that box checked, so `collectSelectedBoardIds()` returned `["none"]` (truthy) and the full `album.invokeai_board_ids` was never used. Every other saved board came back unchecked. (The bug only bit when `none` was among the saved boards — otherwise the DOM scrape returned `[]` and the fallback kicked in.)

## Fix

`loadBoards` now takes an explicit `preferredIds`:
- The **initial auto-load** passes `album.invokeai_board_ids` directly — no DOM scrape.
- The **manual "Connect & Load Boards"** button passes the current in-DOM selection, so an in-progress edit isn't clobbered on reconnect.

## Testing

- New regression test reproduces the exact scenario (all boards incl. Uncategorized) — verified it **fails without the fix, passes with it**.
- Added a test that manual reconnect preserves the user's in-progress selection.
- `npm test` (381 tests), `npm run lint`, `npm run format:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)