### PR TITLE
feat: reindex button with progress ring in the semantic map titlebar

### DIFF
--- a/photomap/frontend/static/css/umap-floating-window.css
+++ b/photomap/frontend/static/css/umap-floating-window.css
@@ -61,6 +61,60 @@
   font-size: 1em;
 }
 
+.umap-titlebar-left {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-width: 0;
+  /* Was on the select itself before the reindex button joined it. */
+  max-width: 60%;
+}
+
+#umapReindexBtn {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  margin: 0;
+}
+
+/* Progress ring shown in place of the reindex button while indexing runs.
+   The fill arc is driven from JS via stroke-dashoffset (circumference 2πr,
+   r=8 → 50.27); the -90° rotation starts the arc at 12 o'clock. */
+.umap-reindex-progress {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px;
+  cursor: default;
+}
+
+.umap-reindex-progress svg {
+  transform: rotate(-90deg);
+}
+
+.umap-reindex-track {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.25);
+  stroke-width: 3;
+}
+
+.umap-reindex-ring {
+  fill: none;
+  stroke: #ff9800;
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-dasharray: 50.27;
+  stroke-dashoffset: 50.27;
+  transition:
+    stroke-dashoffset 0.3s,
+    stroke 0.3s;
+}
+
+/* Phases without a meaningful percentage (directory traversal) show a
+   spinning quarter arc instead of a fill level. Keyframes: spinners.css. */
+.umap-reindex-progress.indeterminate svg {
+  animation: umap-spin 1.2s linear infinite;
+}
+
 #semanticMapAlbumSelect {
   cursor: pointer;
   background: transparent;
@@ -72,7 +126,8 @@
   border-radius: 4px;
   padding: 2px 22px 2px 6px;
   margin: 0;
-  max-width: 60%;
+  max-width: 100%;
+  min-width: 0;
   text-overflow: ellipsis;
   appearance: none;
   -webkit-appearance: none;

