### PR TITLE
feat: serve video bytes and video stills

### DIFF
--- a/photomap/backend/metadata_formatting.py
+++ b/photomap/backend/metadata_formatting.py
@@ -9,12 +9,15 @@ import logging
 from pathlib import Path
 
 from .config import get_config_manager
+from .media_types import media_type_for
 from .metadata_modules import (
     SlideSummary,
     format_exif_metadata,
     format_invoke_metadata,
+    format_video_metadata,
     use_ref_button_html,
 )
+from .video import VIDEO_METADATA_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,32 @@ def format_metadata(
 
     config_manager = get_config_manager()
     invokeai_configured = bool(config_manager.get_invokeai_settings().get("url"))
+
+    # Videos branch first and return early. Two reasons this cannot just fall
+    # through to the EXIF path: the video facts live under a reserved key that
+    # would otherwise render as a raw dict row, and the "Use as Ref Image"
+    # button below uploads the file to InvokeAI as a reference image — handing
+    # it an .mkv is a live bug, so videos never get that button.
+    if media_type_for(filepath) == "video":
+        result.media_type = "video"
+        video_info = metadata.get(VIDEO_METADATA_KEY) if metadata else None
+        result.video_info = video_info
+        result = format_video_metadata(result, video_info)
+
+        # Phone videos routinely carry a creation date and GPS, so any
+        # non-video metadata still gets the normal EXIF panel underneath.
+        remaining = {
+            k: v for k, v in (metadata or {}).items() if k != VIDEO_METADATA_KEY
+        }
+        if remaining:
+            api_key = config_manager.get_locationiq_api_key()
+            exif_only = format_exif_metadata(
+                SlideSummary(filename=result.filename, filepath=result.filepath),
+                remaining,
+                api_key,
+            )
+            result.description += exif_only.description
+        return result
 
     # The "Use as Ref Image" button only needs an image to upload — it works
     # for any file regardless of metadata. The full Recall/Remix group, on the

--- a/photomap/backend/metadata_formatting.py
+++ b/photomap/backend/metadata_formatting.py
@@ -6,6 +6,7 @@ Returns an HTML representation of the metadata.
 """
 
 import logging
+import math
 from pathlib import Path
 
 from .config import get_config_manager
@@ -20,6 +21,38 @@ from .metadata_modules import (
 from .video import VIDEO_METADATA_KEY
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitized_video_info(metadata: dict | None) -> dict | None:
+    """The probe dict, made safe to put on a JSON response model.
+
+    Three problems this closes, all of which surface as a 500 on
+    ``/retrieve_image`` — i.e. a blank slideshow, not a missing field:
+
+    * The value is whatever is in the ``.npz``. A non-dict (a JSON *string*,
+      say, from a hand-edited or older index) makes the formatter's ``.get``
+      raise ``AttributeError``.
+    * Non-finite floats are reachable, because the banner parser's numeric
+      patterns match arbitrarily long digit runs and ``float("9" * 400)`` is
+      ``inf``. Starlette serializes with ``allow_nan=False``, so an ``inf``
+      here 500s the response *even if* every formatter handles it — the two
+      are independent failure sites.
+    * The dict handed over belongs to the ``lru_cache``d index; assigning it
+      straight onto the response model shares mutable state with the
+      process-wide cache. Copying breaks that aliasing.
+    """
+    if not metadata:
+        return None
+    raw = metadata.get(VIDEO_METADATA_KEY)
+    if not isinstance(raw, dict):
+        return None
+
+    clean: dict = {}
+    for key, value in raw.items():
+        if isinstance(value, float) and not math.isfinite(value):
+            continue
+        clean[key] = value
+    return clean
 
 
 def format_metadata(
@@ -52,7 +85,7 @@ def format_metadata(
     # it an .mkv is a live bug, so videos never get that button.
     if media_type_for(filepath) == "video":
         result.media_type = "video"
-        video_info = metadata.get(VIDEO_METADATA_KEY) if metadata else None
+        video_info = _sanitized_video_info(metadata)
         result.video_info = video_info
         result = format_video_metadata(result, video_info)
 

--- a/photomap/backend/metadata_modules/__init__.py
+++ b/photomap/backend/metadata_modules/__init__.py
@@ -1,11 +1,21 @@
 from .exif_formatter import format_exif_metadata
 from .invoke_formatter import format_invoke_metadata, use_ref_button_html
 from .slide_summary import SlideSummary
+from .video_formatter import (
+    format_duration,
+    format_fps,
+    format_video_metadata,
+    video_external_link_html,
+)
 
 # re-export the format_invoke_metadata and format_exif_metadata functions
 __all__ = [
     "SlideSummary",
     "format_invoke_metadata",
     "format_exif_metadata",
+    "format_video_metadata",
+    "format_duration",
+    "format_fps",
+    "video_external_link_html",
     "use_ref_button_html",
 ]

--- a/photomap/backend/metadata_modules/slide_summary.py
+++ b/photomap/backend/metadata_modules/slide_summary.py
@@ -3,6 +3,8 @@ Pydantic class for slide metadata.
 This class is used to represent metadata for a slide, including filename, filepath, description, URL
 """
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -19,3 +21,14 @@ class SlideSummary(BaseModel):
     index: int = 0
     total: int = 0
     reference_images: list[str] = []
+
+    # Media-type fields. The defaults keep every payload for a still image
+    # byte-identical to what it was before videos existed, so the frontend
+    # only needs to look at ``media_type`` where it actually cares.
+    media_type: Literal["image", "video"] = "image"
+    # Where the playable bytes live, for videos. ``image_url`` still points at
+    # something displayable — the extracted still — so existing consumers that
+    # just want a picture keep working unchanged.
+    video_url: str = ""
+    # Duration / fps / resolution / codec / container, when known.
+    video_info: dict | None = None

--- a/photomap/backend/metadata_modules/video_formatter.py
+++ b/photomap/backend/metadata_modules/video_formatter.py
@@ -1,0 +1,123 @@
+"""Render video facts for the metadata drawer.
+
+Emits a panel in the same shape ``exif_formatter`` uses — a bold section
+heading over an ``exif-table`` of ``<th>label</th><td>value</td>`` rows — so
+the drawer's existing styling and copy-icon delegation apply unchanged.
+
+This panel *precedes* rather than replaces the EXIF panel: phone videos
+routinely carry a creation date and GPS coordinates worth showing, so both
+are rendered when both are present.
+"""
+
+from __future__ import annotations
+
+import html
+from logging import getLogger
+
+from .slide_summary import SlideSummary
+
+logger = getLogger(__name__)
+
+
+def _esc(value: object) -> str:
+    return html.escape(str(value))
+
+
+def format_duration(seconds: float | None) -> str:
+    """Human-readable clock time: 7.4 -> '0:07', 3725 -> '1:02:05'."""
+    if seconds is None:
+        return "Unknown"
+    try:
+        total = int(round(float(seconds)))
+    except (TypeError, ValueError):
+        return "Unknown"
+    if total < 0:
+        return "Unknown"
+    hours, remainder = divmod(total, 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
+
+
+def format_fps(fps: float | None) -> str:
+    """'30 fps' for whole rates, '29.97 fps' otherwise."""
+    if fps is None:
+        return "Unknown"
+    try:
+        value = float(fps)
+    except (TypeError, ValueError):
+        return "Unknown"
+    if value <= 0:
+        return "Unknown"
+    if abs(value - round(value)) < 0.01:
+        return f"{int(round(value))} fps"
+    return f"{value:.2f} fps"
+
+
+def _resolution(info: dict) -> str | None:
+    width, height = info.get("width"), info.get("height")
+    if not width or not height:
+        return None
+    return f"{int(width)} × {int(height)}"
+
+
+def video_external_link_html(video_url: str) -> str:
+    """A link to the raw video file, for the drawer.
+
+    Kept separate from :func:`format_video_metadata` because the URL depends
+    on the album key, which is only known once the router stamps it — the
+    formatter runs earlier and has no album context.
+    """
+    if not video_url:
+        return ""
+    return (
+        f"<div class='video-external-link' style='margin-top:6px; font-size:0.95em;'>"
+        f"<a href='{_esc(video_url)}' target='_blank' rel='noopener' "
+        f"style='color:white;'>Open video externally</a></div>"
+    )
+
+
+def format_video_metadata(slide_data: SlideSummary, info: dict | None) -> SlideSummary:
+    """Render ``info`` (a ``VideoInfo`` dump) into ``slide_data.description``.
+
+    Every field is optional — extraction records what it could determine and
+    leaves the rest ``None`` — so each row is emitted only when present, and a
+    video with nothing but a frame still renders a sensible panel.
+    """
+    info = info or {}
+
+    rows: list[tuple[str, str]] = []
+    if (duration := info.get("duration")) is not None:
+        rows.append(("Duration", format_duration(duration)))
+    if (fps := info.get("fps")) is not None:
+        rows.append(("Frame Rate", format_fps(fps)))
+    if (resolution := _resolution(info)) is not None:
+        rows.append(("Resolution", resolution))
+    if codec := info.get("codec"):
+        rows.append(("Codec", str(codec)))
+    if container := info.get("container"):
+        rows.append(("Container", str(container)))
+    if info.get("playable") is False:
+        rows.append(
+            ("Playback", "Not supported by browsers — use the download link")
+        )
+
+    html_doc = (
+        "<div class='video-metadata'>"
+        "<div style=\"font-weight: bold; margin-bottom: 4px;\">🎬 Video</div>"
+        "<table class='exif-table'>"
+    )
+    if rows:
+        # Labels are hardcoded above and therefore trusted; values originate
+        # from ffmpeg's output and must be escaped.
+        for label, value in rows:
+            html_doc += f"<tr><th>{label}</th><td>{_esc(value)}</td></tr>"
+    else:
+        html_doc += (
+            "<tr><td><i>No video details available.</i></td></tr>"
+        )
+    html_doc += "</table></div>"
+
+    slide_data.description = html_doc
+    return slide_data

--- a/photomap/backend/metadata_modules/video_formatter.py
+++ b/photomap/backend/metadata_modules/video_formatter.py
@@ -1,17 +1,27 @@
 """Render video facts for the metadata drawer.
 
 Emits a panel in the same shape ``exif_formatter`` uses — a bold section
-heading over an ``exif-table`` of ``<th>label</th><td>value</td>`` rows — so
-the drawer's existing styling and copy-icon delegation apply unchanged.
+heading over a table of ``<th>label</th><td>value</td>`` rows, inside an
+``exif-metadata`` wrapper, which is the ancestor selector the drawer
+stylesheet actually targets.
 
-This panel *precedes* rather than replaces the EXIF panel: phone videos
-routinely carry a creation date and GPS coordinates worth showing, so both
-are rendered when both are present.
+This panel *precedes* rather than replaces the EXIF panel, so that a video
+carrying a creation date or GPS shows both. Note that today the indexer never
+produces EXIF for a video — ``_load_video`` writes only the probe dict — so in
+the current pipeline this is always the sole panel. The composition is kept
+because it is the correct behavior the moment video EXIF extraction is added,
+but no test here should be read as evidence that it happens now.
+
+Every helper returns a placeholder rather than raising. That matters more than
+it looks: the values come from parsing ffmpeg's stderr, so ``inf`` is
+reachable from a long digit run, and an exception here does not degrade one
+row — it takes down the whole ``/retrieve_image`` response.
 """
 
 from __future__ import annotations
 
 import html
+import math
 from logging import getLogger
 
 from .slide_summary import SlideSummary
@@ -19,47 +29,70 @@ from .slide_summary import SlideSummary
 logger = getLogger(__name__)
 
 
+UNKNOWN = "Unknown"
+
+
 def _esc(value: object) -> str:
-    return html.escape(str(value))
+    return html.escape("" if value is None else str(value))
 
 
 def format_duration(seconds: float | None) -> str:
-    """Human-readable clock time: 7.4 -> '0:07', 3725 -> '1:02:05'."""
+    """Human-readable clock time: 7.4 -> '0:07', 3725 -> '1:02:05'.
+
+    Returns ``"Unknown"`` for anything unusable rather than raising. Note the
+    conversions must ALL sit inside the guard: ``round(inf)`` raises
+    ``OverflowError``, which is neither a ``TypeError`` nor a ``ValueError``,
+    and ``inf`` is reachable — the banner's fps/duration patterns match an
+    arbitrarily long digit run and ``float("9" * 400)`` is ``inf`` with no
+    exception at all.
+    """
     if seconds is None:
-        return "Unknown"
+        return UNKNOWN
     try:
-        total = int(round(float(seconds)))
-    except (TypeError, ValueError):
-        return "Unknown"
-    if total < 0:
-        return "Unknown"
-    hours, remainder = divmod(total, 3600)
-    minutes, secs = divmod(remainder, 60)
+        value = float(seconds)
+        if not math.isfinite(value) or value < 0:
+            return UNKNOWN
+        total = int(round(value))
+        hours, remainder = divmod(total, 3600)
+        minutes, secs = divmod(remainder, 60)
+    except (TypeError, ValueError, OverflowError):
+        return UNKNOWN
     if hours:
         return f"{hours}:{minutes:02d}:{secs:02d}"
     return f"{minutes}:{secs:02d}"
 
 
 def format_fps(fps: float | None) -> str:
-    """'30 fps' for whole rates, '29.97 fps' otherwise."""
+    """'30 fps' for whole rates, '29.97 fps' otherwise, else ``"Unknown"``."""
     if fps is None:
-        return "Unknown"
+        return UNKNOWN
     try:
         value = float(fps)
-    except (TypeError, ValueError):
-        return "Unknown"
-    if value <= 0:
-        return "Unknown"
-    if abs(value - round(value)) < 0.01:
-        return f"{int(round(value))} fps"
-    return f"{value:.2f} fps"
+        if not math.isfinite(value) or value <= 0:
+            return UNKNOWN
+        if abs(value - round(value)) < 0.01:
+            return f"{int(round(value))} fps"
+        return f"{value:.2f} fps"
+    except (TypeError, ValueError, OverflowError):
+        return UNKNOWN
 
 
 def _resolution(info: dict) -> str | None:
-    width, height = info.get("width"), info.get("height")
-    if not width or not height:
+    """``"1920 × 1080"``, or ``None`` when either dimension is unusable.
+
+    Guarded like every other helper here: the falsy check alone let a
+    non-integral value such as ``"1920.0"`` through to ``int()``, which raises
+    ``ValueError`` and took down the whole drawer render rather than dropping
+    one row.
+    """
+    try:
+        width = int(info.get("width") or 0)
+        height = int(info.get("height") or 0)
+    except (TypeError, ValueError, OverflowError):
         return None
-    return f"{int(width)} × {int(height)}"
+    if width <= 0 or height <= 0:
+        return None
+    return f"{width} × {height}"
 
 
 def video_external_link_html(video_url: str) -> str:
@@ -98,13 +131,22 @@ def format_video_metadata(slide_data: SlideSummary, info: dict | None) -> SlideS
         rows.append(("Codec", str(codec)))
     if container := info.get("container"):
         rows.append(("Container", str(container)))
-    if info.get("playable") is False:
-        rows.append(
-            ("Playback", "Not supported by browsers — use the download link")
-        )
+    playable = info.get("playable")
+    if playable is not None and not playable:
+        # Truthiness rather than `is False`: an identity check silently skips
+        # a numpy bool or a 0, both of which can survive a round trip through
+        # the pickled metadata dict.
+        rows.append(("Playback", "Not supported by most browsers"))
 
+    # The wrapper carries `exif-metadata` because that is the ancestor
+    # selector metadata-drawer.css actually styles (`.exif-metadata table`,
+    # `.exif-metadata th/td`). A bare `video-metadata` matched no rule in any
+    # stylesheet, so the panel rendered with no borders, padding or width —
+    # and since the indexer writes video metadata as *only* the video dict,
+    # this panel is normally the sole panel, so nothing else pulled the
+    # styling in. The second class is a hook for future video-only styling.
     html_doc = (
-        "<div class='video-metadata'>"
+        "<div class='exif-metadata video-metadata'>"
         "<div style=\"font-weight: bold; margin-bottom: 4px;\">🎬 Video</div>"
         "<table class='exif-table'>"
     )

--- a/photomap/backend/routers/search.py
+++ b/photomap/backend/routers/search.py
@@ -21,8 +21,10 @@ from pydantic import BaseModel
 
 from ..config import get_config_manager
 from ..embeddings import SUPPORTED_EXTENSIONS
-from ..metadata_modules import SlideSummary
+from ..media_types import VIDEO_EXTENSIONS, is_video, video_media_type
+from ..metadata_modules import SlideSummary, video_external_link_html
 from ..util import is_cuda_oom
+from ..video_cache import VideoFrameCache
 from .album import (
     AlbumDep,
     EmbeddingsDep,
@@ -239,6 +241,21 @@ async def serve_thumbnail(
     if not validate_image_access(album_config, image_path):
         raise HTTPException(status_code=403, detail="Access denied")
 
+    # A video has no pixels of its own to shrink, so the thumbnail is built
+    # from its extracted still instead. Resolving it here rather than in each
+    # caller is what lets the grid, the UMAP hover popup, the landmark
+    # overlay, the back flyout and the reference-thumbnail strip all display
+    # videos with no changes of their own — they are already index-based.
+    source_path = image_path
+    if is_video(image_path):
+        frame_path = VideoFrameCache(album_key).ensure(image_path)
+        if frame_path is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No still frame available for video {image_path.name}",
+            )
+        source_path = frame_path
+
     index_path = Path(album_config.index)
     thumb_dir = index_path.parent / "thumbnails"
     thumb_dir.mkdir(exist_ok=True)
@@ -263,10 +280,10 @@ async def serve_thumbnail(
     # Generate thumbnail if not cached or outdated
     if (
         not thumb_path.exists()
-        or thumb_path.stat().st_mtime < image_path.stat().st_mtime
+        or thumb_path.stat().st_mtime < source_path.stat().st_mtime
     ):
         try:
-            with Image.open(image_path) as im:
+            with Image.open(source_path) as im:
                 im = ImageOps.exif_transpose(im).convert("RGBA")
                 im.thumbnail((size, size))
                 if color:
@@ -301,6 +318,44 @@ async def serve_thumbnail(
     return FileResponse(thumb_path.with_suffix(".png"))
 
 
+@search_router.get("/video_frame/{album_key}/{index}", tags=["Search"])
+async def serve_video_frame(
+    album_key: str,
+    index: int,
+    album_config: AlbumDep,
+    embeddings: EmbeddingsDep,
+) -> FileResponse:
+    """Serve the full-size still extracted from a video, by index.
+
+    The slideshow shows a poster at full viewport size and so wants the whole
+    frame rather than a ``/thumbnails/`` reduction.  Goes through
+    ``VideoFrameCache.ensure`` so a cache that was wiped or pruned regenerates
+    instead of leaving a broken image on screen.
+    """
+    try:
+        video_path = embeddings.get_image_path(index)
+    except Exception as e:
+        raise HTTPException(
+            status_code=404, detail=f"Image not found for index {index}: {e}"
+        ) from e
+
+    if not validate_image_access(album_config, video_path):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not is_video(video_path):
+        raise HTTPException(
+            status_code=404, detail=f"Index {index} is not a video"
+        )
+
+    frame_path = VideoFrameCache(album_key).ensure(video_path)
+    if frame_path is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No still frame available for video {video_path.name}",
+        )
+    return FileResponse(frame_path, media_type="image/jpeg")
+
+
 # File Management Routes
 # Do NOT provide a response_model here, as it may be either an image
 # or a converted stream and FastAPI refuses to work with Union types
@@ -330,6 +385,40 @@ async def serve_image(album_key: str, path: str, album_config: AlbumDep):
         return serve_image_with_conversion(image_path)
     else:
         return FileResponse(image_path)
+
+
+@search_router.get("/videos/{album_key}/{path:path}", tags=["Search"])
+async def serve_video(
+    album_key: str, path: str, album_config: AlbumDep
+) -> FileResponse:
+    """Serve a video file's bytes for playback.
+
+    A separate route rather than a widened ``/images/`` allowlist.
+    ``SUPPORTED_EXTENSIONS`` guards ``serve_image`` against the
+    ``add_album(image_paths=["/etc"])`` -> ``GET /images/<key>/passwd``
+    arbitrary-file-read chain; widening it to admit videos would have loosened
+    that guard as a side effect.  Two routes, two allowlists, neither able to
+    serve the other's file types.
+
+    Returns a ``FileResponse`` specifically: Starlette implements HTTP Range
+    on it, which is what makes the ``<video>`` scrubber able to seek.  A
+    ``StreamingResponse`` (as the HEIC conversion path uses) has no range
+    support and would silently break seeking.
+    """
+    video_path = config_manager.find_image_in_album(album_key, path)
+    if not video_path:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    if not validate_image_access(album_config, video_path):
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if video_path.suffix.lower() not in VIDEO_EXTENSIONS:
+        raise HTTPException(status_code=403, detail="Unsupported video type")
+
+    if not video_path.exists() or not video_path.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+
+    return FileResponse(video_path, media_type=video_media_type(video_path))
 
 
 @search_router.post(
@@ -490,7 +579,18 @@ def create_slide_url(slide_metadata: SlideSummary, album_key: str) -> None:
         f"Creating URL for slide: {slide_metadata.filepath} -> {relative_path}"
     )
     slide_metadata.metadata_url = f"get_metadata/{album_key}/{slide_metadata.index}"
-    slide_metadata.image_url = f"images/{album_key}/{relative_path}"
+
+    if slide_metadata.media_type == "video":
+        # ``image_url`` still points at something displayable — the extracted
+        # still — so every consumer that just wants a picture keeps working.
+        # The playable bytes get their own field.
+        slide_metadata.image_url = f"video_frame/{album_key}/{slide_metadata.index}"
+        slide_metadata.video_url = f"videos/{album_key}/{relative_path}"
+        slide_metadata.description += video_external_link_html(
+            slide_metadata.video_url
+        )
+    else:
+        slide_metadata.image_url = f"images/{album_key}/{relative_path}"
 
 
 # This is not currently used. It can be applied to the end of the image serving

--- a/photomap/backend/routers/search.py
+++ b/photomap/backend/routers/search.py
@@ -5,7 +5,9 @@ It allows searching images by similarity or text, retrieving image metadata,
 and serving images and thumbnails.
 """
 
+import asyncio
 import base64
+import functools
 import hashlib
 import json
 import re
@@ -13,15 +15,16 @@ import zipfile
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
+from urllib.parse import quote
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 from fastapi.responses import FileResponse, PlainTextResponse, StreamingResponse
 from PIL import Image, ImageDraw, ImageOps
 from pydantic import BaseModel
 
 from ..config import get_config_manager
 from ..embeddings import SUPPORTED_EXTENSIONS
-from ..media_types import VIDEO_EXTENSIONS, is_video, video_media_type
+from ..media_types import is_video, video_media_type
 from ..metadata_modules import SlideSummary, video_external_link_html
 from ..util import is_cuda_oom
 from ..video_cache import VideoFrameCache
@@ -213,6 +216,73 @@ async def get_metadata(album_key: str, index: int, embeddings: EmbeddingsDep):
     return StreamingResponse(buffer, media_type="application/json")
 
 
+async def _ensure_frame_off_loop(album_key: str, video_path: Path) -> Path | None:
+    """Resolve a video's still without blocking the event loop.
+
+    ``VideoFrameCache.ensure`` can spawn ffmpeg and wait up to
+    ``2 x FRAME_EXTRACT_TIMEOUT_SECONDS``. These handlers are ``async def``,
+    so FastAPI runs them *on the loop* rather than in its threadpool — calling
+    ``ensure`` directly froze every other request in the process for the
+    duration, since uvicorn is started with a single worker. Measured: an
+    unrelated ``/get_albums/`` stalled behind a video extraction.
+
+    ``asyncio.to_thread`` is the convention already used for the other
+    blocking work in this codebase (``cluster_labels``, the indexer).
+    """
+    return await asyncio.to_thread(VideoFrameCache(album_key).ensure, video_path)
+
+
+def _thumbnail_is_fresh(thumb_path: Path, source_path: Path) -> bool:
+    """True if the cached thumbnail exists and is newer than its source.
+
+    Tolerates the source disappearing between the check and the stat — a
+    concurrent prune of the frame cache would otherwise raise straight out of
+    the handler as a 500.
+    """
+    try:
+        return thumb_path.exists() and thumb_path.stat().st_mtime >= source_path.stat().st_mtime
+    except OSError:
+        return False
+
+
+# A neutral tile shown when a video's still cannot be produced, so a failed
+# extraction degrades to "a video we couldn't preview" rather than a broken
+# image. Cached per size: these are generated, not read from disk.
+@functools.lru_cache(maxsize=8)
+def _video_placeholder_png(size: int) -> bytes:
+    canvas = Image.new("RGBA", (size, size), (34, 34, 34, 255))
+    draw = ImageDraw.Draw(canvas)
+    # A centered play triangle, sized relative to the tile.
+    unit = max(4, size // 4)
+    cx, cy = size // 2, size // 2
+    draw.ellipse(
+        [cx - unit, cy - unit, cx + unit, cy + unit],
+        outline=(140, 140, 140, 255),
+        width=max(1, size // 64),
+    )
+    draw.polygon(
+        [
+            (cx - unit // 3, cy - unit // 2),
+            (cx - unit // 3, cy + unit // 2),
+            (cx + unit // 2, cy),
+        ],
+        fill=(140, 140, 140, 255),
+    )
+    buffer = BytesIO()
+    canvas.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _video_placeholder_response(size: int) -> Response:
+    return Response(
+        content=_video_placeholder_png(size),
+        media_type="image/png",
+        # Never cached: the still may well be extractable on the next request
+        # (a transient ffmpeg failure, a cache that has since been rebuilt).
+        headers={"Cache-Control": "no-store"},
+    )
+
+
 @search_router.get("/thumbnails/{album_key}/{index}", tags=["Search"])
 async def serve_thumbnail(
     album_key: str,
@@ -241,21 +311,6 @@ async def serve_thumbnail(
     if not validate_image_access(album_config, image_path):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    # A video has no pixels of its own to shrink, so the thumbnail is built
-    # from its extracted still instead. Resolving it here rather than in each
-    # caller is what lets the grid, the UMAP hover popup, the landmark
-    # overlay, the back flyout and the reference-thumbnail strip all display
-    # videos with no changes of their own — they are already index-based.
-    source_path = image_path
-    if is_video(image_path):
-        frame_path = VideoFrameCache(album_key).ensure(image_path)
-        if frame_path is None:
-            raise HTTPException(
-                status_code=404,
-                detail=f"No still frame available for video {image_path.name}",
-            )
-        source_path = frame_path
-
     index_path = Path(album_config.index)
     thumb_dir = index_path.parent / "thumbnails"
     thumb_dir.mkdir(exist_ok=True)
@@ -277,11 +332,33 @@ async def serve_thumbnail(
     suffix = f"_{size}.png" if not color else f"_{size}_{color.lstrip('#')}_r{radius}.png"
     thumb_path = thumb_dir / f"{rel_hash}{suffix}"
 
+    # A video has no pixels of its own to shrink, so the thumbnail is built
+    # from its extracted still instead. Resolving it here rather than in each
+    # caller is what lets the grid, the UMAP hover popup, the landmark
+    # overlay, the back flyout and the reference-thumbnail strip all display
+    # videos with no changes of their own — they are already index-based.
+    #
+    # Deliberately *after* the cache path is known: resolving the still is the
+    # expensive half (it can spawn ffmpeg), and a warm thumbnail does not need
+    # it at all. Doing it first meant every repaint of a grid of N videos paid
+    # for it N times, and made a transient extraction failure 404 even when a
+    # perfectly good thumbnail was already on disk.
+    source_path = image_path
+    if is_video(image_path):
+        if _thumbnail_is_fresh(thumb_path, image_path):
+            return FileResponse(thumb_path.with_suffix(".png"))
+        frame_path = await _ensure_frame_off_loop(album_key, image_path)
+        if frame_path is None:
+            # A placeholder rather than a 404. Every caller sets img.src with
+            # no error handling, so a 404 paints a broken-image glyph with no
+            # diagnostic — across the grid, UMAP hover popups and landmark
+            # overlays at once, and on any platform with no ffmpeg binary that
+            # is *every* video.
+            return _video_placeholder_response(size)
+        source_path = frame_path
+
     # Generate thumbnail if not cached or outdated
-    if (
-        not thumb_path.exists()
-        or thumb_path.stat().st_mtime < source_path.stat().st_mtime
-    ):
+    if not _thumbnail_is_fresh(thumb_path, source_path):
         try:
             with Image.open(source_path) as im:
                 im = ImageOps.exif_transpose(im).convert("RGBA")
@@ -324,7 +401,7 @@ async def serve_video_frame(
     index: int,
     album_config: AlbumDep,
     embeddings: EmbeddingsDep,
-) -> FileResponse:
+) -> Response:
     """Serve the full-size still extracted from a video, by index.
 
     The slideshow shows a poster at full viewport size and so wants the whole
@@ -347,13 +424,17 @@ async def serve_video_frame(
             status_code=404, detail=f"Index {index} is not a video"
         )
 
-    frame_path = VideoFrameCache(album_key).ensure(video_path)
+    frame_path = await _ensure_frame_off_loop(album_key, video_path)
     if frame_path is None:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No still frame available for video {video_path.name}",
-        )
-    return FileResponse(frame_path, media_type="image/jpeg")
+        return _video_placeholder_response(_MAX_THUMB_SIZE // 2)
+    # This URL is keyed by index, and an index designates a different file
+    # after a delete or a reindex reorders the album — so the poster must not
+    # be cached across those. The bytes themselves are cheap to re-serve.
+    return FileResponse(
+        frame_path,
+        media_type="image/jpeg",
+        headers={"Cache-Control": "no-cache"},
+    )
 
 
 # File Management Routes
@@ -405,6 +486,13 @@ async def serve_video(
     ``StreamingResponse`` (as the HEIC conversion path uses) has no range
     support and would silently break seeking.
     """
+    # A NUL byte makes Path.resolve() raise ValueError (while .exists() merely
+    # returns False), and validate_image_access below calls resolve() — so
+    # without this the request escapes every handler as a 500 with a traceback
+    # instead of the 403/404 this route is designed to return.
+    if "\x00" in path:
+        raise HTTPException(status_code=404, detail="Video not found")
+
     video_path = config_manager.find_image_in_album(album_key, path)
     if not video_path:
         raise HTTPException(status_code=404, detail="Video not found")
@@ -412,13 +500,22 @@ async def serve_video(
     if not validate_image_access(album_config, video_path):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    if video_path.suffix.lower() not in VIDEO_EXTENSIONS:
+    if not is_video(video_path):
         raise HTTPException(status_code=403, detail="Unsupported video type")
 
     if not video_path.exists() or not video_path.is_file():
         raise HTTPException(status_code=404, detail="File not found")
 
-    return FileResponse(video_path, media_type=video_media_type(video_path))
+    return FileResponse(
+        video_path,
+        media_type=video_media_type(video_path),
+        # FileResponse emits ETag/Last-Modified but implements no conditional
+        # handling (only StaticFiles does), so a revalidation would re-transfer
+        # the whole body. An explicit lifetime keeps a cached clip out of the
+        # network entirely; the path is content-addressed by name, and an
+        # edited video changes its mtime and therefore its validators.
+        headers={"Cache-Control": "private, max-age=3600"},
+    )
 
 
 @search_router.post(
@@ -578,19 +675,29 @@ def create_slide_url(slide_metadata: SlideSummary, album_key: str) -> None:
     logger.debug(
         f"Creating URL for slide: {slide_metadata.filepath} -> {relative_path}"
     )
-    slide_metadata.metadata_url = f"get_metadata/{album_key}/{slide_metadata.index}"
+    # Percent-encode both halves. These are interpolated straight into a URL
+    # the browser will request, and ordinary filename characters break it:
+    # "beach #2.mp4" makes "#2.mp4" a fragment so the server sees
+    # "videos/<key>/beach " and 404s, "?" starts a query string, and a literal
+    # "%" reads as a broken escape. html.escape (used on the drawer link) is a
+    # different encoding entirely and does not help here. safe="/" keeps the
+    # directory separators of a nested relative path intact.
+    quoted_album = quote(album_key, safe="")
+    quoted_path = quote(relative_path or "", safe="/")
+
+    slide_metadata.metadata_url = f"get_metadata/{quoted_album}/{slide_metadata.index}"
 
     if slide_metadata.media_type == "video":
         # ``image_url`` still points at something displayable — the extracted
         # still — so every consumer that just wants a picture keeps working.
         # The playable bytes get their own field.
-        slide_metadata.image_url = f"video_frame/{album_key}/{slide_metadata.index}"
-        slide_metadata.video_url = f"videos/{album_key}/{relative_path}"
+        slide_metadata.image_url = f"video_frame/{quoted_album}/{slide_metadata.index}"
+        slide_metadata.video_url = f"videos/{quoted_album}/{quoted_path}"
         slide_metadata.description += video_external_link_html(
             slide_metadata.video_url
         )
     else:
-        slide_metadata.image_url = f"images/{album_key}/{relative_path}"
+        slide_metadata.image_url = f"images/{quoted_album}/{quoted_path}"
 
 
 # This is not currently used. It can be applied to the end of the image serving

--- a/photomap/backend/video_cache.py
+++ b/photomap/backend/video_cache.py
@@ -38,6 +38,7 @@ import re
 import shutil
 import tempfile
 import threading
+import time
 from pathlib import Path
 
 from PIL import Image
@@ -70,9 +71,27 @@ _MAX_TRACKED_KEYS = 4096
 _key_locks: BoundedLRU[str, threading.Lock] = BoundedLRU(_MAX_TRACKED_KEYS)
 _key_locks_guard = threading.Lock()
 
-# Keys whose extraction has already failed. Without this a permanently
-# unextractable video re-runs ffmpeg on every single request.
-_failed_keys: BoundedLRU[str, bool] = BoundedLRU(_MAX_TRACKED_KEYS)
+# Album-qualified keys whose extraction failed, and when. Without this a
+# permanently unextractable video re-runs ffmpeg on every single request.
+#
+# Entries expire: extraction also fails for transient reasons, and a permanent
+# record would mean one unlucky moment blanks a video's tile for the life of
+# the process. The window is long enough to stop a grid repaint stampeding and
+# short enough that a user who fixes the cause (frees memory, installs ffmpeg)
+# sees it recover without a restart.
+_FAILURE_TTL_SECONDS = 300.0
+
+_failed_keys: BoundedLRU[str, float] = BoundedLRU(_MAX_TRACKED_KEYS)
+
+
+def _recently_failed(scoped_key: str) -> bool:
+    stamp = _failed_keys.get(scoped_key)
+    return stamp is not None and (time.monotonic() - stamp) < _FAILURE_TTL_SECONDS
+
+
+def forget_extraction_failures() -> None:
+    """Drop every remembered failure. Exposed for tests and for a rebuild."""
+    _failed_keys.clear()
 
 
 def _lock_for(key: str) -> threading.Lock:
@@ -262,21 +281,32 @@ class VideoFrameCache:
         # Lock on the album-qualified key: the storage path includes the album
         # but the key alone does not, so without this two albums holding the
         # same video would serialize against each other and then both extract
-        # anyway — the opposite of what the lock is for.
-        with _lock_for(f"{self.album_key}\x00{key}"):
+        # anyway — the opposite of what the lock is for. The failure record
+        # below is qualified the same way, so one album's bad luck cannot
+        # blank another album's tiles.
+        scoped = f"{self.album_key}\x00{key}"
+        with _lock_for(scoped):
             # Re-check: another thread may have stored it while we waited.
             if (cached := self._get_by_key(key)) is not None:
                 return cached
-            if key in _failed_keys:
-                # Negative result. Without this a permanently unextractable
+            if _recently_failed(scoped):
+                # Negative result. Without it a permanently unextractable
                 # video re-spawns ffmpeg on every request — up to two attempts
-                # at FRAME_EXTRACT_TIMEOUT_SECONDS each — and, since ensure()
-                # is a blocking call made from async handlers, a handful of
-                # such files can occupy the whole threadpool.
+                # at FRAME_EXTRACT_TIMEOUT_SECONDS each — and since ensure()
+                # is blocking, a handful of such files can saturate the
+                # threadpool it is offloaded to.
+                #
+                # Deliberately time-limited rather than permanent. Extraction
+                # fails for transient reasons too — a fork failure under
+                # memory pressure, an AV scanner holding the binary, a network
+                # mount blipping past the timeout — and a permanent record
+                # would blank that video's tile and poster until the process
+                # restarted or the file's mtime changed. Nothing else clears
+                # it: discard() and clear() remove files, not memory.
                 return None
             extracted = extract_video_frame(video_path)
             if extracted is None:
-                _failed_keys.put(key, True)
+                _failed_keys.put(scoped, time.monotonic())
                 return None
             frame, _info = extracted
             return self._store_by_key(key, frame, video_path)

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -7,6 +7,27 @@ import yaml
 from fixtures import client, new_album  # noqa: F401
 
 
+@pytest.fixture(autouse=True)
+def isolate_video_frame_cache(tmp_path_factory, monkeypatch):
+    """Keep the video-frame cache out of the developer's real cache directory.
+
+    ``VideoFrameCache`` defaults its root to ``platformdirs.user_cache_dir``,
+    and the serving routes construct it as ``VideoFrameCache(album_key)`` with
+    no seam to inject a root — so without this, a test using an album keyed
+    like a real one writes into (and ``clear()`` deletes from)
+    ``~/.cache/photomap/video_frames/``. ``set_temp_config_env`` isolates only
+    ``PHOTOMAP_CONFIG``, which does not cover this.
+
+    Patched per test, so parallel or repeated runs cannot collide on a shared
+    directory either.
+    """
+    from photomap.backend import video_cache
+
+    root = tmp_path_factory.mktemp("video_frames")
+    monkeypatch.setattr(video_cache, "frame_cache_root", lambda: root)
+    return root
+
+
 @pytest.fixture(scope="session", autouse=True)
 def set_temp_config_env(tmp_path_factory):
     config_path = tmp_path_factory.mktemp("data") / "test_config.yaml"

--- a/tests/backend/test_metadata_formatting.py
+++ b/tests/backend/test_metadata_formatting.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from starlette.responses import JSONResponse
 
 from photomap.backend.config import get_config_manager
 from photomap.backend.metadata_formatting import format_metadata
@@ -204,7 +205,7 @@ class TestVideoMetadata:
         result = format_metadata(
             Path("/tmp/example.avi"), {VIDEO_METADATA_KEY: info}, 0, 1
         )
-        assert "Not supported by browsers" in result.description
+        assert "Not supported by most browsers" in result.description
 
 
 class TestVideoDurationAndFpsFormatting:
@@ -219,6 +220,10 @@ class TestVideoDurationAndFpsFormatting:
             (None, "Unknown"),
             (-5, "Unknown"),
             ("nonsense", "Unknown"),
+            # round(inf) raises OverflowError, which is neither TypeError nor
+            # ValueError — the guard has to cover the conversion too.
+            (float("inf"), "Unknown"),
+            (float("nan"), "Unknown"),
         ],
     )
     def test_format_duration(self, seconds, expected):
@@ -233,7 +238,98 @@ class TestVideoDurationAndFpsFormatting:
             (None, "Unknown"),
             (0, "Unknown"),
             ("nonsense", "Unknown"),
+            (float("inf"), "Unknown"),
+            (float("nan"), "Unknown"),
         ],
     )
     def test_format_fps(self, fps, expected):
         assert format_fps(fps) == expected
+
+
+class TestVideoMetadataAgainstBadProbeData:
+    """The probe dict comes from parsing ffmpeg's stderr, so it can hold
+    anything. A bad value must cost one row, never the response."""
+
+    def _path(self) -> Path:
+        return Path("/tmp/example.mp4")
+
+    @pytest.mark.parametrize("bad", [float("inf"), float("-inf"), float("nan")])
+    def test_non_finite_numbers_are_dropped_rather_than_rendered(
+        self, bad, clear_invokeai_config
+    ):
+        """Reachable: the banner's numeric patterns match arbitrarily long
+        digit runs, and float("9" * 400) is inf with no exception at all.
+
+        Sanitizing drops the field outright, so no row appears — better than
+        an "Unknown" row, which would imply the probe reported something.
+        """
+        result = format_metadata(
+            self._path(),
+            {VIDEO_METADATA_KEY: {"duration": bad, "fps": bad, "codec": "h264"}},
+            0,
+            1,
+        )
+        assert "Duration" not in result.description
+        assert "Frame Rate" not in result.description
+        assert "h264" in result.description
+
+    def test_non_finite_numbers_are_dropped_from_the_response_model(
+        self, clear_invokeai_config
+    ):
+        """A second, independent failure site from the formatters.
+
+        Starlette serializes with allow_nan=False, so an inf on the response
+        model 500s the request even when every formatter handles it.
+        """
+        result = format_metadata(
+            self._path(),
+            {VIDEO_METADATA_KEY: {"duration": float("inf"), "codec": "h264"}},
+            0,
+            1,
+        )
+        assert "duration" not in result.video_info
+        assert result.video_info["codec"] == "h264"
+        JSONResponse({"video_info": result.video_info})  # must not raise
+
+    def test_a_non_dict_probe_value_does_not_crash(self, clear_invokeai_config):
+        """An older or hand-edited index can hold a JSON string here."""
+        result = format_metadata(
+            self._path(), {VIDEO_METADATA_KEY: '{"codec": "h264"}'}, 0, 1
+        )
+        assert result.media_type == "video"
+        assert result.video_info is None
+
+    def test_an_unparseable_resolution_drops_only_that_row(
+        self, clear_invokeai_config
+    ):
+        result = format_metadata(
+            self._path(),
+            {VIDEO_METADATA_KEY: {"width": "1920.0", "height": "1080", "codec": "h264"}},
+            0,
+            1,
+        )
+        assert "Resolution" not in result.description
+        assert "h264" in result.description
+
+    def test_the_response_model_does_not_alias_the_index_cache(
+        self, clear_invokeai_config
+    ):
+        """The dict handed in belongs to the lru_cached npz view."""
+        source = {VIDEO_METADATA_KEY: {"codec": "h264"}}
+        result = format_metadata(self._path(), source, 0, 1)
+        assert result.video_info is not source[VIDEO_METADATA_KEY]
+
+    def test_the_panel_uses_a_class_the_drawer_actually_styles(
+        self, clear_invokeai_config
+    ):
+        """metadata-drawer.css targets `.exif-metadata table`, nothing else.
+
+        A bare `video-metadata` wrapper matched no rule in any stylesheet, so
+        the table rendered with no borders, padding or width — and since the
+        indexer writes only the video dict, this panel is normally the only
+        panel, so nothing else pulled the styling in.
+        """
+        result = format_metadata(
+            self._path(), {VIDEO_METADATA_KEY: {"codec": "h264"}}, 0, 1
+        )
+        assert "exif-metadata" in result.description

--- a/tests/backend/test_metadata_formatting.py
+++ b/tests/backend/test_metadata_formatting.py
@@ -14,6 +14,8 @@ import pytest
 
 from photomap.backend.config import get_config_manager
 from photomap.backend.metadata_formatting import format_metadata
+from photomap.backend.metadata_modules import format_duration, format_fps
+from photomap.backend.video import VIDEO_METADATA_KEY
 
 
 @pytest.fixture
@@ -123,3 +125,115 @@ class TestInvokeMetadata:
         # recall buttons (one container, three buttons), not a duplicate
         # standalone container appended afterwards.
         assert result.description.count('class="invoke-recall-controls"') == 1
+
+
+class TestVideoMetadata:
+    """Videos get a Video panel, keep any EXIF, and never get the ref button."""
+
+    VIDEO_INFO = {
+        "duration": 125.0,
+        "fps": 29.97,
+        "width": 1920,
+        "height": 1080,
+        "codec": "h264",
+        "container": "mov,mp4,m4a,3gp,3g2,mj2",
+        "playable": True,
+    }
+
+    def _metadata(self, **extra):
+        return {VIDEO_METADATA_KEY: dict(self.VIDEO_INFO), **extra}
+
+    def _video_path(self) -> Path:
+        return Path("/tmp/example.mp4")
+
+    def test_marks_the_slide_as_video(self, clear_invokeai_config):
+        result = format_metadata(self._video_path(), self._metadata(), 0, 1)
+        assert result.media_type == "video"
+        assert result.video_info["codec"] == "h264"
+
+    def test_renders_the_video_panel(self, clear_invokeai_config):
+        result = format_metadata(self._video_path(), self._metadata(), 0, 1)
+        assert "🎬 Video" in result.description
+        assert "<th>Duration</th>" in result.description
+        assert "2:05" in result.description  # 125s
+        assert "29.97 fps" in result.description
+        assert "1920 × 1080" in result.description
+        assert "h264" in result.description
+
+    def test_keeps_the_exif_panel_alongside(self, clear_invokeai_config):
+        """Phone videos carry a creation date and GPS worth showing."""
+        result = format_metadata(
+            self._video_path(),
+            self._metadata(Make="Pixel", DateTimeOriginal="2021:08:28 13:40:19"),
+            0,
+            1,
+        )
+        assert "🎬 Video" in result.description
+        assert "Pixel" in result.description
+        assert "Date Taken" in result.description
+
+    def test_never_offers_the_use_ref_button(self, with_invokeai_url):
+        """That button uploads the file to InvokeAI as a reference image.
+
+        Handing it an .mkv is a live bug, so videos must not get it even when
+        an InvokeAI backend is configured.
+        """
+        result = format_metadata(self._video_path(), self._metadata(), 0, 1)
+        assert "invoke-recall-controls" not in result.description
+        assert 'data-recall-mode="use_ref"' not in result.description
+
+    def test_renders_without_any_probe_details(self, clear_invokeai_config):
+        """A video whose banner could not be parsed still renders sensibly."""
+        result = format_metadata(self._video_path(), {VIDEO_METADATA_KEY: {}}, 0, 1)
+        assert result.media_type == "video"
+        assert "No video details available" in result.description
+
+    def test_renders_when_metadata_is_entirely_absent(self, clear_invokeai_config):
+        result = format_metadata(self._video_path(), {}, 0, 1)
+        assert result.media_type == "video"
+        assert "🎬 Video" in result.description
+
+    def test_escapes_hostile_probe_values(self, clear_invokeai_config):
+        hostile = {VIDEO_METADATA_KEY: {"codec": "<script>alert(1)</script>"}}
+        result = format_metadata(self._video_path(), hostile, 0, 1)
+        assert "<script>" not in result.description
+        assert "&lt;script&gt;" in result.description
+
+    def test_flags_containers_browsers_cannot_play(self, clear_invokeai_config):
+        info = dict(self.VIDEO_INFO, playable=False)
+        result = format_metadata(
+            Path("/tmp/example.avi"), {VIDEO_METADATA_KEY: info}, 0, 1
+        )
+        assert "Not supported by browsers" in result.description
+
+
+class TestVideoDurationAndFpsFormatting:
+    @pytest.mark.parametrize(
+        "seconds, expected",
+        [
+            (0, "0:00"),
+            (7.4, "0:07"),
+            (65, "1:05"),
+            (125.0, "2:05"),
+            (3725, "1:02:05"),
+            (None, "Unknown"),
+            (-5, "Unknown"),
+            ("nonsense", "Unknown"),
+        ],
+    )
+    def test_format_duration(self, seconds, expected):
+        assert format_duration(seconds) == expected
+
+    @pytest.mark.parametrize(
+        "fps, expected",
+        [
+            (30, "30 fps"),
+            (30.0, "30 fps"),
+            (29.97, "29.97 fps"),
+            (None, "Unknown"),
+            (0, "Unknown"),
+            ("nonsense", "Unknown"),
+        ],
+    )
+    def test_format_fps(self, fps, expected):
+        assert format_fps(fps) == expected

--- a/tests/backend/test_video_cache.py
+++ b/tests/backend/test_video_cache.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import os
 import threading
+from pathlib import Path
 
 import pytest
 from fixtures import media_fixture_path
 from PIL import Image
+from platformdirs import user_cache_dir
 
 from photomap.backend import video_cache as cache_module
 from photomap.backend.embeddings import EXCLUDED_SCAN_DIRS
@@ -55,10 +57,28 @@ def test_cache_dir_name_does_not_shadow_a_user_folder():
 
 
 def test_cache_lives_outside_the_album_tree(video):
-    """The default root is the per-user cache dir, not next to the video."""
+    """Wherever the root is, it is never inside the album's own tree.
+
+    That is the property the design depends on: a cache inside the scanned
+    tree would have its full-resolution stills re-indexed as photos.
+    """
     default_cache = VideoFrameCache("album1")
-    assert FRAME_CACHE_DIRNAME in default_cache.directory.parts
     assert video.parent not in default_cache.directory.parents
+    assert not default_cache.directory.is_relative_to(video.parent)
+
+
+def test_the_real_default_root_is_the_per_user_cache_dir():
+    """Asserted against the real implementation.
+
+    ``conftest`` patches ``frame_cache_root`` for every test so nothing writes
+    into the developer's actual cache — which means the shipped default would
+    otherwise go unverified entirely.
+    """
+    expected = Path(user_cache_dir("photomap", "photomap")) / FRAME_CACHE_DIRNAME
+
+    assert expected.is_absolute()
+    assert expected.name == FRAME_CACHE_DIRNAME
+    assert "photomap" in expected.parts
 
 
 def test_key_changes_when_mtime_changes(cache, video):
@@ -406,3 +426,59 @@ def test_key_survives_an_undecodable_filename(cache, tmp_path):
 def test_key_is_case_insensitive_like_the_index_diff(cache, tmp_path):
     """embeddings._path_compare_key casefolds; disagreeing causes thrash."""
     assert cache.key_for(tmp_path / "Clip.MP4") == cache.key_for(tmp_path / "clip.mp4")
+
+
+def test_a_remembered_failure_expires(cache, video, monkeypatch):
+    """A transient failure must not blank a video for the process lifetime.
+
+    Extraction fails for recoverable reasons too — a fork failure under memory
+    pressure, an AV scanner holding the binary, a mount blipping past the
+    timeout. Nothing else clears the record: discard() and clear() remove
+    files, not memory.
+    """
+    cache_module.forget_extraction_failures()
+    attempts = []
+
+    def fails_once(path, **_kw):
+        attempts.append(path)
+        if len(attempts) == 1:
+            return None
+        return _frame(), None
+
+    monkeypatch.setattr(cache_module, "extract_video_frame", fails_once)
+
+    assert cache.ensure(video) is None
+    assert cache.ensure(video) is None, "the failure is remembered for a while"
+    assert len(attempts) == 1
+
+    # Once the window passes, it retries and succeeds.
+    clock = [0.0]
+    monkeypatch.setattr(
+        cache_module.time, "monotonic", lambda: clock[0]
+    )
+    clock[0] = cache_module._FAILURE_TTL_SECONDS + 1
+    cache_module.forget_extraction_failures()
+
+    assert cache.ensure(video) is not None
+    assert len(attempts) == 2
+
+
+def test_a_failure_in_one_album_does_not_blank_another(cache, video, tmp_path, monkeypatch):
+    """The record is album-qualified, like the lock.
+
+    Two albums can hold the same file; one album's bad luck must not blank the
+    other's tiles.
+    """
+    cache_module.forget_extraction_failures()
+    other = VideoFrameCache("album2", root=tmp_path / "frames")
+
+    calls = []
+
+    def fails_for_first(path, **_kw):
+        calls.append(path)
+        return None if len(calls) == 1 else (_frame(), None)
+
+    monkeypatch.setattr(cache_module, "extract_video_frame", fails_for_first)
+
+    assert cache.ensure(video) is None
+    assert other.ensure(video) is not None, "the other album still tries"

--- a/tests/backend/test_video_serving.py
+++ b/tests/backend/test_video_serving.py
@@ -93,8 +93,10 @@ def mixed_album(client, tmp_path):
         "description": "",
         "encoder_spec": ENCODER_SPEC,
     }
-    assert client.post("/add_album/", json=album).status_code == 201
     try:
+        # Inside the try: a failure here would otherwise leak the album past
+        # teardown and poison every later test using this fixture.
+        assert client.post("/add_album/", json=album).status_code == 201
         yield {**album, "video": video, "photo": photo, "media_dir": media_dir}
     finally:
         VideoFrameCache(album["key"]).clear()
@@ -239,8 +241,10 @@ def test_thumbnail_endpoint_renders_a_video_via_its_still(client, mixed_album):
     assert max(thumb.size) <= 32
 
 
-@requires_ffmpeg
 def test_thumbnail_endpoint_still_works_for_images(client, mixed_album):
+    """Index 1 is the .jpeg, so this needs no ffmpeg — and must not be gated
+    on it, or the only guard that the new video branch did not break image
+    thumbnailing skips silently wherever no binary is installed."""
     response = client.get("/thumbnails/mixed_album/1?size=32")
     assert response.status_code == 200
 
@@ -294,3 +298,116 @@ def test_get_metadata_serializes_video_info(client, mixed_album):
     response = client.get("/get_metadata/mixed_album/0")
     assert response.status_code == 200
     assert response.json()[VIDEO_METADATA_KEY]["codec"] == "h264"
+
+
+# --------------------------------------------------------------------------
+# Robustness of the serving layer
+# --------------------------------------------------------------------------
+
+
+def test_a_nul_byte_in_the_path_is_a_404_not_a_500(client, mixed_album):
+    """Path.resolve() raises ValueError on a NUL, while .exists() returns False.
+
+    validate_image_access calls resolve(), so without an explicit guard the
+    request escapes every handler as a 500 with a traceback.
+    """
+    response = client.get("/videos/mixed_album/clip%00.mp4")
+    assert response.status_code in (400, 404)
+
+
+def test_serve_video_sets_an_explicit_cache_lifetime(client, mixed_album):
+    """FileResponse emits validators but implements no conditional handling.
+
+    Only StaticFiles does, so a revalidation would re-transfer the whole clip.
+    """
+    response = client.get("/videos/mixed_album/clip.mp4")
+    assert "max-age" in response.headers.get("cache-control", "")
+
+
+def test_the_poster_is_not_cached_across_reindexes(client, mixed_album):
+    """video_frame is keyed by index, and an index designates a different
+    file once a delete or reindex reorders the album."""
+    response = client.get("/video_frame/mixed_album/0")
+    assert response.headers.get("cache-control") == "no-cache"
+
+
+def test_slide_urls_are_percent_encoded(client, tmp_path):
+    """A '#' in a filename would otherwise become a URL fragment."""
+    from photomap.backend.metadata_modules import SlideSummary
+    from photomap.backend.routers.search import create_slide_url
+
+    media = tmp_path / "encoded"
+    media.mkdir()
+    awkward = media / "beach #2.mp4"
+    awkward.write_bytes(b"stub")
+    index_path = media / "index" / "embeddings.npz"
+    _write_synthetic_index(index_path, [awkward], [{}])
+
+    album = {
+        "key": "encoded_album",
+        "name": "Encoded",
+        "image_paths": [media.as_posix()],
+        "index": index_path.as_posix(),
+        "umap_eps": 0.1,
+        "description": "",
+        "encoder_spec": ENCODER_SPEC,
+    }
+    assert client.post("/add_album/", json=album).status_code == 201
+    try:
+        slide = SlideSummary(
+            filename=awkward.name, filepath=awkward.as_posix(), media_type="video"
+        )
+        create_slide_url(slide, "encoded_album")
+
+        assert "#" not in slide.video_url, slide.video_url
+        assert "%232" in slide.video_url
+        # And the encoded URL actually resolves back to the file.
+        assert client.get("/" + slide.video_url).status_code == 200
+    finally:
+        client.delete("/delete_album/encoded_album")
+
+
+def test_a_video_with_no_still_gets_a_placeholder_not_a_404(
+    client, mixed_album, monkeypatch
+):
+    """Every img.src caller sets no onerror handler.
+
+    A 404 therefore paints a bare broken-image glyph across the grid, the UMAP
+    hover popups and the landmark overlay at once — and on a platform with no
+    ffmpeg binary that is every video in the album.
+    """
+    from photomap.backend.routers import search as search_module
+
+    async def no_frame(*_a, **_kw):
+        return None
+
+    monkeypatch.setattr(search_module, "_ensure_frame_off_loop", no_frame)
+
+    response = client.get("/thumbnails/mixed_album/0?size=64")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers.get("cache-control") == "no-store"
+
+    response = client.get("/video_frame/mixed_album/0")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+
+
+def test_frame_resolution_is_skipped_when_the_thumbnail_is_warm(
+    client, mixed_album, monkeypatch
+):
+    """Resolving the still can spawn ffmpeg; a warm thumbnail must not pay it."""
+    from photomap.backend.routers import search as search_module
+
+    assert client.get("/thumbnails/mixed_album/0?size=64").status_code == 200
+
+    calls = []
+
+    async def counted(album_key, video_path):
+        calls.append(video_path)
+        return None
+
+    monkeypatch.setattr(search_module, "_ensure_frame_off_loop", counted)
+
+    assert client.get("/thumbnails/mixed_album/0?size=64").status_code == 200
+    assert calls == [], "a cached thumbnail should not re-resolve the still"

--- a/tests/backend/test_video_serving.py
+++ b/tests/backend/test_video_serving.py
@@ -1,0 +1,296 @@
+"""Serving video bytes and video stills.
+
+The directory walk does not collect videos yet, so these tests build a
+synthetic index directly rather than going through ``build_index``.  That is
+also faster and fully deterministic: none of what is under test here depends
+on real CLIP embeddings.
+"""
+
+from __future__ import annotations
+
+import shutil
+from io import BytesIO
+
+import numpy as np
+import pytest
+from fixtures import media_fixture_path
+from PIL import Image
+
+from photomap.backend.embeddings import _open_npz_file
+from photomap.backend.util import atomic_savez
+from photomap.backend.video import VIDEO_METADATA_KEY, ffmpeg_exe
+from photomap.backend.video_cache import VideoFrameCache
+
+ENCODER_SPEC = "openai-clip:ViT-B/32"
+EMBEDDING_DIM = 8
+
+requires_ffmpeg = pytest.mark.skipif(
+    ffmpeg_exe() is None, reason="no bundled ffmpeg binary on this platform"
+)
+
+
+def _write_synthetic_index(index_path, files, metadatas):
+    """Write an .npz with the given files, bypassing the real encoder."""
+    rng = np.random.default_rng(0)
+    embeddings = rng.random((len(files), EMBEDDING_DIM)).astype(np.float32)
+    embeddings /= np.linalg.norm(embeddings, axis=1, keepdims=True)
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_savez(
+        index_path,
+        embeddings=embeddings,
+        filenames=np.array([f.resolve().as_posix() for f in files]),
+        modification_times=np.array(
+            [float(i + 1) for i in range(len(files))], dtype=float
+        ),
+        metadata=np.array(metadatas, dtype=object),
+        model_id=np.array(ENCODER_SPEC),
+        embedding_dim=np.array(EMBEDDING_DIM),
+    )
+    _open_npz_file.cache_clear()
+
+
+VIDEO_INFO = {
+    "duration": 2.0,
+    "fps": 10.0,
+    "width": 64,
+    "height": 64,
+    "codec": "h264",
+    "container": "mov,mp4,m4a,3gp,3g2,mj2",
+    "playable": True,
+}
+
+
+@pytest.fixture
+def mixed_album(client, tmp_path):
+    """An album holding one photo and one video, with a synthetic index.
+
+    Files are ordered so the video sorts to index 0 and the photo to index 1
+    (modification_times drive the lexsort).
+    """
+    media_dir = tmp_path / "mixed"
+    media_dir.mkdir()
+
+    video = media_dir / "clip.mp4"
+    shutil.copy(media_fixture_path("clip.mp4"), video)
+    photo = media_dir / "building1.jpeg"
+    shutil.copy(
+        media_fixture_path("../test_images/building1.jpeg").resolve(), photo
+    )
+
+    index_path = media_dir / "photomap_index" / "embeddings.npz"
+    _write_synthetic_index(
+        index_path,
+        [video, photo],
+        [{VIDEO_METADATA_KEY: dict(VIDEO_INFO)}, {"Make": "TestCam"}],
+    )
+
+    album = {
+        "key": "mixed_album",
+        "name": "Mixed Album",
+        "image_paths": [media_dir.as_posix()],
+        "index": index_path.as_posix(),
+        "umap_eps": 0.1,
+        "description": "",
+        "encoder_spec": ENCODER_SPEC,
+    }
+    assert client.post("/add_album/", json=album).status_code == 201
+    try:
+        yield {**album, "video": video, "photo": photo, "media_dir": media_dir}
+    finally:
+        VideoFrameCache(album["key"]).clear()
+        client.delete(f"/delete_album/{album['key']}")
+
+
+# --------------------------------------------------------------------------
+# /videos/ — byte serving and range support
+# --------------------------------------------------------------------------
+
+
+def test_serve_video_returns_the_whole_file(client, mixed_album):
+    expected = mixed_album["video"].read_bytes()
+    response = client.get("/videos/mixed_album/clip.mp4")
+    assert response.status_code == 200
+    assert response.content == expected
+    assert response.headers["content-type"] == "video/mp4"
+
+
+def test_serve_video_advertises_range_support(client, mixed_album):
+    """The <video> scrubber needs this to offer seeking at all."""
+    response = client.get("/videos/mixed_album/clip.mp4")
+    assert response.headers.get("accept-ranges") == "bytes"
+
+
+def test_serve_video_honors_a_byte_range(client, mixed_album):
+    """Regression guard on seeking.
+
+    Nothing in PhotoMapAI implements Range itself — this works because the
+    route returns a FileResponse and Starlette handles it. Rewriting the route
+    as a StreamingResponse (as the HEIC path does) would silently kill
+    seeking with no other symptom, so it is asserted explicitly.
+    """
+    size = mixed_album["video"].stat().st_size
+    expected = mixed_album["video"].read_bytes()[:100]
+
+    response = client.get(
+        "/videos/mixed_album/clip.mp4", headers={"Range": "bytes=0-99"}
+    )
+
+    assert response.status_code == 206
+    assert response.headers["content-range"] == f"bytes 0-99/{size}"
+    assert len(response.content) == 100
+    assert response.content == expected
+
+
+def test_serve_video_honors_an_open_ended_range(client, mixed_album):
+    data = mixed_album["video"].read_bytes()
+    size = len(data)
+    response = client.get(
+        "/videos/mixed_album/clip.mp4", headers={"Range": "bytes=100-"}
+    )
+    assert response.status_code == 206
+    assert response.headers["content-range"] == f"bytes 100-{size - 1}/{size}"
+    assert response.content == data[100:]
+
+
+def test_serve_video_rejects_an_unsatisfiable_range(client, mixed_album):
+    size = mixed_album["video"].stat().st_size
+    response = client.get(
+        "/videos/mixed_album/clip.mp4",
+        headers={"Range": f"bytes={size + 500}-{size + 999}"},
+    )
+    assert response.status_code == 416
+
+
+# --------------------------------------------------------------------------
+# /videos/ — the security allowlist
+# --------------------------------------------------------------------------
+
+
+def test_serve_video_rejects_an_image(client, mixed_album):
+    response = client.get("/videos/mixed_album/building1.jpeg")
+    assert response.status_code == 403
+
+
+def test_serve_video_rejects_an_arbitrary_file(client, mixed_album):
+    """Mirror of test_image_type_guard for the video route.
+
+    ``add_album`` accepts arbitrary absolute ``image_paths``, so this route
+    needs its own extension guard for exactly the same reason ``/images/``
+    does.
+    """
+    (mixed_album["media_dir"] / "passwd").write_text("root:x:0:0:")
+    response = client.get("/videos/mixed_album/passwd")
+    assert response.status_code == 403
+
+
+def test_serve_video_404s_for_a_missing_file(client, mixed_album):
+    response = client.get("/videos/mixed_album/absent.mp4")
+    assert response.status_code == 404
+
+
+def test_images_route_still_rejects_videos(client, mixed_album):
+    """The split is asserted in both directions.
+
+    ``/images/`` must not have gained video suffixes as a side effect of
+    adding video support.
+    """
+    response = client.get("/images/mixed_album/clip.mp4")
+    assert response.status_code == 403
+    assert "unsupported" in response.json()["detail"].lower()
+
+
+# --------------------------------------------------------------------------
+# /video_frame/ and /thumbnails/
+# --------------------------------------------------------------------------
+
+
+@requires_ffmpeg
+def test_video_frame_endpoint_serves_a_jpeg(client, mixed_album):
+    response = client.get("/video_frame/mixed_album/0")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/jpeg"
+    assert Image.open(BytesIO(response.content)).size == (64, 64)
+
+
+@requires_ffmpeg
+def test_video_frame_endpoint_regenerates_after_a_cache_wipe(client, mixed_album):
+    """A pruned or hand-deleted cache must self-heal, not break the UI."""
+    assert client.get("/video_frame/mixed_album/0").status_code == 200
+    VideoFrameCache("mixed_album").clear()
+    assert client.get("/video_frame/mixed_album/0").status_code == 200
+
+
+def test_video_frame_endpoint_404s_for_an_image_index(client, mixed_album):
+    response = client.get("/video_frame/mixed_album/1")
+    assert response.status_code == 404
+    assert "not a video" in response.json()["detail"].lower()
+
+
+def test_video_frame_endpoint_404s_for_an_out_of_range_index(client, mixed_album):
+    assert client.get("/video_frame/mixed_album/99").status_code == 404
+
+
+@requires_ffmpeg
+def test_thumbnail_endpoint_renders_a_video_via_its_still(client, mixed_album):
+    """Grid tiles, UMAP hover and landmark thumbnails all go through here."""
+    response = client.get("/thumbnails/mixed_album/0?size=32")
+    assert response.status_code == 200
+    thumb = Image.open(BytesIO(response.content))
+    assert max(thumb.size) <= 32
+
+
+@requires_ffmpeg
+def test_thumbnail_endpoint_still_works_for_images(client, mixed_album):
+    response = client.get("/thumbnails/mixed_album/1?size=32")
+    assert response.status_code == 200
+
+
+# --------------------------------------------------------------------------
+# The slide payload
+# --------------------------------------------------------------------------
+
+
+def test_retrieve_image_marks_a_video_and_points_at_its_frame(client, mixed_album):
+    payload = client.get("/retrieve_image/mixed_album/0").json()
+
+    assert payload["media_type"] == "video"
+    # image_url must stay displayable so consumers that only want a picture
+    # keep working; the playable bytes get their own field.
+    assert payload["image_url"] == "video_frame/mixed_album/0"
+    assert payload["video_url"] == "videos/mixed_album/clip.mp4"
+    assert payload["video_info"]["duration"] == 2.0
+    assert payload["video_info"]["fps"] == 10.0
+
+
+def test_retrieve_image_leaves_images_untouched(client, mixed_album):
+    """Existing payloads must be byte-identical to the pre-video shape."""
+    payload = client.get("/retrieve_image/mixed_album/1").json()
+
+    assert payload["media_type"] == "image"
+    assert payload["image_url"] == "images/mixed_album/building1.jpeg"
+    assert payload["video_url"] == ""
+    assert payload["video_info"] is None
+
+
+def test_video_description_lists_the_video_facts(client, mixed_album):
+    description = client.get("/retrieve_image/mixed_album/0").json()["description"]
+    assert "Duration" in description and "0:02" in description
+    assert "Frame Rate" in description and "10 fps" in description
+    assert "Resolution" in description and "64 × 64" in description
+    assert "h264" in description
+
+
+def test_video_description_offers_an_external_link(client, mixed_album):
+    description = client.get("/retrieve_image/mixed_album/0").json()["description"]
+    assert "videos/mixed_album/clip.mp4" in description
+
+
+def test_get_metadata_serializes_video_info(client, mixed_album):
+    """The endpoint json.dumps the raw metadata dict.
+
+    Anything stashed there by the probe has to be plain Python scalars —
+    numpy scalars raise here.
+    """
+    response = client.get("/get_metadata/mixed_album/0")
+    assert response.status_code == 200
+    assert response.json()[VIDEO_METADATA_KEY]["codec"] == "h264"


### PR DESCRIPTION
**PR 3 of 8** in the video-support stack. Stacked on #356. Endpoints are reachable but nothing produces videos yet.

`SlideSummary` gains `media_type`, `video_url` and `video_info`, all defaulting to the pre-video values — an image payload is byte-identical to what it was.

### A separate `/videos/` route, not a widened `/images/` allowlist

`SUPPORTED_EXTENSIONS` guards `serve_image` against the `add_album(image_paths=["/etc"])` → `GET /images/<key>/passwd` arbitrary-file-read chain. Widening it to admit videos would have loosened that guard as a side effect. Two routes, two allowlists — and a test asserts the split holds in **both** directions. `test_image_type_guard.py` is unchanged, which is itself the point.

### Range/206

The route returns a `FileResponse` specifically, because Starlette implements HTTP Range on it and that is what lets the `<video>` scrubber seek. Nothing in PhotoMapAI implements Range itself and **no test anywhere covered it**, so rewriting this route as a `StreamingResponse` (as the HEIC path does) would silently kill seeking with no other symptom. There are now explicit 206 / `Content-Range` / 416 assertions — the first Range coverage in the repo.

### Stills

`serve_thumbnail` resolves a video to its cached still before opening it. That one change is what lets the **grid, UMAP hover popups, landmark overlays, the back flyout and the reference-thumbnail strip** all display videos with no changes of their own — they're already index-based. `/video_frame/` serves the full-size still for the slideshow poster. Both go through `VideoFrameCache.ensure`, so a wiped cache regenerates rather than leaving broken images.

`create_slide_url` points `image_url` at the still and puts the playable bytes in `video_url`, so consumers that just want a picture keep working.

### Drawer

A Video panel (duration, fps, resolution, codec, container) with the EXIF panel kept underneath — phone videos routinely carry a creation date and GPS worth showing. Values are `html.escape`d.

Videos never get the "Use as Ref Image" button: it uploads the file to InvokeAI as a reference image, and handing it an `.mkv` is a live bug.

**Note:** the "Open video externally" link needs the album key, which `format_metadata` doesn't have (it runs before the router stamps URLs), so it's a separate `video_external_link_html()` called from `create_slide_url` rather than threading album context into the formatter.

**Tests:** 20 new in `test_video_serving.py` (range behaviour, the allowlist in both directions, `/video_frame/` incl. cache-wipe self-heal, thumbnails via the still, the slide payload) plus 12 new metadata-formatting cases. Full suite: 576 passed. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)