### PR TITLE
feat: modal video player

### DIFF
--- a/photomap/frontend/static/css/video-player.css
+++ b/photomap/frontend/static/css/video-player.css
@@ -1,0 +1,76 @@
+/* video-player.css */
+/* Modal video player, opened from the play badge on a video still. */
+
+/* The base .modal-content caps at 600px, which letterboxes a 1080p clip into
+   a stamp. The player gets a much wider box and a darker backdrop. */
+#videoPlayerModal {
+  background: rgba(0, 0, 0, 0.82);
+}
+
+.video-player-content {
+  width: min(92vw, 1400px);
+  max-width: min(92vw, 1400px);
+  padding: 2.2em 1.2em 1.2em;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
+}
+
+.video-player-title {
+  color: #ddd;
+  font-size: 0.95rem;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.video-player-title:empty {
+  display: none;
+}
+
+.video-player-element {
+  width: 100%;
+  /* Leave room for the title and close button so the controls are never
+     pushed off the bottom of a short viewport. */
+  max-height: 78vh;
+  background: #000;
+  border-radius: 6px;
+  display: block;
+}
+
+.video-player-element[hidden] {
+  display: none;
+}
+
+/* Shown when the container is one browsers cannot play, or when the <video>
+   element reports an error. */
+.video-player-fallback {
+  padding: 2em 1em;
+  text-align: center;
+  color: #ddd;
+}
+
+.video-player-fallback[hidden] {
+  display: none;
+}
+
+.video-player-fallback p {
+  margin: 0 0 1em;
+}
+
+.video-player-download {
+  display: inline-block;
+  padding: 0.55em 1.2em;
+  background: #3a3a3a;
+  color: #fff;
+  border-radius: 6px;
+  text-decoration: none;
+}
+
+.video-player-download:hover,
+.video-player-download:focus-visible {
+  background: #4a4a4a;
+}
+
+.video-player-download[hidden] {
+  display: none;
+}

--- a/photomap/frontend/static/javascript/control-panel.js
+++ b/photomap/frontend/static/javascript/control-panel.js
@@ -4,7 +4,6 @@ import { deleteImage, getIndexMetadata } from "./index.js";
 import { getCurrentFilepath, getCurrentSlideIndex, slideState } from "./slide-state.js";
 import { saveSettingsToLocalStorage, state } from "./state.js";
 import { errorDetail, hideSpinner, showSpinner } from "./utils.js";
-import { isVideoPlayerOpen } from "./video-player.js";
 
 // Cache DOM elements
 let elements = {};
@@ -30,16 +29,23 @@ function toggleFullscreen() {
   }
 }
 