--- a/photomap/frontend/static/javascript/umap-reindex.js
+++ b/photomap/frontend/static/javascript/umap-reindex.js
@@ -1,0 +1,210 @@
+// umap-reindex.js
+// The 🔄 button in the semantic-map titlebar: a shortcut for "Update Index"
+// on the current album without opening Album Management. While an index
+// update runs, the button is swapped for a small progress ring whose fill
+// tracks progress_percentage, whose colour tracks the phase (matching the
+// Album Manager's status colours), and whose hover title carries the live
+// status text. Clicking the ring does nothing — cancellation stays in the
+// Album Manager. On completion an "albumIndexUpdated" event is dispatched
+// so the map can reload itself.
+
+import { updateIndex } from "./index.js";
+import { state } from "./state.js";
+import { fetchJson } from "./utils.js";
+
+// Mutable so tests can shorten the poll cadence.
+export const reindexConfig = {
+  pollInterval: 1000,
+  maxPollFailures: 5,
+};
+
+const RUNNING_STATUSES = ["scanning", "downloading", "indexing", "mapping"];
+
+// Same palette as the Album Manager's status lines.
+const PHASE_COLORS = {
+  scanning: "#ff9800",
+  indexing: "#ff9800",
+  downloading: "#9c27b0",
+  mapping: "#2196f3",
+};
+
+const RING_CIRCUMFERENCE = 50.27; // 2πr for the r=8 ring in the template
+
+let pollTimer = null;
+
+function elements() {
+  return {
+    btn: document.getElementById("umapReindexBtn"),
+    progress: document.getElementById("umapReindexProgress"),
+    ring: document.getElementById("umapReindexRing"),
+  };
+}
+
+function showRing() {
+  const { btn, progress } = elements();
+  if (btn) {
+    btn.style.display = "none";
+  }
+  if (progress) {
+    progress.style.display = "inline-flex";
+  }
+}
+
+function showButton() {
+  const { btn, progress } = elements();
+  if (btn) {
+    btn.style.display = "";
+  }
+  if (progress) {
+    progress.style.display = "none";
+  }
+}
+
+function updateRing(progressData) {
+  const { progress, ring } = elements();
+  if (!progress || !ring) {
+    return;
+  }
+
+  const status = progressData.status;
+  ring.style.stroke = PHASE_COLORS[status] || "#ff9800";
+
+  // The traversal phase reports counts, not a completion fraction — show a
+  // spinning quarter arc there and a real fill everywhere else.
+  const indeterminate = status === "scanning";
+  progress.classList.toggle("indeterminate", indeterminate);
+  let percentage = Number(progressData.progress_percentage);
+  if (!Number.isFinite(percentage)) {
+    percentage = 0;
+  }
+  percentage = Math.min(100, Math.max(0, percentage));
+  const fraction = indeterminate ? 0.25 : percentage / 100;
+  ring.style.strokeDashoffset = String(RING_CIRCUMFERENCE * (1 - fraction));
+
+  // Native title tooltip: shows the live status text on hover.
+  const step = progressData.current_step || "Indexing in progress...";
+  const suffix = indeterminate ? "" : ` (${Math.round(percentage)}%)`;
+  progress.title = `${step}${suffix}`;
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  showButton();
+}
+
+// Poll the backend for this run's progress until it leaves a running state.
+// Mirrors the Album Manager's card polling, but scoped to the titlebar ring.
+function beginProgress(albumKey, initialProgress = null) {
+  if (pollTimer) {
+    return;
+  }
+  showRing();
+  if (initialProgress) {
+    updateRing(initialProgress);
+  }
+
+  let consecutiveFailures = 0;
+  pollTimer = setInterval(async () => {
+    try {
+      const progress = await fetchJson(`index_progress/${albumKey}`);
+      consecutiveFailures = 0;
+      if (RUNNING_STATUSES.includes(progress.status)) {
+        updateRing(progress);
+        return;
+      }
+      stopPolling();
+      if (progress.status === "completed") {
+        window.dispatchEvent(new CustomEvent("albumIndexUpdated", { detail: { albumKey } }));
+      } else if (progress.status === "error") {
+        const { btn } = elements();
+        if (btn) {
+          btn.title = `Index update failed: ${progress.error_message || "unknown error"} — click to retry`;
+        }
+      }
+    } catch (error) {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= reindexConfig.maxPollFailures) {
+        console.error(`Giving up polling index progress for album ${albumKey}:`, error);
+        stopPolling();
+      }
+    }
+  }, reindexConfig.pollInterval);
+}
+
+export async function startUmapReindex() {
+  const albumKey = state.album;
+  if (!albumKey || pollTimer) {
+    return;
+  }
+
+  // If an update is already running (Album Manager, Update All, another
+  // tab), attach the ring to that run instead of starting a duplicate.
+  try {
+    const progress = await fetchJson(`index_progress/${albumKey}`);
+    if (RUNNING_STATUSES.includes(progress.status)) {
+      beginProgress(albumKey, progress);
+      return;
+    }
+  } catch {
+    // Progress endpoint unreachable — fall through and let updateIndex()
+    // surface any real error to the user.
+  }
+
+  const response = await updateIndex(albumKey); // alerts + returns null on failure
+  if (!response) {
+    return;
+  }
+  beginProgress(albumKey);
+}
+
+// Attach the ring to an already-running update for the current album (e.g.
+// one started from Album Management before this window was opened). Called
+// when the semantic map is shown and when the album changes.
+export async function checkUmapReindexOngoing() {
+  const albumKey = state.album;
+  if (!albumKey) {
+    return;
+  }
+  if (pollTimer) {
+    // A poller from a previous album may still be running after an album
+    // switch; restart cleanly against the current album.
+    stopPolling();
+  }
+  try {
+    const progress = await fetchJson(`index_progress/${albumKey}`);
+    if (RUNNING_STATUSES.includes(progress.status)) {
+      beginProgress(albumKey, progress);
+    }
+  } catch {
+    // No progress info — leave the plain button in place.
+  }
+}
+
+export function initUmapReindexButton() {
+  const { btn, progress } = elements();
+  if (!btn) {
+    return;
+  }
+  // The titlebar is draggable; keep pointer events on the button (and the
+  // ring) from starting a drag, the same way the album select does.
+  for (const el of [btn, progress]) {
+    if (!el) {
+      continue;
+    }
+    for (const evt of ["mousedown", "touchstart", "dblclick"]) {
+      el.addEventListener(evt, (e) => e.stopPropagation());
+    }
+  }
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    btn.title = "Update this album's index";
+    startUmapReindex();
+  });
+
+  window.addEventListener("albumChanged", () => {
+    checkUmapReindexOngoing();
+  });
+}

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -22,6 +22,7 @@ import {
   state,
 } from "./state.js";
 import { findLandmarkClusterAt } from "./umap-helpers.js";
