### PR TITLE
fix: pin numba>=0.57 to ensure Python 3.12+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "torch",
     "tqdm",
     "transformers",  # SigLIP encoder backend
+    "numba>=0.57",  # 0.57+ supports Python 3.12+; without this, resolver can pick numba 0.53.1 which only supports <3.10
     "umap-learn",
     "uvicorn",
     "psutil",  # Add this for process management


### PR DESCRIPTION
Adds an explicit `numba>=0.57` constraint to `pyproject.toml` so the dependency resolver always picks a version compatible with Python 3.12+.

Without this, `umap-learn`'s loose `numba>=0.51.2` constraint allows the resolver to pick `numba==0.53.1`, which requires `llvmlite==0.36.0` — only supporting Python <3.10. This broke AppImage first-time installs and manual `uv pip install .` on Python 3.12+.

Fixes #338

Generated with [Claude Code](https://claude.ai/code)