### PR TITLE
feat: animate the UMAP reindex ring for updates started in the Album Manager

### DIFF
--- a/photomap/frontend/static/javascript/album-manager.js
+++ b/photomap/frontend/static/javascript/album-manager.js
@@ -1606,6 +1606,10 @@ export class AlbumManager {
         console.log(`Backend reports indexing already in progress for album: ${albumKey}`);
         this.showProgressUIWithoutScroll(cardElement, progress);
         this.startProgressPolling(albumKey, cardElement);
+        // The run predates this click (another tab, Update All, …) so
+        // updateIndex() won't fire albumIndexStarted for it — announce it
+        // here so the semantic map's ring attaches to it as well.
+        window.dispatchEvent(new CustomEvent("albumIndexStarted", { detail: { albumKey } }));
         return;
       }
     } catch {

--- a/photomap/frontend/static/javascript/index.js
+++ b/photomap/frontend/static/javascript/index.js
@@ -5,7 +5,11 @@ import { fetchJson, HttpError } from "./utils.js";
 
 export async function updateIndex(albumKey) {
   try {
-    return await fetchJson("update_index_async/", { json: { album_key: albumKey } });
+    const response = await fetchJson("update_index_async/", { json: { album_key: albumKey } });
+    // Tell interested UI (e.g. the semantic map's titlebar progress ring)
+    // that a run just started, whichever control initiated it.
+    window.dispatchEvent(new CustomEvent("albumIndexStarted", { detail: { albumKey } }));
+    return response;
   } catch (error) {
     console.error("Failed to start indexing:", error);
     alert(`Failed to start indexing: ${error.message}`);

--- a/photomap/frontend/static/javascript/umap-reindex.js
+++ b/photomap/frontend/static/javascript/umap-reindex.js
@@ -7,7 +7,10 @@
 // status text. Clicking the ring does nothing — cancellation stays in the
 // Album Manager. On completion an "albumIndexUpdated" event is dispatched
 // so the map can reload itself, and an albumChanged/"refresh" event so the
-// slideshow picks up the new image set without losing its place.
+// slideshow picks up the new image set without losing its place. The ring
+// also animates for runs started elsewhere: it listens for the
+// "albumIndexStarted" event fired when the Album Manager (Update Index /
+// Update All) kicks off or attaches to an update of the current album.
 
 import { getIndexMetadata, updateIndex } from "./index.js";
 import { state } from "./state.js";
@@ -237,6 +240,17 @@ export function initUmapReindexButton() {
     // ring is already down and the album hasn't changed, so nothing to do.
     if (e.detail?.changeType !== "refresh") {
       checkUmapReindexOngoing();
+    }
+  });
+
+  // An index update was started elsewhere (Album Manager's "Update Index",
+  // "Update All", auto-indexing). If it's for the album being viewed, raise
+  // the ring and track that run; beginProgress is a no-op if the ring is
+  // already polling (e.g. the run was started by this button).
+  window.addEventListener("albumIndexStarted", (e) => {
+    const albumKey = e.detail?.albumKey;
+    if (albumKey && albumKey === state.album) {
+      beginProgress(albumKey);
     }
   });
 }

--- a/tests/frontend/index-api.test.js
+++ b/tests/frontend/index-api.test.js
@@ -1,0 +1,53 @@
+/**
+ * Tests for the index API helpers (index.js): updateIndex announces a newly
+ * started run with the albumIndexStarted window event (consumed by the
+ * semantic map's titlebar progress ring), and stays silent on failure.
+ */
+import { beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+const M = "../../photomap/frontend/static/javascript";
+
+jest.unstable_mockModule(`${M}/utils.js`, () => ({
+  fetchJson: jest.fn(),
+  HttpError: class HttpError extends Error {},
+}));
+
+const { fetchJson } = await import(`${M}/utils.js`);
+const { updateIndex } = await import(`${M}/index.js`);
+
+beforeEach(() => {
+  fetchJson.mockReset();
+  window.alert = jest.fn();
+});
+
+describe("updateIndex", () => {
+  test("dispatches albumIndexStarted and returns the response on success", async () => {
+    const response = { success: true, album_key: "alb" };
+    fetchJson.mockResolvedValue(response);
+    const started = [];
+    const onStarted = (e) => started.push(e.detail.albumKey);
+    window.addEventListener("albumIndexStarted", onStarted);
+    try {
+      const result = await updateIndex("alb");
+      expect(result).toBe(response);
+      expect(started).toEqual(["alb"]);
+    } finally {
+      window.removeEventListener("albumIndexStarted", onStarted);
+    }
+  });
+
+  test("returns null and dispatches nothing when the request fails", async () => {
+    fetchJson.mockRejectedValue(new Error("boom"));
+    const started = [];
+    const onStarted = (e) => started.push(e.detail.albumKey);
+    window.addEventListener("albumIndexStarted", onStarted);
+    try {
+      const result = await updateIndex("alb");
+      expect(result).toBeNull();
+      expect(started).toEqual([]);
+      expect(window.alert).toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("albumIndexStarted", onStarted);
+    }
+  });
+});

--- a/tests/frontend/umap-reindex.test.js
+++ b/tests/frontend/umap-reindex.test.js
@@ -22,7 +22,9 @@ jest.unstable_mockModule(`${M}/utils.js`, () => ({
 const { updateIndex, getIndexMetadata } = await import(`${M}/index.js`);
 const { state } = await import(`${M}/state.js`);
 const { fetchJson } = await import(`${M}/utils.js`);
-const { reindexConfig, startUmapReindex, checkUmapReindexOngoing } = await import(`${M}/umap-reindex.js`);
+const { reindexConfig, startUmapReindex, checkUmapReindexOngoing, initUmapReindexButton } = await import(
+  `${M}/umap-reindex.js`
+);
 
 reindexConfig.pollInterval = 5;
 
@@ -182,5 +184,26 @@ describe("checkUmapReindexOngoing", () => {
     fetchJson.mockResolvedValue({ status: "idle" });
     await checkUmapReindexOngoing();
     expect(document.getElementById("umapReindexProgress").style.display).toBe("none");
+  });
+});
+
+// Keep this block last: initUmapReindexButton registers persistent window
+// listeners that would otherwise react to events dispatched by other tests.
+describe("albumIndexStarted from another control (e.g. Album Manager)", () => {
+  test("raises the ring for the current album and tracks the run to completion", async () => {
+    initUmapReindexButton();
+    fetchJson.mockResolvedValue({ status: "indexing", progress_percentage: 30 });
+
+    // A run on some other album must not touch this ring.
+    window.dispatchEvent(new CustomEvent("albumIndexStarted", { detail: { albumKey: "other-album" } }));
+    await flush();
+    expect(document.getElementById("umapReindexProgress").style.display).toBe("none");
+
+    window.dispatchEvent(new CustomEvent("albumIndexStarted", { detail: { albumKey: "alb" } }));
+    expect(document.getElementById("umapReindexProgress").style.display).toBe("inline-flex");
+    expect(document.getElementById("umapReindexBtn").style.display).toBe("none");
+
+    fetchJson.mockResolvedValue({ status: "completed" });
+    await waitForButtonRestore();
   });
 });


### PR DESCRIPTION
## Summary

The semantic map's titlebar refresh icon already swaps to a progress ring when *it* starts an index update, and the Album Manager's card shows progress for runs started from the map. But the reverse didn't hold: starting "Update Index" (or "Update All") from the Album Manager while the map sat open left the refresh icon inert. This PR makes the ring animate for the currently viewed album regardless of which control initiated the reindex.

## How

- **`index.js`** — `updateIndex()` dispatches a new `albumIndexStarted` window event (with the album key) whenever it successfully starts a run. Every initiator — Album Manager button, Update All, auto-indexing, the UMAP button itself — funnels through this helper, so they all announce themselves.
- **`umap-reindex.js`** — `initUmapReindexButton()` listens for `albumIndexStarted`; when the event names the album being viewed, it raises the progress ring and polls that run to completion (with the existing completion behavior: map reload + in-place slideshow refresh). If the ring is already tracking a run, the listener is a no-op, so the button's own runs aren't double-handled.
- **`album-manager.js`** — the "backend reports indexing already in progress" guard branch also fires the event, so the ring attaches when the Manager latches onto a run it didn't start (e.g. one begun in another tab), mirroring what the Manager's own card UI does.

## Tests

- `tests/frontend/umap-reindex.test.js`: `albumIndexStarted` for the current album raises the ring and tracks the run to completion; an event for a different album is ignored.
- `tests/frontend/index-api.test.js` (new): `updateIndex` dispatches the event and passes the response through on success; returns null and stays silent on failure.
- Full frontend suite: 414 passed; eslint and prettier clean. Verified live: with the semantic map open, an Update Index started from the Album Manager now animates the titlebar ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)