### PR TITLE
fix: stop Chrome offering to save passwords on the UMAP EPS field

### DIFF
--- a/photomap/frontend/templates/modules/album-manager.html
+++ b/photomap/frontend/templates/modules/album-manager.html
@@ -71,11 +71,21 @@
           <div class="form-grid">
             <div class="form-group">
               <label>Username</label>
-              <input id="newAlbumInvokeUsername" type="text" placeholder="(optional, multi-user mode)" />
+              <input
+                id="newAlbumInvokeUsername"
+                type="text"
+                autocomplete="username"
+                placeholder="(optional, multi-user mode)"
+              />
             </div>
             <div class="form-group">
               <label>Password</label>
-              <input id="newAlbumInvokePassword" type="password" placeholder="(optional, multi-user mode)" />
+              <input
+                id="newAlbumInvokePassword"
+                type="password"
+                autocomplete="new-password"
+                placeholder="(optional, multi-user mode)"
+              />
             </div>
           </div>
         </div>
@@ -187,11 +197,16 @@
         <div class="form-grid">
           <div class="form-group">
             <label>Username</label>
-            <input class="edit-album-invoke-username" type="text" placeholder="(optional, multi-user mode)" />
+            <input
+              class="edit-album-invoke-username"
+              type="text"
+              autocomplete="username"
+              placeholder="(optional, multi-user mode)"
+            />
           </div>
           <div class="form-group">
             <label>Password</label>
-            <input class="edit-album-invoke-password" type="password" />
+            <input class="edit-album-invoke-password" type="password" autocomplete="new-password" />
           </div>
         </div>
         <div class="form-group">

--- a/photomap/frontend/templates/modules/umap-floating-window.html
+++ b/photomap/frontend/templates/modules/umap-floating-window.html
@@ -190,6 +190,7 @@
               max="1.0"
               step="0.01"
               value="0.1"
+              autocomplete="off"
               style="width: 60px"
             />
           </div>


### PR DESCRIPTION
## Problem

Clicking in the UMAP **Cluster Strength** (EPS) spinner made Chrome pop up its password save/restore prompt.

## Cause

The InvokeAI credential inputs in the album manager (`newAlbumInvokePassword`, `edit-album-invoke-password`) are real `type="password"` fields that don't live inside a `<form>`. Chrome groups every form-less input on the page into one synthetic form, sees a password field in it, and heuristically guesses which other field is the "username" — its guess landed on the EPS number spinner.

## Fix

- `album-manager.html`: annotate both credential pairs (new-album and edit-album) with `autocomplete="username"` / `autocomplete="new-password"`. With the credentials explicitly annotated, Chrome no longer hunts for a username field elsewhere on the page; `new-password` also stops Chrome offering stored passwords in those fields.
- `umap-floating-window.html`: add `autocomplete="off"` to `umapEpsSpinner` to opt it out of autofill entirely.

## Testing

- All 411 frontend Jest tests pass; prettier and eslint clean.
- Note: if Chrome already saved a bogus credential for `localhost:8050`, the key icon may persist on old saved data until that entry is removed in `chrome://passwords`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)