+import { checkUmapReindexOngoing, initUmapReindexButton } from "./umap-reindex.js";
 import { debounce, getPercentile, isColorLight, makeDraggable } from "./utils.js";
 
 const UMAP_SIZES = {
@@ -1600,6 +1601,10 @@ export async function toggleUmapWindow(show = null) {
       return;
     }
 
+    // If an index update is already running for this album (e.g. started
+    // from Album Management), show the titlebar progress ring for it.
+    checkUmapReindexOngoing();
+
     // Fetch configured eps value from server
     const result = await fetch("get_umap_eps/", {
       method: "POST",
@@ -2021,7 +2026,17 @@ export function isUmapFullscreen() {
 document.addEventListener("DOMContentLoaded", () => {
   setupSemanticMapAlbumSelect();
   populateSemanticMapAlbumSelect();
+  initUmapReindexButton();
   initializeUmapWindow();
+});
+
+// The titlebar reindex button finished an update of the current album: the
+// map on screen is stale, so reload it.
+window.addEventListener("albumIndexUpdated", (e) => {
+  if (e.detail?.albumKey === state.album) {
+    state.dataChanged = true;
+    fetchUmapData();
+  }
 });
 window.addEventListener("albumChanged", initializeUmapWindow);
 

--- a/photomap/frontend/templates/modules/umap-floating-window.html
+++ b/photomap/frontend/templates/modules/umap-floating-window.html
@@ -4,7 +4,38 @@
 <div id="umapFloatingWindow">
   <!-- Titlebar -->
   <div id="umapTitlebar">
-    <select id="semanticMapAlbumSelect" title="Switch album" aria-label="Switch album"></select>
+    <div class="umap-titlebar-left">
+      <button id="umapReindexBtn" class="icon-btn" title="Update this album's index" aria-label="Update this album's index">
+        <!-- Two circling arrows, pale grey on the dark titlebar to match the
+             neighbouring resize icons; sized to the pulldown's text height. -->
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#d0d0d0"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="23 4 23 10 17 10" />
+          <polyline points="1 20 1 14 7 14" />
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10" />
+          <path d="M20.49 15a9 9 0 0 1-14.85 3.36L1 14" />
+        </svg>
+      </button>
+      <!-- Swapped in for the button while an index update runs. The ring
+           fills with progress_percentage; the title carries the status text
+           so hovering shows what the indexer is doing. -->
+      <span id="umapReindexProgress" class="umap-reindex-progress" style="display: none" role="progressbar">
+        <svg viewBox="0 0 20 20" width="20" height="20" aria-hidden="true">
+          <circle class="umap-reindex-track" cx="10" cy="10" r="8" />
+          <circle id="umapReindexRing" class="umap-reindex-ring" cx="10" cy="10" r="8" />
+        </svg>
+      </span>
+      <select id="semanticMapAlbumSelect" title="Switch album" aria-label="Switch album"></select>
+    </div>
     <div style="display: flex; align-items: center; gap: 3px">
       <!-- Resizing icons -->
       <button id="umapResizeFullscreen" title="Fullscreen" class="icon-btn">

--- a/tests/frontend/umap-reindex.test.js
+++ b/tests/frontend/umap-reindex.test.js
@@ -1,0 +1,173 @@
+/**
+ * Tests for the semantic-map titlebar reindex button (umap-reindex.js):
+ * button/ring swap, progress-ring updates from polled status, attaching to
+ * an already-running update, error recovery, and the albumIndexUpdated
+ * completion event that triggers the map reload.
+ */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const M = "../../photomap/frontend/static/javascript";
+
+jest.unstable_mockModule(`${M}/index.js`, () => ({
+  updateIndex: jest.fn(),
+}));
+jest.unstable_mockModule(`${M}/state.js`, () => ({
+  state: { album: "alb" },
+}));
+jest.unstable_mockModule(`${M}/utils.js`, () => ({
+  fetchJson: jest.fn(),
+}));
+
+const { updateIndex } = await import(`${M}/index.js`);
+const { state } = await import(`${M}/state.js`);
+const { fetchJson } = await import(`${M}/utils.js`);
+const { reindexConfig, startUmapReindex, checkUmapReindexOngoing } = await import(`${M}/umap-reindex.js`);
+
+reindexConfig.pollInterval = 5;
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 25));
+
+function buildDom() {
+  document.body.innerHTML = `
+    <button id="umapReindexBtn">🔄</button>
+    <span id="umapReindexProgress" style="display: none">
+      <svg><circle id="umapReindexRing" /></svg>
+    </span>`;
+}
+
+async function waitForButtonRestore() {
+  for (let i = 0; i < 40; i++) {
+    await flush();
+    if (document.getElementById("umapReindexBtn").style.display === "") {
+      return;
+    }
+  }
+  throw new Error("button never restored");
+}
+
+beforeEach(async () => {
+  buildDom();
+  updateIndex.mockReset();
+  fetchJson.mockReset();
+  state.album = "alb";
+  // Drain any poller left over from a previous test.
+  fetchJson.mockResolvedValue({ status: "completed" });
+  await flush();
+});
+
+describe("startUmapReindex", () => {
+  test("starts an update, swaps to the ring, and restores on completion", async () => {
+    const statuses = [
+      { status: "idle" }, // pre-start guard check
+      { status: "indexing", progress_percentage: 50, current_step: "Indexing images" },
+      { status: "completed" },
+    ];
+    fetchJson.mockImplementation(() => Promise.resolve(statuses.shift() ?? { status: "completed" }));
+    updateIndex.mockResolvedValue({ success: true });
+    const events = [];
+    const onUpdated = (e) => events.push(e.detail.albumKey);
+    window.addEventListener("albumIndexUpdated", onUpdated);
+    try {
+      await startUmapReindex();
+      expect(updateIndex).toHaveBeenCalledWith("alb");
+      expect(document.getElementById("umapReindexBtn").style.display).toBe("none");
+      expect(document.getElementById("umapReindexProgress").style.display).toBe("inline-flex");
+
+      await waitForButtonRestore();
+      expect(events).toEqual(["alb"]);
+      expect(document.getElementById("umapReindexProgress").style.display).toBe("none");
+    } finally {
+      window.removeEventListener("albumIndexUpdated", onUpdated);
+    }
+  });
+
+  test("attaches to an already-running update instead of starting one", async () => {
+    fetchJson.mockResolvedValueOnce({ status: "scanning", current_step: "Traversing image files..." });
+    fetchJson.mockResolvedValue({ status: "completed" });
+
+    await startUmapReindex();
+
+    expect(updateIndex).not.toHaveBeenCalled();
+    expect(document.getElementById("umapReindexProgress").style.display).toBe("inline-flex");
+    await waitForButtonRestore();
+  });
+
+  test("failed start (updateIndex null) leaves the plain button in place", async () => {
+    fetchJson.mockResolvedValue({ status: "idle" });
+    updateIndex.mockResolvedValue(null);
+
+    await startUmapReindex();
+
+    expect(document.getElementById("umapReindexBtn").style.display).toBe("");
+    expect(document.getElementById("umapReindexProgress").style.display).toBe("none");
+  });
+
+  test("error status restores the button and surfaces the message in its title", async () => {
+    fetchJson.mockResolvedValueOnce({ status: "idle" });
+    fetchJson.mockResolvedValue({ status: "error", error_message: "boom" });
+    updateIndex.mockResolvedValue({ success: true });
+
+    await startUmapReindex();
+    await waitForButtonRestore();
+
+    expect(document.getElementById("umapReindexBtn").title).toContain("boom");
+  });
+});
+
+describe("progress ring rendering", () => {
+  test("shows phase colour, fill fraction, and hover title from the poll", async () => {
+    fetchJson.mockResolvedValueOnce({ status: "idle" });
+    fetchJson.mockResolvedValueOnce({
+      status: "mapping",
+      progress_percentage: 75,
+      current_step: "Generating image map...",
+    });
+    fetchJson.mockResolvedValue({ status: "completed" });
+    updateIndex.mockResolvedValue({ success: true });
+
+    await startUmapReindex();
+    await flush();
+
+    const ring = document.getElementById("umapReindexRing");
+    const progress = document.getElementById("umapReindexProgress");
+    expect(ring.style.stroke).toBe("#2196f3"); // mapping = blue, as in Album Manager
+    // 75% fill: dashoffset = C * 0.25
+    expect(Number.parseFloat(ring.style.strokeDashoffset)).toBeCloseTo(50.27 * 0.25, 1);
+    expect(progress.title).toBe("Generating image map... (75%)");
+    await waitForButtonRestore();
+  });
+
+  test("scanning phase renders as an indeterminate spinning arc", async () => {
+    fetchJson.mockResolvedValueOnce({ status: "idle" });
+    fetchJson.mockResolvedValueOnce({
+      status: "scanning",
+      progress_percentage: 100,
+      current_step: "Traversing image files... 5000 found",
+    });
+    fetchJson.mockResolvedValue({ status: "completed" });
+    updateIndex.mockResolvedValue({ success: true });
+
+    await startUmapReindex();
+    await flush();
+
+    const progress = document.getElementById("umapReindexProgress");
+    expect(progress.classList.contains("indeterminate")).toBe(true);
+    expect(progress.title).toBe("Traversing image files... 5000 found");
+    await waitForButtonRestore();
+  });
+});
+
+describe("checkUmapReindexOngoing", () => {
+  test("shows the ring when the backend reports a run, stays idle otherwise", async () => {
+    fetchJson.mockResolvedValueOnce({ status: "indexing", progress_percentage: 10 });
+    fetchJson.mockResolvedValue({ status: "completed" });
+
+    await checkUmapReindexOngoing();
+    expect(document.getElementById("umapReindexProgress").style.display).toBe("inline-flex");
+    await waitForButtonRestore();
+
+    fetchJson.mockResolvedValue({ status: "idle" });
+    await checkUmapReindexOngoing();
+    expect(document.getElementById("umapReindexProgress").style.display).toBe("none");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a small refresh button (two circling arrows in pale grey, styled like the neighbouring titlebar icons) immediately left of the album pulldown in the semantic-map window. Clicking it starts an index update for the current album — a shortcut for opening Album Management.
- While the update runs, the button is swapped for a **progress ring** that fills with the real completion percentage and takes the Album Manager's phase colours (orange scanning/indexing, purple model download, blue UMAP). The directory-traversal phase has no meaningful percentage, so it renders as a spinning indeterminate arc instead.
- **Hovering the ring shows the live status text** (e.g. "Checking new image files (1,200 of 5,000)... (24%)") via a tooltip refreshed on each poll tick.
- Opening the map window or switching albums **attaches the ring to an already-running update** (started from Album Management, Update All, or another tab) rather than starting a duplicate. Clicking during a run does nothing — cancellation deliberately stays in Album Management, which has a proper cancel button.
- On completion an `albumIndexUpdated` event fires and **the map reloads itself** with the fresh data. On error the plain button returns with the error message in its tooltip and can be clicked to retry.

All new logic lives in a dedicated `umap-reindex.js` module wired into `umap.js`; no backend changes.

## Test plan

- 7 new Jest tests: button/ring swap and completion event, attach-to-running, failed-start recovery, error-status tooltip, ring colour/fill/title rendering, indeterminate scanning arc, and the ongoing-run check on window open.
- Full frontend suite (394 tests), ESLint, Prettier clean.
- Manually verified against a live album by the author, including the icon styling on the dark titlebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)