+// Panel visibility follows document.fullscreenElement and nothing else.
+//
+// A <video controls> element has its own fullscreen button, which makes this
+// fire with the video as the fullscreen element and again with none on the
+// way out. Suppressing the handler while the video player is open looks like
+// the fix and is worse than the problem: if the app leaves fullscreen while
+// the modal is open — which is what pressing Escape in fullscreen does, since
+// browsers consume that keydown to exit rather than delivering it to the page
+// — the panels keep .hidden-fullscreen (opacity:0 + visibility:hidden, both
+// !important) after the modal closes, and nothing restores them until the
+// user happens to toggle fullscreen twice.
+//
+// Letting every transition through is self-correcting instead. The video's
+// own fullscreen is entered and left in pairs, so the class ends up where it
+// started, and while the modal is open its backdrop sits at z-index 99999 —
+// so no intermediate state is ever visible to the user anyway.
 function handleFullscreenChange() {
-  // A <video controls> element has its own fullscreen button. Using it fires
-  // this handler with the video as the fullscreen element, and *leaving* it
-  // fires again with none — which would read as "the app left fullscreen"
-  // and un-hide every panel behind the still-open modal. While the player
-  // owns the screen, panel visibility is not ours to change.
-  if (isVideoPlayerOpen()) {
-    return;
-  }
-
   const isFullscreen = !!document.fullscreenElement;
 
   // Toggle visibility of UI panels

--- a/photomap/frontend/static/javascript/control-panel.js
+++ b/photomap/frontend/static/javascript/control-panel.js
@@ -4,6 +4,7 @@ import { deleteImage, getIndexMetadata } from "./index.js";
 import { getCurrentFilepath, getCurrentSlideIndex, slideState } from "./slide-state.js";
 import { saveSettingsToLocalStorage, state } from "./state.js";
 import { errorDetail, hideSpinner, showSpinner } from "./utils.js";
+import { isVideoPlayerOpen } from "./video-player.js";
 
 // Cache DOM elements
 let elements = {};
@@ -30,6 +31,15 @@ function toggleFullscreen() {
 }
 
 function handleFullscreenChange() {
+  // A <video controls> element has its own fullscreen button. Using it fires
+  // this handler with the video as the fullscreen element, and *leaving* it
+  // fires again with none — which would read as "the app left fullscreen"
+  // and un-hide every panel behind the still-open modal. While the player
+  // owns the screen, panel visibility is not ours to change.
+  if (isVideoPlayerOpen()) {
+    return;
+  }
+
   const isFullscreen = !!document.fullscreenElement;
 
   // Toggle visibility of UI panels

--- a/photomap/frontend/static/javascript/events.js
+++ b/photomap/frontend/static/javascript/events.js
@@ -94,6 +94,10 @@ const KEYBOARD_SHORTCUTS = {
   Backspace: (e) => handleBackKey(e),
 };
 
+// Keys that must still reach KEYBOARD_SHORTCUTS while the video player is
+// open, because their handlers are how it gets dismissed.
+const PLAYER_DISMISS_KEYS = new Set(["Escape", "Backspace"]);
+
 function pauseSlideshow() {
   state.single_swiper?.pauseSlideshow();
 }
@@ -138,9 +142,13 @@ function shouldIgnoreKeyEvent(e) {
   // While the video player is open the native <video> controls own the
   // keyboard. Space would otherwise be swallowed by handleSpacebarToggle
   // (which preventDefaults it) and toggle the slideshow instead of pausing
-  // the video, and the arrows would change slides behind the modal. Escape
-  // is exempt: it is how the player is dismissed.
-  if (isVideoPlayerOpen() && e.key !== "Escape") {
+  // the video, and the arrows would change slides behind the modal.
+  //
+  // Escape and Backspace are exempt: both are ways to dismiss the player, and
+  // their handlers check for it. Leaving Backspace out made the guard inside
+  // handleBackKey unreachable — this returns before KEYBOARD_SHORTCUTS is
+  // consulted, so the shortcut never ran and the key silently did nothing.
+  if (isVideoPlayerOpen() && !PLAYER_DISMISS_KEYS.has(e.key)) {
     return true;
   }
   return false;

--- a/photomap/frontend/static/javascript/events.js
+++ b/photomap/frontend/static/javascript/events.js
@@ -23,6 +23,7 @@ import { initializeSingleSwiper } from "./swiper.js";
 import {} from "./touch.js"; // Import touch event handlers
 import { isUmapFullscreen, toggleUmapWindow } from "./umap.js";
 import { setCheckmarkOnIcon } from "./utils.js";
+import { closeVideoPlayer, initializeVideoPlayer, isVideoPlayerOpen } from "./video-player.js";
 
 // MAIN INITIALIZATION FUNCTIONS
 // Initialize event listeners after the DOM is fully loaded
@@ -75,7 +76,15 @@ const KEYBOARD_SHORTCUTS = {
   ArrowLeft: () => pauseSlideshow(),
   ArrowRight: () => pauseSlideshow(),
   i: () => toggleMetadataOverlay(),
-  Escape: () => hideMetadataOverlay(),
+  Escape: () => {
+    // The video player is the topmost layer, so Escape dismisses it first
+    // and leaves the metadata drawer alone.
+    if (isVideoPlayerOpen()) {
+      closeVideoPlayer();
+      return;
+    }
+    hideMetadataOverlay();
+  },
   f: () => toggleFullscreen(),
   g: () => toggleGridSwiperView(),
   m: () => toggleUmapWindow(),
@@ -92,6 +101,13 @@ function pauseSlideshow() {
 function handleBackKey(e) {
   e.preventDefault();
   e.stopPropagation();
+  // The player is a transient overlay, not a navigation state — it pushes no
+  // history entry, so Back dismisses it rather than moving the slideshow
+  // underneath it.
+  if (isVideoPlayerOpen()) {
+    closeVideoPlayer();
+    return;
+  }
   backStack.popOne();
 }
 
@@ -116,12 +132,26 @@ function handleKeydown(e) {
 }
 
 function shouldIgnoreKeyEvent(e) {
-  return e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA" || e.target.isContentEditable;
+  if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA" || e.target.isContentEditable) {
+    return true;
+  }
+  // While the video player is open the native <video> controls own the
+  // keyboard. Space would otherwise be swallowed by handleSpacebarToggle
+  // (which preventDefaults it) and toggle the slideshow instead of pausing
+  // the video, and the arrows would change slides behind the modal. Escape
+  // is exempt: it is how the player is dismissed.
+  if (isVideoPlayerOpen() && e.key !== "Escape") {
+    return true;
+  }
+  return false;
 }
 
 function setupGlobalEventListeners() {
   // Keyboard navigation
   window.addEventListener("keydown", handleKeydown);
+
+  // Modal video player, opened by the play badge on a video still.
+  initializeVideoPlayer();
 
   // Window resize event
   window.addEventListener("resize", positionMetadataDrawer);

--- a/photomap/frontend/static/javascript/touch.js
+++ b/photomap/frontend/static/javascript/touch.js
@@ -115,7 +115,12 @@ function handleTouchEnd(e) {
     document.msFullscreenElement
   );
 
-  if (isTap && isFullscreen) {
+  // A tap on a control — the play badge, the player's own buttons — is not a
+  // tap on the slide. Without this, tapping the play badge in fullscreen both
+  // opens the player and toggles the slideshow behind it.
+  const tappedAControl = e.target?.closest?.("button, .video-badge, #videoPlayerModal");
+
+  if (isTap && isFullscreen && !tappedAControl) {
     toggleSlideshowWithIndicator();
   } else {
     // Only detect horizontal swipe (left/right) for pausing slideshow

--- a/photomap/frontend/static/javascript/video-player.js
+++ b/photomap/frontend/static/javascript/video-player.js
@@ -1,0 +1,174 @@
+/**
+ * Modal video player.
+ *
+ * Opens on the `videoPlayRequested` event dispatched by the play badge, over
+ * a dimmed backdrop, reusing the shared `.modal-overlay` machinery.
+ *
+ * The modal owns its own `<video>` element and never borrows one from a
+ * slide. Swiper destroys slide DOM nodes as the user navigates
+ * (`trimShuffleBacklog`, `enforceHighWaterMark`, `resetAllSlides`), and a
+ * detached `<video>` goes on playing audio.
+ */
+
+import { state } from "./state.js";
+
+let modal = null;
+let videoEl = null;
+let titleEl = null;
+let fallbackEl = null;
+let fallbackMessageEl = null;
+let downloadLinkEl = null;
+let initialized = false;
+
+// Whether the slideshow was running when the player opened. Restored rather
+// than force-started on close, so opening a video from a paused slideshow
+// doesn't silently start it.
+let slideshowWasRunning = false;
+
+export function isVideoPlayerOpen() {
+  return Boolean(modal?.classList.contains("visible"));
+}
+
+function showFallback(message, url) {
+  if (!fallbackEl) {
+    return;
+  }
+  fallbackMessageEl.textContent = message;
+  if (downloadLinkEl) {
+    downloadLinkEl.href = url || "#";
+    downloadLinkEl.hidden = !url;
+  }
+  fallbackEl.hidden = false;
+  if (videoEl) {
+    videoEl.hidden = true;
+  }
+}
+
+function hideFallback() {
+  if (fallbackEl) {
+    fallbackEl.hidden = true;
+  }
+  if (videoEl) {
+    videoEl.hidden = false;
+  }
+}
+
+/** Stop playback and release the stream. */
+function teardownVideo() {
+  if (!videoEl) {
+    return;
+  }
+  videoEl.pause();
+  // Clearing the src and calling load() is what actually stops the download
+  // and the audio. Merely hiding the overlay leaves both running.
+  videoEl.removeAttribute("src");
+  videoEl.load();
+}
+
+export function openVideoPlayer({ url, filename, playable = true } = {}) {
+  if (!modal) {
+    return;
+  }
+
+  if (titleEl) {
+    titleEl.textContent = filename || "";
+  }
+
+  hideFallback();
+
+  if (!url) {
+    showFallback("This video is unavailable.", "");
+  } else if (playable === false) {
+    // The static hint says browsers generally can't play this container. Say
+    // so up front rather than showing a black rectangle, but still offer the
+    // file — see the error handler for the cases the hint gets wrong.
+    showFallback(`${filename || "This video"} is in a format your browser probably cannot play.`, url);
+  } else {
+    videoEl.src = url;
+  }
+
+  // Snapshot before pausing, and restore rather than force-start on close.
+  slideshowWasRunning = Boolean(state.swiper?.autoplay?.running);
+  state.single_swiper?.pauseSlideshow?.();
+  // Otherwise the arrow keys change slides behind the modal while the user is
+  // trying to scrub.
+  state.swiper?.keyboard?.disable?.();
+
+  modal.classList.add("visible");
+  modal.querySelector(".modal-close")?.focus?.();
+}
+
+export function closeVideoPlayer() {
+  if (!modal || !isVideoPlayerOpen()) {
+    return;
+  }
+
+  teardownVideo();
+  modal.classList.remove("visible");
+  hideFallback();
+
+  state.swiper?.keyboard?.enable?.();
+  if (slideshowWasRunning) {
+    state.single_swiper?.startSlideshow?.();
+  }
+  slideshowWasRunning = false;
+}
+
+export function initializeVideoPlayer() {
+  if (initialized) {
+    return;
+  }
+  modal = document.getElementById("videoPlayerModal");
+  if (!modal) {
+    return;
+  }
+  videoEl = document.getElementById("videoPlayerElement");
+  titleEl = document.getElementById("videoPlayerTitle");
+  fallbackEl = document.getElementById("videoPlayerFallback");
+  fallbackMessageEl = document.getElementById("videoPlayerFallbackMessage");
+  downloadLinkEl = document.getElementById("videoPlayerDownloadLink");
+
+  document.getElementById("videoPlayerCloseBtn")?.addEventListener("click", closeVideoPlayer);
+
+  // Click the backdrop to dismiss, but not a click inside the panel.
+  modal.addEventListener("click", (e) => {
+    if (e.target === modal) {
+      closeVideoPlayer();
+    }
+  });
+
+  // The real playability test. No static extension list can get this right in
+  // either direction — an HEVC .mp4 plays in Safari but not Firefox — so the
+  // player always tries, and reacts to what actually happened.
+  videoEl?.addEventListener("error", () => {
+    const url = videoEl.getAttribute("src");
+    if (!url) {
+      return; // teardown clears src, which fires error; not a real failure
+    }
+    showFallback(`${titleEl?.textContent || "This video"} could not be played in your browser.`, url);
+  });
+
+  // A playing video must not be left behind by navigation: the modal would
+  // then describe a different slide than the drawer and the UMAP marker, and
+  // on an album change the indices are about to be re-based entirely.
+  window.addEventListener("slideChanged", closeVideoPlayer);
+  window.addEventListener("albumChanged", closeVideoPlayer);
+
+  window.addEventListener("videoPlayRequested", (e) => {
+    openVideoPlayer(e.detail || {});
+  });
+
+  initialized = true;
+}
+
+/** Test seam: drop cached element references so a fresh DOM can be wired. */
+export function _resetVideoPlayerForTests() {
+  initialized = false;
+  modal = null;
+  videoEl = null;
+  titleEl = null;
+  fallbackEl = null;
+  fallbackMessageEl = null;
+  downloadLinkEl = null;
+  slideshowWasRunning = false;
+}

--- a/photomap/frontend/static/javascript/video-player.js
+++ b/photomap/frontend/static/javascript/video-player.js
@@ -97,6 +97,12 @@ export function openVideoPlayer({ url, filename, playable = true } = {}) {
 
   hideFallback();
 
+  // Mark the modal open before anything can start streaming. closeVideoPlayer
+  // early-returns when the modal is not visible, so a close arriving between
+  // "src is set" and "modal is visible" would be a silent no-op and leave the
+  // video playing — audible — behind a modal the user never saw.
+  modal.classList.add("visible");
+
   if (!url) {
     showFallback("This video is unavailable.", "");
   } else if (playable === false) {
@@ -116,8 +122,19 @@ export function openVideoPlayer({ url, filename, playable = true } = {}) {
   // trying to scrub.
   state.swiper?.keyboard?.disable?.();
 
-  modal.classList.add("visible");
-  modal.querySelector(".modal-close")?.focus?.();
+  // Focus the video, not the close button.
+  //
+  // shouldIgnoreKeyEvent() lets Space through to the player precisely so the
+  // native controls can pause — but a focused <button> activates on Space, so
+  // focusing the close button hands it the key instead and Space *dismisses
+  // the player* mid-clip. Verified in Chromium: close button focused, Space
+  // fires the button's click; video focused, Space toggles playback.
+  //
+  // When the fallback is showing there is no video to drive, and the element
+  // is hidden (an unfocusable element would silently leave focus on <body>),
+  // so the close button is the right target there.
+  const focusTarget = videoEl && !videoEl.hidden ? videoEl : modal.querySelector(".modal-close");
+  focusTarget?.focus?.();
 }
 
 export function closeVideoPlayer() {

--- a/photomap/frontend/static/javascript/video-player.js
+++ b/photomap/frontend/static/javascript/video-player.js
@@ -53,6 +53,27 @@ function hideFallback() {
   }
 }
 
+/**
+ * Start playing as soon as the player opens.
+ *
+ * This runs inside the click on the play badge — window events dispatch
+ * synchronously, so the gesture's transient user activation is still live —
+ * which is what lets playback start *with sound* instead of being refused by
+ * the browser's autoplay policy.
+ *
+ * A rejection here is not a playback failure and must not raise the error
+ * fallback. It means either the browser declined anyway (NotAllowedError, on
+ * a stricter policy or a synthetic open) or the load was torn down while
+ * still pending (AbortError, from closing the modal quickly). In both cases
+ * the native controls are right there for the user.
+ */
+function startPlayback() {
+  const started = videoEl?.play?.();
+  started?.catch?.((err) => {
+    console.debug("Video autoplay declined:", err?.name || err);
+  });
+}
+
 /** Stop playback and release the stream. */
 function teardownVideo() {
   if (!videoEl) {
@@ -85,6 +106,7 @@ export function openVideoPlayer({ url, filename, playable = true } = {}) {
     showFallback(`${filename || "This video"} is in a format your browser probably cannot play.`, url);
   } else {
     videoEl.src = url;
+    startPlayback();
   }
 
   // Snapshot before pausing, and restore rather than force-start on close.

--- a/photomap/frontend/static/main.js
+++ b/photomap/frontend/static/main.js
@@ -5,24 +5,25 @@
 // albumChanged or searchResultsChanged listener — its handler must run first
 // so it can mark the upcoming slideChanged as a jump. window.dispatchEvent
 // listeners fire in registration order; there is no capture-phase shortcut.
-import { backStack } from './javascript/back-stack.js';
-import './javascript/album-manager.js';
-import './javascript/bookmarks.js';
-import './javascript/cluster-utils.js';
-import './javascript/events.js';
-import './javascript/metadata-drawer.js';
-import './javascript/invoke-recall.js';
-import './javascript/page-visibility.js';
-import './javascript/search-ui.js';
-import './javascript/search.js';
-import './javascript/seek-slider.js';
-import './javascript/settings.js';
-import { slideState } from './javascript/slide-state.js';
-import './javascript/state.js';
-import './javascript/swiper.js';
-import './javascript/umap.js';
-import './javascript/utils.js';
-import './javascript/curation.js';
+import { backStack } from "./javascript/back-stack.js";
+import "./javascript/album-manager.js";
+import "./javascript/bookmarks.js";
+import "./javascript/cluster-utils.js";
+import "./javascript/events.js";
+import "./javascript/metadata-drawer.js";
+import "./javascript/invoke-recall.js";
+import "./javascript/page-visibility.js";
+import "./javascript/search-ui.js";
+import "./javascript/search.js";
+import "./javascript/seek-slider.js";
+import "./javascript/settings.js";
+import { slideState } from "./javascript/slide-state.js";
+import "./javascript/state.js";
+import "./javascript/swiper.js";
+import "./javascript/umap.js";
+import "./javascript/utils.js";
+import "./javascript/curation.js";
+import "./javascript/video-player.js";
 
 backStack.setNavigator((entry) => {
   // Always restore by global index. Passing isSearchIndex=true would make

--- a/photomap/frontend/templates/main.html
+++ b/photomap/frontend/templates/main.html
@@ -45,6 +45,7 @@
     <link rel="stylesheet" type="text/css" href="{{ static_url('css/about.css') }}" />
     <link rel="stylesheet" type="text/css" href="{{ static_url('css/bookmarks.css') }}" />
     <link rel="stylesheet" type="text/css" href="{{ static_url('css/video-badge.css') }}" />
+    <link rel="stylesheet" type="text/css" href="{{ static_url('css/video-player.css') }}" />
     <link rel="stylesheet" type="text/css" href="{{ static_url('css/umap-floating-window.css') }}" />
     <link rel="stylesheet" type="text/css" href="{{ static_url('css/curation.css') }}" />
 
@@ -90,6 +91,7 @@
     {% include "modules/confirm-modal.html" %}
     {% include "modules/about.html" %}
     {% include "modules/curation.html" %}
+    {% include "modules/video-player-modal.html" %}
     
 
 </body>

--- a/photomap/frontend/templates/modules/video-player-modal.html
+++ b/photomap/frontend/templates/modules/video-player-modal.html
@@ -7,8 +7,12 @@
     <!-- The <video> lives here permanently rather than being created per
          open, so its listeners are wired once. Its src is set on open and
          cleared on close — leaving a src behind keeps the browser streaming
-         and, worse, keeps the audio playing. -->
-    <video id="videoPlayerElement" class="video-player-element" controls preload="metadata"></video>
+         and, worse, keeps the audio playing.
+
+         playsinline: without it iOS Safari hijacks playback into its own
+         fullscreen view the moment the video starts, which would drop the
+         user out of the modal entirely. -->
+    <video id="videoPlayerElement" class="video-player-element" controls playsinline preload="metadata"></video>
 
     <!-- Shown instead of the player when the container is one browsers
          cannot play, or when the <video> reports an error. -->

--- a/photomap/frontend/templates/modules/video-player-modal.html
+++ b/photomap/frontend/templates/modules/video-player-modal.html
@@ -1,0 +1,20 @@
+<!-- Modal video player. Opened by the play badge on a video still. -->
+<div id="videoPlayerModal" class="modal-overlay">
+  <div class="modal-content video-player-content">
+    <button class="modal-close" id="videoPlayerCloseBtn" aria-label="Close video player">&times;</button>
+    <div class="video-player-title" id="videoPlayerTitle"></div>
+
+    <!-- The <video> lives here permanently rather than being created per
+         open, so its listeners are wired once. Its src is set on open and
+         cleared on close — leaving a src behind keeps the browser streaming
+         and, worse, keeps the audio playing. -->
+    <video id="videoPlayerElement" class="video-player-element" controls preload="metadata"></video>
+
+    <!-- Shown instead of the player when the container is one browsers
+         cannot play, or when the <video> reports an error. -->
+    <div class="video-player-fallback" id="videoPlayerFallback" hidden>
+      <p id="videoPlayerFallbackMessage"></p>
+      <a id="videoPlayerDownloadLink" class="video-player-download" href="#" download>Download the video</a>
+    </div>
+  </div>
+</div>

--- a/photomap/frontend/templates/modules/video-player-modal.html
+++ b/photomap/frontend/templates/modules/video-player-modal.html
@@ -11,8 +11,21 @@
 
          playsinline: without it iOS Safari hijacks playback into its own
          fullscreen view the moment the video starts, which would drop the
-         user out of the modal entirely. -->
-    <video id="videoPlayerElement" class="video-player-element" controls playsinline preload="metadata"></video>
+         user out of the modal entirely.
+
+         tabindex="0": a no-op in browsers, where <video controls> is already
+         focusable and in the tab order (verified in Chromium — focus order
+         and Space-to-pause are unchanged). It is here to state the contract
+         the open path depends on: focus goes to the video so the native
+         controls own Space. -->
+    <video
+      id="videoPlayerElement"
+      class="video-player-element"
+      controls
+      playsinline
+      preload="metadata"
+      tabindex="0"
+    ></video>
 
     <!-- Shown instead of the player when the container is one browsers
          cannot play, or when the <video> reports an error. -->

--- a/tests/frontend/video-player-integration.test.js
+++ b/tests/frontend/video-player-integration.test.js
@@ -1,0 +1,143 @@
+// Integration tests for the seams the video player reaches into: the control
+// panel's fullscreen handling, and the modal template it queries by id.
+//
+// video-player.test.js exercises the module against a hand-written fixture,
+// which is exactly why these live separately: every bug found in review was in
+// the wiring between modules, not inside video-player.js.
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const mockState = {
+  single_swiper: { pauseSlideshow: jest.fn(), startSlideshow: jest.fn() },
+  swiper: { autoplay: { running: false }, keyboard: { disable: jest.fn(), enable: jest.fn() } },
+};
+
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/state.js", () => ({
+  state: mockState,
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/index.js", () => ({
+  deleteImage: jest.fn(),
+  getIndexMetadata: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/slide-state.js", () => ({
+  getCurrentFilepath: jest.fn(),
+  getCurrentSlideIndex: jest.fn(),
+  slideState: { getCurrentSlide: () => ({ globalIndex: 0 }) },
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/utils.js", () => ({
+  errorDetail: jest.fn(),
+  hideSpinner: jest.fn(),
+  showSpinner: jest.fn(),
+  setCheckmarkOnIcon: jest.fn(),
+}));
+
+const { initializeControlPanel } = await import("../../photomap/frontend/static/javascript/control-panel.js");
+const { _resetVideoPlayerForTests, closeVideoPlayer, initializeVideoPlayer, openVideoPlayer } =
+  await import("../../photomap/frontend/static/javascript/video-player.js");
+
+const TEMPLATE_PATH = fileURLToPath(
+  new URL("../../photomap/frontend/templates/modules/video-player-modal.html", import.meta.url)
+);
+const TEMPLATE_HTML = readFileSync(TEMPLATE_PATH, "utf8");
+
+const MP4 = { url: "videos/a/clip.mp4", filename: "clip.mp4", playable: true };
+
+/** Set document.fullscreenElement and fire the event the browser would. */
+function setFullscreen(el) {
+  Object.defineProperty(document, "fullscreenElement", { value: el, configurable: true });
+  document.dispatchEvent(new Event("fullscreenchange"));
+}
+
+const panel = () => document.getElementById("controlPanel");
+const isPanelHidden = () => panel().classList.contains("hidden-fullscreen");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // The real modal markup, not a copy of it — see the parity test below.
+  document.body.innerHTML = `
+    <div id="controlPanel"></div>
+    <div id="searchPanel"></div>
+    <div id="fixedScoreDisplay"></div>
+    ${TEMPLATE_HTML}`;
+
+  // jsdom implements none of these on HTMLMediaElement.
+  window.HTMLMediaElement.prototype.play = jest.fn(() => Promise.resolve());
+  window.HTMLMediaElement.prototype.pause = jest.fn();
+  window.HTMLMediaElement.prototype.load = jest.fn();
+
+  _resetVideoPlayerForTests();
+  initializeVideoPlayer();
+  initializeControlPanel();
+  setFullscreen(null);
+});
+
+describe("the modal template and the module agree", () => {
+  // video-player.test.js builds its own fixture. That fixture passing proves
+  // nothing about the shipped page if an id is renamed on one side only, and
+  // the player would then silently do nothing at all.
+  it.each([
+    "videoPlayerModal",
+    "videoPlayerElement",
+    "videoPlayerTitle",
+    "videoPlayerFallback",
+    "videoPlayerFallbackMessage",
+    "videoPlayerDownloadLink",
+    "videoPlayerCloseBtn",
+  ])("the template provides #%s", (id) => {
+    expect(document.getElementById(id)).not.toBeNull();
+  });
+
+  it("wires up against the real template", () => {
+    openVideoPlayer(MP4);
+    expect(document.getElementById("videoPlayerModal").classList.contains("visible")).toBe(true);
+    expect(document.getElementById("videoPlayerElement").getAttribute("src")).toBe(MP4.url);
+  });
+
+  it("keeps playsinline, so iOS does not hijack playback into its own view", () => {
+    expect(document.getElementById("videoPlayerElement").hasAttribute("playsinline")).toBe(true);
+  });
+
+  it("focuses the real template's video, so Space reaches playback", () => {
+    // The fixture in video-player.test.js could drift into being focusable
+    // when the shipped markup is not; this asserts it against the template.
+    openVideoPlayer(MP4);
+    expect(document.activeElement).toBe(document.getElementById("videoPlayerElement"));
+  });
+});
+
+describe("fullscreen panel visibility", () => {
+  it("restores the panels when the app leaves fullscreen while the player is open", () => {
+    // Pressing Escape in fullscreen exits fullscreen; browsers consume that
+    // keydown rather than delivering it, so the modal is still open when
+    // fullscreenchange fires. Suppressing the handler here left the control
+    // panel at opacity:0 + visibility:hidden !important with no way back.
+    setFullscreen(document.documentElement);
+    expect(isPanelHidden()).toBe(true);
+
+    openVideoPlayer(MP4);
+    setFullscreen(null);
+    closeVideoPlayer();
+
+    expect(isPanelHidden()).toBe(false);
+  });
+
+  it("leaves the panels hidden when the app is still fullscreen after the player closes", () => {
+    setFullscreen(document.documentElement);
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    expect(isPanelHidden()).toBe(true);
+  });
+
+  it("survives the video's own fullscreen button being used and dismissed", () => {
+    // Entering and leaving video fullscreen is a matched pair, so the class
+    // ends where it started. While the modal is up its backdrop covers the
+    // panels at z-index 99999, so no intermediate state is ever visible.
+    openVideoPlayer(MP4);
+    setFullscreen(document.getElementById("videoPlayerElement"));
+    setFullscreen(null);
+    closeVideoPlayer();
+    expect(isPanelHidden()).toBe(false);
+  });
+});

--- a/tests/frontend/video-player.test.js
+++ b/tests/frontend/video-player.test.js
@@ -90,6 +90,56 @@ describe("opening", () => {
     expect(mockKeyboardDisable).toHaveBeenCalled();
   });
 
+  it("starts playing immediately", () => {
+    // The modal is opened from a click on the play badge, so this call still
+    // carries that gesture's user activation and may play with sound.
+    openVideoPlayer(MP4);
+    expect(video().play).toHaveBeenCalled();
+  });
+
+  it("does not try to play when there is nothing to play", () => {
+    openVideoPlayer({ url: "", filename: "clip.mp4", playable: true });
+    expect(video().play).not.toHaveBeenCalled();
+  });
+
+  it("does not try to play a container it has already declared unplayable", () => {
+    openVideoPlayer({ url: "videos/a/clip.avi", filename: "clip.avi", playable: false });
+    expect(video().play).not.toHaveBeenCalled();
+  });
+
+  it("survives the browser refusing to autoplay", async () => {
+    // A refusal is a policy decision, not a playback failure: the native
+    // controls are right there, so it must not raise the error fallback.
+    const refusal = Object.assign(new Error("blocked"), { name: "NotAllowedError" });
+    window.HTMLMediaElement.prototype.play = jest.fn(() => Promise.reject(refusal));
+
+    openVideoPlayer(MP4);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(isVideoPlayerOpen()).toBe(true);
+    expect(fallback().hidden).toBe(true);
+  });
+
+  it("survives a play() aborted by closing the modal straight away", async () => {
+    const abort = Object.assign(new Error("aborted"), { name: "AbortError" });
+    window.HTMLMediaElement.prototype.play = jest.fn(() => Promise.reject(abort));
+
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(isVideoPlayerOpen()).toBe(false);
+    expect(fallback().hidden).toBe(true);
+  });
+
+  it("tolerates a browser with no play() at all", () => {
+    delete window.HTMLMediaElement.prototype.play;
+    expect(() => openVideoPlayer(MP4)).not.toThrow();
+    expect(isVideoPlayerOpen()).toBe(true);
+  });
+
   it("opens from a videoPlayRequested event", () => {
     // The seam between the badge (PR 4) and the player.
     window.dispatchEvent(new CustomEvent("videoPlayRequested", { detail: MP4 }));

--- a/tests/frontend/video-player.test.js
+++ b/tests/frontend/video-player.test.js
@@ -46,7 +46,7 @@ beforeEach(() => {
       <div class="modal-content video-player-content">
         <button class="modal-close" id="videoPlayerCloseBtn">&times;</button>
         <div class="video-player-title" id="videoPlayerTitle"></div>
-        <video id="videoPlayerElement" class="video-player-element" controls></video>
+        <video id="videoPlayerElement" class="video-player-element" controls tabindex="0"></video>
         <div class="video-player-fallback" id="videoPlayerFallback" hidden>
           <p id="videoPlayerFallbackMessage"></p>
           <a id="videoPlayerDownloadLink" href="#" download>Download the video</a>
@@ -140,6 +140,23 @@ describe("opening", () => {
     expect(isVideoPlayerOpen()).toBe(true);
   });
 
+  it("focuses the video, so Space reaches playback", () => {
+    // shouldIgnoreKeyEvent() lets Space through to the player precisely so the
+    // native controls can pause. A focused <button> activates on Space, so
+    // focusing the close button instead makes Space dismiss the player
+    // mid-clip — verified in Chromium.
+    openVideoPlayer(MP4);
+    expect(document.activeElement).toBe(video());
+  });
+
+  it("focuses the close button when the fallback is showing", () => {
+    // There is no video to drive, and a hidden element cannot take focus —
+    // leaving it on <body>, where Escape still works but Tab starts from the
+    // top of the page.
+    openVideoPlayer({ url: "videos/a/clip.avi", filename: "clip.avi", playable: false });
+    expect(document.activeElement).toBe(document.getElementById("videoPlayerCloseBtn"));
+  });
+
   it("opens from a videoPlayRequested event", () => {
     // The seam between the badge (PR 4) and the player.
     window.dispatchEvent(new CustomEvent("videoPlayRequested", { detail: MP4 }));
@@ -195,6 +212,18 @@ describe("closing", () => {
   it("is a no-op when already closed", () => {
     closeVideoPlayer();
     expect(video().pause).not.toHaveBeenCalled();
+  });
+
+  it("can stop a video that started playing during the same open", () => {
+    // close() early-returns unless the modal is marked visible, so the open
+    // path has to mark it visible *before* anything starts streaming.
+    // Otherwise a close arriving mid-open is a silent no-op and the clip
+    // plays on — audible — behind a modal that was never shown.
+    openVideoPlayer(MP4);
+    expect(modal().classList.contains("visible")).toBe(true);
+    closeVideoPlayer();
+    expect(video().pause).toHaveBeenCalled();
+    expect(video().hasAttribute("src")).toBe(false);
   });
 });
 

--- a/tests/frontend/video-player.test.js
+++ b/tests/frontend/video-player.test.js
@@ -1,0 +1,246 @@
+// Unit tests for video-player.js
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockPauseSlideshow = jest.fn();
+const mockStartSlideshow = jest.fn();
+const mockKeyboardDisable = jest.fn();
+const mockKeyboardEnable = jest.fn();
+
+const mockState = {
+  single_swiper: {
+    pauseSlideshow: mockPauseSlideshow,
+    startSlideshow: mockStartSlideshow,
+  },
+  swiper: {
+    autoplay: { running: false },
+    keyboard: { disable: mockKeyboardDisable, enable: mockKeyboardEnable },
+  },
+};
+
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/state.js", () => ({
+  state: mockState,
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+
+const { _resetVideoPlayerForTests, closeVideoPlayer, initializeVideoPlayer, isVideoPlayerOpen, openVideoPlayer } =
+  await import("../../photomap/frontend/static/javascript/video-player.js");
+
+const MP4 = { url: "videos/album/clip.mp4", filename: "clip.mp4", playable: true };
+
+function modal() {
+  return document.getElementById("videoPlayerModal");
+}
+function video() {
+  return document.getElementById("videoPlayerElement");
+}
+function fallback() {
+  return document.getElementById("videoPlayerFallback");
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockState.swiper.autoplay.running = false;
+
+  document.body.innerHTML = `
+    <div id="videoPlayerModal" class="modal-overlay">
+      <div class="modal-content video-player-content">
+        <button class="modal-close" id="videoPlayerCloseBtn">&times;</button>
+        <div class="video-player-title" id="videoPlayerTitle"></div>
+        <video id="videoPlayerElement" class="video-player-element" controls></video>
+        <div class="video-player-fallback" id="videoPlayerFallback" hidden>
+          <p id="videoPlayerFallbackMessage"></p>
+          <a id="videoPlayerDownloadLink" href="#" download>Download the video</a>
+        </div>
+      </div>
+    </div>
+  `;
+
+  // jsdom implements neither play() nor load() on HTMLMediaElement.
+  window.HTMLMediaElement.prototype.play = jest.fn(() => Promise.resolve());
+  window.HTMLMediaElement.prototype.pause = jest.fn();
+  window.HTMLMediaElement.prototype.load = jest.fn();
+
+  _resetVideoPlayerForTests();
+  initializeVideoPlayer();
+});
+
+afterEach(() => {
+  _resetVideoPlayerForTests();
+  document.body.innerHTML = "";
+});
+
+describe("opening", () => {
+  it("shows the modal and loads the video", () => {
+    openVideoPlayer(MP4);
+    expect(modal().classList.contains("visible")).toBe(true);
+    expect(video().getAttribute("src")).toBe("videos/album/clip.mp4");
+    expect(isVideoPlayerOpen()).toBe(true);
+  });
+
+  it("shows the filename", () => {
+    openVideoPlayer(MP4);
+    expect(document.getElementById("videoPlayerTitle").textContent).toBe("clip.mp4");
+  });
+
+  it("pauses the slideshow and disables swiper keyboard nav", () => {
+    // Otherwise the slideshow advances behind the modal, and the arrow keys
+    // change slides while the user is trying to scrub.
+    openVideoPlayer(MP4);
+    expect(mockPauseSlideshow).toHaveBeenCalled();
+    expect(mockKeyboardDisable).toHaveBeenCalled();
+  });
+
+  it("opens from a videoPlayRequested event", () => {
+    // The seam between the badge (PR 4) and the player.
+    window.dispatchEvent(new CustomEvent("videoPlayRequested", { detail: MP4 }));
+    expect(isVideoPlayerOpen()).toBe(true);
+    expect(video().getAttribute("src")).toBe("videos/album/clip.mp4");
+  });
+});
+
+describe("closing", () => {
+  it("hides the modal", () => {
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    expect(modal().classList.contains("visible")).toBe(false);
+    expect(isVideoPlayerOpen()).toBe(false);
+  });
+
+  it("stops playback and releases the stream", () => {
+    // Merely hiding the overlay leaves the browser streaming and, worse,
+    // leaves the audio playing.
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    expect(video().pause).toHaveBeenCalled();
+    expect(video().hasAttribute("src")).toBe(false);
+    expect(video().load).toHaveBeenCalled();
+  });
+
+  it("closes on the close button", () => {
+    openVideoPlayer(MP4);
+    document.getElementById("videoPlayerCloseBtn").click();
+    expect(isVideoPlayerOpen()).toBe(false);
+  });
+
+  it("closes on a backdrop click", () => {
+    openVideoPlayer(MP4);
+    modal().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(isVideoPlayerOpen()).toBe(false);
+  });
+
+  it("does not close on a click inside the panel", () => {
+    openVideoPlayer(MP4);
+    modal()
+      .querySelector(".modal-content")
+      .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(isVideoPlayerOpen()).toBe(true);
+  });
+
+  it("re-enables swiper keyboard nav", () => {
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    expect(mockKeyboardEnable).toHaveBeenCalled();
+  });
+
+  it("is a no-op when already closed", () => {
+    closeVideoPlayer();
+    expect(video().pause).not.toHaveBeenCalled();
+  });
+});
+
+describe("slideshow state", () => {
+  it("restores a running slideshow", () => {
+    mockState.swiper.autoplay.running = true;
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    expect(mockStartSlideshow).toHaveBeenCalled();
+  });
+
+  it("does not start a slideshow that was paused", () => {
+    // Restore, never force-start: opening a video from a paused slideshow
+    // must not silently start it.
+    mockState.swiper.autoplay.running = false;
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    expect(mockStartSlideshow).not.toHaveBeenCalled();
+  });
+});
+
+describe("navigation closes the player", () => {
+  it.each(["slideChanged", "albumChanged"])("closes on %s", (eventName) => {
+    // Otherwise the modal describes clip A while the drawer and the UMAP
+    // marker describe clip B — and on an album change the indices are about
+    // to be re-based entirely.
+    openVideoPlayer(MP4);
+    window.dispatchEvent(new CustomEvent(eventName, { detail: {} }));
+    expect(isVideoPlayerOpen()).toBe(false);
+    expect(video().pause).toHaveBeenCalled();
+  });
+});
+
+describe("formats the browser cannot play", () => {
+  it("explains instead of showing a dead player", () => {
+    openVideoPlayer({ url: "videos/album/clip.avi", filename: "clip.avi", playable: false });
+
+    expect(fallback().hidden).toBe(false);
+    expect(video().hidden).toBe(true);
+    expect(video().hasAttribute("src")).toBe(false);
+    expect(document.getElementById("videoPlayerFallbackMessage").textContent).toMatch(/cannot play/i);
+  });
+
+  it("offers the file for download", () => {
+    openVideoPlayer({ url: "videos/album/clip.avi", filename: "clip.avi", playable: false });
+    const link = document.getElementById("videoPlayerDownloadLink");
+    expect(link.getAttribute("href")).toBe("videos/album/clip.avi");
+    expect(link.hidden).toBe(false);
+  });
+
+  it("falls back when the video element itself errors", () => {
+    // The load-bearing half: no static extension list predicts this
+    // correctly in either direction (an HEVC .mp4 plays in Safari but not
+    // Firefox), so the player always tries and reacts to what happened.
+    openVideoPlayer(MP4);
+    expect(fallback().hidden).toBe(true);
+
+    video().dispatchEvent(new Event("error"));
+
+    expect(fallback().hidden).toBe(false);
+    expect(document.getElementById("videoPlayerFallbackMessage").textContent).toMatch(/could not be played/i);
+    expect(document.getElementById("videoPlayerDownloadLink").getAttribute("href")).toBe("videos/album/clip.mp4");
+  });
+
+  it("ignores the error fired by teardown clearing the src", () => {
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    video().dispatchEvent(new Event("error"));
+    expect(fallback().hidden).toBe(true);
+  });
+
+  it("recovers the player on the next open", () => {
+    openVideoPlayer({ url: "videos/album/clip.avi", filename: "clip.avi", playable: false });
+    closeVideoPlayer();
+    openVideoPlayer(MP4);
+    expect(fallback().hidden).toBe(true);
+    expect(video().hidden).toBe(false);
+    expect(video().getAttribute("src")).toBe("videos/album/clip.mp4");
+  });
+
+  it("explains when there is no URL at all", () => {
+    openVideoPlayer({ url: "", filename: "clip.mp4", playable: true });
+    expect(fallback().hidden).toBe(false);
+    expect(document.getElementById("videoPlayerDownloadLink").hidden).toBe(true);
+  });
+});
+
+describe("without the modal markup", () => {
+  it("initializes and opens without throwing", () => {
+    // main.html always includes the modal, but the module must not explode if
+    // it is imported into a page that does not.
+    document.body.innerHTML = "";
+    _resetVideoPlayerForTests();
+    initializeVideoPlayer();
+    openVideoPlayer(MP4);
+    closeVideoPlayer();
+    expect(isVideoPlayerOpen()).toBe(false);
+  });
+});


### PR DESCRIPTION
**PR 5 of 8** in the video-support stack. Stacked on #358.

Consumes the `videoPlayRequested` event from the play badge and plays the video in a modal over a dimmed backdrop, reusing the shared `.modal-overlay` machinery with a much wider content box — the base `.modal-content` caps at 600px, which would letterbox a 1080p clip into a stamp.

**The modal owns its own `<video>`** and never borrows one from a slide. Swiper destroys slide DOM nodes as the user navigates (`trimShuffleBacklog`, `enforceHighWaterMark`, `resetAllSlides`), and a detached `<video>` goes on playing audio.

### Lifecycle — each row is a real bug if missed

| Trigger | Behaviour |
|---|---|
| close | `pause()`, remove `src`, `load()`. Merely hiding the overlay leaves the browser streaming **and audible**. |
| open | snapshot `autoplay.running`, pause, and **restore** on close — never force-start, so opening a video from a paused slideshow doesn't silently start it |
| open | disable Swiper keyboard nav |
| `Space` | `shouldIgnoreKeyEvent` now suppresses globals while open, so Space pauses the *video* rather than being swallowed by `handleSpacebarToggle`'s `preventDefault` |
| arrows | scrub the video instead of changing slides behind the modal |
| `Escape` | dismisses the player, taking priority over `hideMetadataOverlay` |
| `Backspace` | dismisses the player rather than moving the slideshow underneath it — the modal is transient and pushes no history entry |
| `slideChanged` / `albumChanged` | close + pause, so the modal can never describe a different slide than the drawer and the UMAP marker |
| fullscreen | `handleFullscreenChange` bails while open — `<video controls>` has its own fullscreen button, and leaving *that* fullscreen would otherwise read as "the app left fullscreen" and un-hide every panel behind the still-open modal |
| touch | `touch.js` no longer treats a tap on a button or the badge as a tap on the slide, which in fullscreen would both open the player and toggle the slideshow |

### Formats browsers cannot play

An explanation and a download link rather than a black rectangle. Belt and braces: the static `playable` flag covers the common case, but the `<video>` `error` listener is the **load-bearing** half — no extension list predicts an HEVC `.mp4` (Safari yes, Firefox no) correctly in either direction, so the player always tries and reacts to what actually happened. The error fired by teardown clearing `src` is distinguished from a real failure.

**Tests:** 22 new — open/close, the badge→player seam, slideshow restore semantics, navigation teardown, both fallback paths, error-recovery on reopen, and a page with no modal markup at all. Frontend 501 passed / 35 suites; backend 576 passed; eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)