### PR TITLE
feat: images/videos/both filter on the semantic map

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ PhotoMapAI is a fast, modern image browser and search tool for large photo colle
 - Bookmark images for quick access, batch download, or deletion
 - Curator mode for selecting a balanced set of images to use for LoRA training
 - Responsive UI for desktop and mobile
-- Support for wide range of image formats, including Apple's HEIC
+- Support for a wide range of image formats, including Apple's HEIC
+- Video support: clips are indexed by an extracted still, so they appear in search and on the semantic map, and play in an embedded player
 - Integration with the <a href="https://github.com/invoke-ai/InvokeAI">InvokeAI</a> AI image generation system
 - Extensible backend (FastAPI)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,8 @@ themes.
 - A [curator mode](user-guide/curator-mode) for creating training sets for LoRA models.
 - Extensible [backend](developer/architecture) (FastAPI)
 - Responsive UI for desktop and mobile
-- Support for wide range of image formats, including Apple's HEIC
+- Support for a wide range of image formats, including Apple's HEIC
+- Video support: clips are indexed by an extracted still, so they appear in search and on the semantic map, and play in an embedded player
 - All images are local to your computer; nothing goes out to the internet
 
 Quick Links:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ Here are some frequently-encountered issues and their resolutions.
 
 ## No images are showing up in my display
 
-Make sure that you have configured and indexed a [photo album](user-guide/albums.md), that the directory(s) associated with the album contain valid images (JPEG, PNG, HEIC), and that the images are readable by your user account. Scroll to the album in question using the [Album Manager](user-guide/albums.md#managing-albums) and make sure that it has been indexed and that at least two images exist in the album. If necessary, reindex using the **Index** button.
+Make sure that you have configured and indexed a [photo album](user-guide/albums.md), that the directory(s) associated with the album contain valid images (JPEG, PNG, HEIC) or videos, and that the images are readable by your user account. Scroll to the album in question using the [Album Manager](user-guide/albums.md#managing-albums) and make sure that it has been indexed and that at least two images exist in the album. If necessary, reindex using the **Index** button.
 
 If these attempts fail, send a bug report to the [PhotoMap Issues](https://github.com/lstein/PhotoMapAI/issues) page, copying any error messages you see in the browser's JavaScript console and the PhotoMapAI launch script window.
 

--- a/docs/user-guide/albums.md
+++ b/docs/user-guide/albums.md
@@ -29,7 +29,7 @@ window that prompts you to enter the following fields:
 
 At least one image folder needs to be defined. You can type the path in manually, or browse the filesystem for a folder by clicking on the folder icon to the right of the image folder field. Each time you enter a path, a new empty field will appear, allowing you to add additional folders to the album. You can remove a previously-entered folder by clicking a trash icon that appears next to it.
 
-You are free to organize your image files in any way you wish. You can dump them into a single big folder, or organize them into multiple nested subfolders. During indexing, PhotoMapAI will traverse the folder structure and identify all image files of type JPEG, PNG, TIFF, HEIF, and HEIC.
+You are free to organize your image files in any way you wish. You can dump them into a single big folder, or organize them into multiple nested subfolders. During indexing, PhotoMapAI will traverse the folder structure and identify all image files of type JPEG, PNG, TIFF, HEIF, and HEIC, as well as video files such as MP4, MOV, WebM, AVI and MKV. Each video is indexed by a still frame captured shortly after its start, so it takes part in search and clustering exactly like a photo.
 
 ### InvokeAI-Backed Albums
 

--- a/docs/user-guide/basic-usage.md
+++ b/docs/user-guide/basic-usage.md
@@ -12,7 +12,7 @@ Enter a short lowercase key for the album, such as "family", a longer descriptiv
 
 You'll now need to tell the album where its photos are stored. Enter one or more filesystem paths in the text field at the bottom named "Image Paths". Photos can be stored in a single large folder, or stored in multiple nestered folders. They can reside on the local disk or on a shared disk. If you wish, you can point the album to multiple folders, and their contents will be combined into a single album.
 
-PhotoMapAI supports photos in JPEG, PNG, TIFF, GIF, and HEIC/HEIF formats.
+PhotoMapAI supports photos in JPEG, PNG, TIFF, GIF, and HEIC/HEIF formats, and videos in MP4, MOV, WebM, OGV, AVI, MKV and other formats ffmpeg can read. Videos display their opening still overlaid with a play button, duration and frame rate; click it to play the video in an embedded player. Formats browsers cannot play natively (such as AVI and MKV) are still indexed and searchable, and offer a download link instead.
 
 The screenshot below shows the dialogue after populating it on a Linux or MacOS system. On Windows systems use the usual `C:\path\to\directory` notation.
 

--- a/docs/user-guide/semantic-map.md
+++ b/docs/user-guide/semantic-map.md
@@ -78,6 +78,19 @@ With "Show hover thumbnails" turned on and "Show landmarks" turned off:
 
 <img src="../../img/photomap_hover_thumbnail.png" width="480" alt="Thumbnail controls" class="img-hover-zoom">
 
+## Showing images, videos, or both
+
+If the album contains videos as well as photos, the **Show** radio buttons choose
+which of them the map draws: **Both**, **Images only**, or **Videos only**.
+Videos are placed by the same semantic embedding as photos — computed from a
+still captured shortly after the video starts — so a clip lands next to the
+pictures it looks like.
+
+Filtering changes only what the map displays. Cluster identity is unaffected,
+so a cluster keeps its colour and its members whichever setting you pick;
+selecting a cluster while a filter is active loads only the media types
+currently shown. The controls are disabled for albums that contain no videos.
+
 By default, landmarks will be turned on and hover images turned off when you enter the map's fullscreen mode. The opposite happens when  you leave fullscreen mode and enter windowed mode. See below for more information on window modes and sizes.
 
 ---

--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -1142,6 +1142,37 @@ class Embeddings(BaseModel):
             index_result.filenames, index_result.modification_times
         )
 
+    @staticmethod
+    def _register_unreadable_files_warning(
+        album_key: str, result: "IndexResult | None"
+    ) -> None:
+        """Queue the "N files were skipped" notice for this run's completion.
+
+        Files that could not be read at all were collected in ``bad_files`` and
+        reported nowhere — the user just saw a smaller count than expected.
+        Videos make it far more likely (a truncated download, a codec ffmpeg
+        cannot handle), so it needs surfacing.
+
+        This has to run *before* ``complete_operation``, which is what folds
+        pending notices into the ProgressInfo the poller reads and clears the
+        queue. Registering it afterwards — from the router, once the index call
+        has returned — left the notice stranded in the queue: never shown for
+        this run, and silently attached to whichever run completed next.
+        """
+        if result is None or not result.bad_files:
+            return
+        count = len(result.bad_files)
+        noun, verb = ("file", "was") if count == 1 else ("files", "were")
+        progress_tracker.add_completion_warning(
+            album_key,
+            f"{count} {noun} could not be read and {verb} skipped.",
+        )
+        logger.warning(
+            f"Skipped {count} unreadable {noun} in album '{album_key}': "
+            + ", ".join(p.name for p in result.bad_files[:5])
+            + ("…" if count > 5 else "")
+        )
+
     def _prune_video_frame_cache(self, filenames, modification_times) -> None:
         """Drop cached stills that the just-written index no longer refers to.
 
@@ -1459,6 +1490,7 @@ class Embeddings(BaseModel):
                 self.create_umap_index, result.embeddings
             )
             result.umap_embeddings = umap_embeddings
+            self._register_unreadable_files_warning(album_key, result)
             progress_tracker.complete_operation(
                 album_key, "Indexing completed successfully"
             )
@@ -1728,6 +1760,11 @@ class Embeddings(BaseModel):
                 len(missing_image_paths),
                 on_save_start=_on_save_start,
             )
+            # Before either completion path below: a run that indexed nothing
+            # new can still have skipped files, and complete_operation is what
+            # consumes the queue.
+            self._register_unreadable_files_warning(album_key, result)
+
             if not did_rebuild:
                 logger.info(
                     "No new images needed to be indexed. Will not regenerate umap"

--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -41,12 +41,14 @@ from .encoders import (
     capture_download_progress,
     get_cached_encoder,
 )
-from .media_types import IMAGE_EXTENSIONS, is_video
+from .media_types import IMAGE_EXTENSIONS, INDEXABLE_EXTENSIONS, is_video
 from .metadata_extraction import MetadataExtractor
 from .metadata_formatting import format_metadata
 from .metadata_modules import SlideSummary
 from .progress import IndexingCancelled, progress_tracker
 from .util import atomic_savez
+from .video import VIDEO_METADATA_KEY, extract_video_frame
+from .video_cache import VideoFrameCache
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +106,11 @@ LAST_UPDATED_FILENAME = "last_updated"
 # thumbnail population that is as many header opens as the album has photos,
 # on every single update.
 SCAN_REJECTS_FILENAME = "scan_rejects.npz"
+
+# Bump to discard every existing scan-reject cache once. Version 1 retires
+# caches written while videos still went through the pixel gate, which could
+# hold permanent rejections for perfectly good video files.
+SCAN_REJECTS_VERSION = 1
 
 # Process-wide gate around the GPU-using portion of indexing. Two concurrent
 # albums each spinning up a CLIP/SigLIP encoder will OOM a typical 8-12 GiB
@@ -461,6 +468,11 @@ class Embeddings(BaseModel):
     # heavy upscaling. Default mirrors the Album field default in config.py.
     min_image_dimension: int = 256
     min_image_bytes: int = DIMENSION_REJECT_MIN_BYTES
+    # Album this index belongs to, used to address the per-album video-frame
+    # cache. Optional because the CLI entry points build an Embeddings from a
+    # bare .npz path with no album behind it; videos still index there, their
+    # stills just aren't persisted and get re-extracted on demand.
+    album_key: str | None = None
 
     def __init__(self, **data):
         """Ensure embeddings_path is always resolved to prevent cache key mismatches."""
@@ -536,6 +548,21 @@ class Embeddings(BaseModel):
         surfaced side by side in the album editor; either can be disabled.
         Callers that already stat'ed the file pass the result as ``st``.
         """
+        # Videos bypass the gate entirely. Its bands are image heuristics: the
+        # middle band opens the file with ``Image.open(path).size``, which
+        # raises on a video, and the caller memoizes that ``False`` into
+        # scan_rejects.npz keyed by (size, mtime) — so a video rejected once
+        # would stay invisible until the file itself changed, with no UI to
+        # clear it. An explicit early return is the point, not an accident of
+        # the byte bands: most real videos exceed the probe ceiling and would
+        # pass on size alone, so the bug would never reproduce in manual
+        # testing with real footage, only with small clips.
+        #
+        # Nor is the pixel gate applied after extraction: a 240p home video is
+        # legitimately worth indexing.
+        if is_video(path):
+            return True
+
         min_dim = self.min_image_dimension
         byte_floor = self.min_image_bytes
         pixel_gate_active = min_dim > 1
@@ -592,6 +619,18 @@ class Embeddings(BaseModel):
                     or int(data["min_bytes"]) != self.min_image_bytes
                 ):
                     return {}
+                # A cache written before videos bypassed the gate can hold
+                # permanent rejections for them: the gate opened the file with
+                # PIL, that raised, and the verdict was memoized against
+                # (size, mtime). Since those only change if the file itself
+                # does, such a video would stay invisible forever with no UI
+                # to clear it. Discarding the whole cache once on version
+                # change is cheap — it only costs one re-probe per file.
+                version = (
+                    int(data["cache_version"]) if "cache_version" in data.files else 0
+                )
+                if version != SCAN_REJECTS_VERSION:
+                    return {}
                 return {
                     str(key): (int(size), float(mtime))
                     for key, size, mtime in zip(
@@ -615,6 +654,7 @@ class Embeddings(BaseModel):
                 mtimes=np.array([v[1] for v in rejects.values()], dtype=np.float64),
                 min_dim=np.int64(self.min_image_dimension),
                 min_bytes=np.int64(self.min_image_bytes),
+                cache_version=np.int64(SCAN_REJECTS_VERSION),
             )
         except OSError as e:
             logger.warning(f"Could not save scan-reject cache {path}: {e}")
@@ -622,7 +662,7 @@ class Embeddings(BaseModel):
     def get_image_files_from_directory(
         self,
         directory: Path,
-        exts: AbstractSet[str] = SUPPORTED_EXTENSIONS,
+        exts: AbstractSet[str] = INDEXABLE_EXTENSIONS,
         progress_callback: Callable | None = None,
         update_interval: int = 100,
         apply_dimension_gate: bool = True,
@@ -713,7 +753,7 @@ class Embeddings(BaseModel):
     def get_image_files(
         self,
         image_paths_or_dir: list[Path] | Path,
-        exts: AbstractSet[str] = SUPPORTED_EXTENSIONS,
+        exts: AbstractSet[str] = INDEXABLE_EXTENSIONS,
         progress_callback: Callable | None = None,
         apply_dimension_gate: bool = True,
         reject_sink: dict[str, tuple[int, float]] | None = None,
@@ -827,14 +867,53 @@ class Embeddings(BaseModel):
         """Root directory for CLIP model caching (None = use the default cache)."""
         return None
 
-    def _load_image(
-        self, image_path: Path
-    ) -> tuple[Image.Image, float, dict] | None:
+    def _load_video(self, video_path: Path) -> tuple[Image.Image, float, dict] | None:
+        """Extract a video's still frame, cache it, and describe the video.
+
+        Returns the same shape as :meth:`_load_image` so the batch encoder
+        treats a video exactly like a photo from here on. ``None`` on any
+        failure — the caller already records that as a ``bad_file`` and moves
+        on, so "skip with a warning, never abort" is the pre-existing
+        contract rather than something new.
+
+        Thread-safe: each call spawns and owns its own ffmpeg process.
+        """
+        try:
+            extracted = extract_video_frame(video_path)
+            if extracted is None:
+                return None
+            frame, info = extracted
+
+            # Persist the still so the grid, slideshow poster and UMAP
+            # thumbnails have something to show without re-running ffmpeg.
+            # Extraction happens here, at index time, and never in a request
+            # handler — a lazy path would spawn dozens of concurrent ffmpeg
+            # processes on the first grid paint, with no timeout, no cancel
+            # and nowhere to surface a warning.
+            if self.album_key:
+                VideoFrameCache(self.album_key).store(video_path, frame)
+
+            # Video facts ride inside the existing per-image metadata dict, so
+            # every .npz rewrite path carries them for free and indexes
+            # predating video support need no migration.
+            metadata = {VIDEO_METADATA_KEY: info.model_dump()}
+            # Videos carry no EXIF for _get_modification_time to read.
+            return frame, video_path.stat().st_mtime, metadata
+        except Exception as e:
+            logger.error(f"Error processing video {video_path}: {e}")
+            return None
+
+    def _load_image(self, image_path: Path) -> tuple[Image.Image, float, dict] | None:
         """Open an image and extract modtime + metadata. Returns None on failure.
+
+        Videos are dispatched to :meth:`_load_video`, which returns the same
+        shape, so everything downstream of here is media-agnostic.
 
         Thread-safe: PIL decoders release the GIL during native I/O and the
         helpers used here don't share mutable state.
         """
+        if is_video(image_path):
+            return self._load_video(image_path)
         try:
             pil = Image.open(image_path)
             pil = ImageOps.exif_transpose(pil)
@@ -895,20 +974,38 @@ class Embeddings(BaseModel):
         buf_modtimes: list[float] = []
         buf_metadatas: list[dict] = []
 
+        def keep(j: int, path: Path, embedding) -> None:
+            embeddings.append(embedding)
+            filenames.append(path.resolve().as_posix())
+            modification_times.append(buf_modtimes[j])
+            metadatas.append(buf_metadatas[j])
+
         def flush() -> None:
             if not buf_images:
                 return
             try:
                 batch_emb = encoder.encode_images(buf_images)
             except Exception as e:
-                logger.error(f"Error encoding batch of {len(buf_images)} images: {e}")
-                bad_files.extend(buf_paths)
+                # Retry the batch one item at a time so a single hostile
+                # image costs only itself. Extracted video frames are the
+                # first realistic source of such an image, and losing a whole
+                # batch of unrelated photos to one of them would be a
+                # confusing, hard-to-attribute data loss.
+                logger.warning(
+                    f"Error encoding batch of {len(buf_images)} images ({e}); "
+                    "retrying them individually."
+                )
+                for j, path in enumerate(buf_paths):
+                    try:
+                        single = encoder.encode_images([buf_images[j]])
+                    except Exception as inner:
+                        logger.error(f"Error encoding {path}: {inner}")
+                        bad_files.append(path)
+                    else:
+                        keep(j, path, single[0])
             else:
                 for j, path in enumerate(buf_paths):
-                    embeddings.append(batch_emb[j])
-                    filenames.append(path.resolve().as_posix())
-                    modification_times.append(buf_modtimes[j])
-                    metadatas.append(buf_metadatas[j])
+                    keep(j, path, batch_emb[j])
             buf_paths.clear()
             buf_images.clear()
             buf_modtimes.clear()
@@ -1040,6 +1137,38 @@ class Embeddings(BaseModel):
 
         # Clear cache after saving
         _open_npz_file.cache_clear()
+
+        self._prune_video_frame_cache(
+            index_result.filenames, index_result.modification_times
+        )
+
+    def _prune_video_frame_cache(self, filenames, modification_times) -> None:
+        """Drop cached stills that the just-written index no longer refers to.
+
+        One sweep here replaces what would otherwise be seven separate
+        cleanups — mtime changes, moves, copies, single and batch deletes, and
+        files removed outside the app all leave orphans behind, and each would
+        need its own hook. Running at save time means it runs exactly when the
+        index is authoritative.
+
+        Failures only waste disk, so they are logged and swallowed.
+        """
+        if not self.album_key:
+            return
+        try:
+            cache = VideoFrameCache(self.album_key)
+            if not cache.directory.is_dir():
+                return
+            keep = {
+                cache.key_for(Path(str(name)), float(mtime))
+                for name, mtime in zip(filenames, modification_times, strict=False)
+                if is_video(Path(str(name)))
+            }
+            removed = cache.prune(keep)
+            if removed:
+                logger.info(f"Removed {removed} stale video frame(s) from the cache")
+        except Exception as e:
+            logger.warning(f"Could not prune the video frame cache: {e}")
 
     @staticmethod
     def _path_compare_key(p: Path) -> str:

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 from ..config import Album, create_album, default_board_index_path, get_config_manager
 from ..embeddings import Embeddings
 from ..encoders import default_encoder_spec
+from ..video_cache import VideoFrameCache
 
 
 class UmapEpsSetRequest(BaseModel):
@@ -105,6 +106,7 @@ def get_embeddings_for_album(album_key: str) -> Embeddings:
         encoder_spec=album_config.encoder_spec,
         min_image_dimension=album_config.min_image_dimension,
         min_image_bytes=album_config.min_image_bytes,
+        album_key=album_key,
     )
 
 
@@ -190,6 +192,19 @@ def _cleanup_derived_index(album: Album | None) -> None:
         shutil.rmtree(derived_dir)
     except OSError as e:
         logger.warning(f"Could not remove index directory {derived_dir}: {e}")
+
+
+def _cleanup_video_frames(album_key: str) -> None:
+    """Remove an album's extracted video stills when the album goes away.
+
+    The frame cache lives in the per-user cache directory, keyed by album, so
+    nothing else would ever reclaim it. Never raises: a failure here costs
+    disk space, not correctness.
+    """
+    try:
+        VideoFrameCache(album_key).clear()
+    except Exception as e:
+        logger.warning(f"Could not clear video frame cache for '{album_key}': {e}")
 
 
 def _album_public_dict(album: Album) -> dict[str, Any]:
@@ -349,6 +364,7 @@ async def delete_album(album_key: str) -> JSONResponse:
         album = config_manager.get_album(album_key)
         if config_manager.delete_album(album_key):
             _cleanup_derived_index(album)
+            _cleanup_video_frames(album_key)
             return JSONResponse(
                 content={
                     "success": True,

--- a/photomap/backend/routers/index.py
+++ b/photomap/backend/routers/index.py
@@ -786,7 +786,6 @@ async def _update_index_background_async(album_key: str, album_config):
                 )
                 stored_spec = None
 
-            result = None
             if stored_spec is not None and stored_spec != album_config.encoder_spec:
                 logger.warning(
                     f"Encoder mismatch for album '{album_key}': existing index was built "
@@ -801,36 +800,22 @@ async def _update_index_background_async(album_key: str, album_config):
                 )
                 index_path.unlink()
                 logger.info(f"Creating new index for album '{album_key}'...")
-                result = await embeddings.create_index_async(
+                await embeddings.create_index_async(
                     image_paths, album_key, create_index=True
                 )
             else:
                 logger.info(f"Updating existing index for album '{album_key}'...")
-                result = await embeddings.update_index_async(image_paths, album_key)
+                await embeddings.update_index_async(image_paths, album_key)
         else:
             logger.info(f"Creating new index for album '{album_key}'...")
-            result = await embeddings.create_index_async(
+            await embeddings.create_index_async(
                 image_paths, album_key, create_index=True
             )
 
-        # Files that couldn't be read at all are collected but were, until
-        # now, reported nowhere — the user just saw a smaller count than
-        # expected. Videos make that much more likely (a truncated download, a
-        # codec ffmpeg can't handle), so surface it. ``add_`` rather than
-        # ``set_`` so this composes with the board album's
-        # "N of M missing on disk" notice instead of discarding it.
-        if result is not None and result.bad_files:
-            count = len(result.bad_files)
-            noun = "file" if count == 1 else "files"
-            progress_tracker.add_completion_warning(
-                album_key,
-                f"{count} {noun} could not be read and were skipped.",
-            )
-            logger.warning(
-                f"Skipped {count} unreadable {noun} in album '{album_key}': "
-                + ", ".join(p.name for p in result.bad_files[:5])
-                + ("…" if count > 5 else "")
-            )
+        # The "N files were skipped" notice is registered inside the indexing
+        # calls above, not here: ``complete_operation`` runs before they
+        # return, and it is what folds pending notices into the ProgressInfo
+        # the poller reads. Anything added at this point is stranded.
 
         logger.info(f"Index update completed for album '{album_key}'")
 

--- a/photomap/backend/routers/index.py
+++ b/photomap/backend/routers/index.py
@@ -20,6 +20,7 @@ from ..config import get_config_manager
 from ..embeddings import LAST_UPDATED_FILENAME, Embeddings, peek_encoder_spec
 from ..media_types import is_video
 from ..progress import IndexingCancelled, progress_tracker
+from ..video_cache import VideoFrameCache
 from .album import (
     AlbumDep,
     EmbeddingsDep,
@@ -341,6 +342,16 @@ def _remove_image_file(image_path: Path, move_to_trash: bool) -> None:
         ) from e
 
 
+def _discard_cached_frame(album_key: str, path: Path) -> None:
+    """Remove a deleted video's cached still. Never raises."""
+    if not is_video(path):
+        return
+    try:
+        VideoFrameCache(album_key).discard(path)
+    except Exception as e:
+        logger.debug(f"Could not discard cached frame for {path}: {e}")
+
+
 @index_router.delete(
     "/delete_image/{album_key}/{index}",
     tags=["Index"],
@@ -385,6 +396,11 @@ async def delete_image(
 
         print(f"{'Trashing' if move_to_trash else 'Deleting'} image: {image_path}")
         _remove_image_file(image_path, move_to_trash)
+
+        # Drop the extracted still too. The index-time sweep would collect it
+        # eventually, but not until the next update — and a stale frame for a
+        # deleted file is exactly the kind of thing users notice.
+        _discard_cached_frame(album_key, image_path)
 
         # Remove from embeddings
         embeddings.remove_image_from_embeddings(index)
@@ -464,6 +480,7 @@ async def delete_images(
                     else:
                         image_path.unlink()
 
+                _discard_cached_frame(album_key, image_path)
                 deleted_indices.append(index)
                 deleted_files.append(image_path.name)
             except Exception as e:
@@ -690,7 +707,12 @@ async def _resolve_board_album_files(album_config) -> tuple[list[Path], int]:
         album_config.invokeai_password,
     )
     images_dir = Path(album_config.invokeai_root).expanduser() / "outputs" / "images"
-    paths = [images_dir / name for name in names]
+    # Board albums stay image-only for now. Newer InvokeAI versions can hold
+    # video assets, but deletion for board albums routes through
+    # invokeai_client.delete_image, which has not been verified against them —
+    # indexing a video we could not then delete would be worse than skipping
+    # it. Directory albums are unaffected.
+    paths = [images_dir / name for name in names if not is_video(Path(name))]
     existing = [p for p in paths if p.is_file()]
     missing = len(paths) - len(existing)
     if missing and not existing:
@@ -751,6 +773,7 @@ async def _update_index_background_async(album_key: str, album_config):
             encoder_spec=album_config.encoder_spec,
             min_image_dimension=album_config.min_image_dimension,
             min_image_bytes=getattr(album_config, "min_image_bytes", 8192),
+            album_key=album_key,
         )
 
         if index_path.exists():
@@ -763,6 +786,7 @@ async def _update_index_background_async(album_key: str, album_config):
                 )
                 stored_spec = None
 
+            result = None
             if stored_spec is not None and stored_spec != album_config.encoder_spec:
                 logger.warning(
                     f"Encoder mismatch for album '{album_key}': existing index was built "
@@ -777,16 +801,35 @@ async def _update_index_background_async(album_key: str, album_config):
                 )
                 index_path.unlink()
                 logger.info(f"Creating new index for album '{album_key}'...")
-                await embeddings.create_index_async(
+                result = await embeddings.create_index_async(
                     image_paths, album_key, create_index=True
                 )
             else:
                 logger.info(f"Updating existing index for album '{album_key}'...")
-                await embeddings.update_index_async(image_paths, album_key)
+                result = await embeddings.update_index_async(image_paths, album_key)
         else:
             logger.info(f"Creating new index for album '{album_key}'...")
-            await embeddings.create_index_async(
+            result = await embeddings.create_index_async(
                 image_paths, album_key, create_index=True
+            )
+
+        # Files that couldn't be read at all are collected but were, until
+        # now, reported nowhere — the user just saw a smaller count than
+        # expected. Videos make that much more likely (a truncated download, a
+        # codec ffmpeg can't handle), so surface it. ``add_`` rather than
+        # ``set_`` so this composes with the board album's
+        # "N of M missing on disk" notice instead of discarding it.
+        if result is not None and result.bad_files:
+            count = len(result.bad_files)
+            noun = "file" if count == 1 else "files"
+            progress_tracker.add_completion_warning(
+                album_key,
+                f"{count} {noun} could not be read and were skipped.",
+            )
+            logger.warning(
+                f"Skipped {count} unreadable {noun} in album '{album_key}': "
+                + ", ".join(p.name for p in result.bad_files[:5])
+                + ("…" if count > 5 else "")
             )
 
         logger.info(f"Index update completed for album '{album_key}'")

--- a/photomap/backend/routers/umap.py
+++ b/photomap/backend/routers/umap.py
@@ -1,11 +1,14 @@
 # UMAP Routes
 
+from pathlib import Path
+
 import numpy as np
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from sklearn.cluster import DBSCAN
 
 from ..config import get_config_manager
+from ..media_types import media_type_for
 from .album import AlbumDep, EmbeddingsDep
 
 umap_router = APIRouter()
@@ -66,6 +69,11 @@ async def get_umap_data(
                 filename_map[filenames[idx]]
             ),  # map from unsorted to sorted indices
             "cluster": int(cluster),
+            # Lets the map filter images/videos without a round-trip per
+            # point. Derived from the suffix, which is already in hand here,
+            # so indexes predating video support report "image" throughout
+            # with no migration.
+            "media": media_type_for(Path(str(filenames[idx]))),
         }
         for idx, (x, y, cluster) in enumerate(
             zip(umap_embeddings[:, 0], umap_embeddings[:, 1], labels, strict=False)

--- a/photomap/frontend/static/css/umap-floating-window.css
+++ b/photomap/frontend/static/css/umap-floating-window.css
@@ -248,11 +248,13 @@
   outline: none;
 }
 
-#umapClickBehaviorContainer {
+#umapClickBehaviorContainer,
+#umapMediaFilterContainer {
   font-size: 0.85em;
 }
 
-#umapClickBehaviorContainer label {
+#umapClickBehaviorContainer label,
+#umapMediaFilterContainer label {
   cursor: pointer;
   user-select: none;
 }

--- a/photomap/frontend/static/javascript/state.js
+++ b/photomap/frontend/static/javascript/state.js
@@ -43,6 +43,7 @@ export const state = {
   umapExitFullscreenOnSelection: true, // Exit fullscreen when cluster is selected
   umapClickSelectsCluster: true, // Whether click selects cluster or single image
   umapControlsVisible: true, // Whether the UMAP controls panel is visible
+  umapMediaFilter: "both", // "both" | "images" | "videos" — what the map draws
   showMetadataFields: true, // Whether the metadata-drawer fields table is shown
   autotaggingEnabled: false, // Whether to build the vocab index and show cluster/image labels
   // Dataset Curator panel state. The curator panel reads these on open and
@@ -119,6 +120,8 @@ const PERSISTED_SETTINGS = [
   { key: "umapExitFullscreenOnSelection", type: "bool", default: true },
   { key: "umapClickSelectsCluster", type: "bool", default: true },
   { key: "umapControlsVisible", type: "bool", default: true },
+  // "both" | "images" | "videos" — which media the semantic map draws.
+  { key: "umapMediaFilter", type: "string", default: "both" },
   { key: "showMetadataFields", type: "bool", default: true },
   {
     key: "autotaggingEnabled",
@@ -449,6 +452,7 @@ export const setUmapShowHoverThumbnails = _setters.umapShowHoverThumbnails;
 export const setUmapExitFullscreenOnSelection = _setters.umapExitFullscreenOnSelection;
 export const setUmapClickSelectsCluster = _setters.umapClickSelectsCluster;
 export const setUmapControlsVisible = _setters.umapControlsVisible;
+export const setUmapMediaFilter = _setters.umapMediaFilter;
 export const setShowMetadataFields = _setters.showMetadataFields;
 export const setAutotaggingEnabled = _setters.autotaggingEnabled;
 export const setCurationTargetCount = _setters.curationTargetCount;

--- a/photomap/frontend/static/javascript/umap-helpers.js
+++ b/photomap/frontend/static/javascript/umap-helpers.js
@@ -15,3 +15,34 @@ export function findLandmarkClusterAt(point, landmarkXs, landmarkYs, landmarkClu
   }
   return null;
 }
+
+// Valid values for the semantic map's media filter.
+export const MEDIA_FILTERS = ["both", "images", "videos"];
+
+// Restrict `points` to one media type.
+//
+// A point with no `media` field counts as an image: /umap_data only started
+// reporting it when video support landed, and a cached response from an older
+// build should keep behaving exactly as it did.
+//
+// Anything other than "images"/"videos" — including a persisted value from a
+// future build — falls through to showing everything, which is the safe
+// failure mode for a filter.
+export function filterPointsByMediaType(points, filter) {
+  if (!Array.isArray(points)) {
+    return [];
+  }
+  if (filter === "images") {
+    return points.filter((p) => (p?.media ?? "image") === "image");
+  }
+  if (filter === "videos") {
+    return points.filter((p) => p?.media === "video");
+  }
+  return points;
+}
+
+// True if any point is a video. Drives whether the filter is offered at all —
+// a "videos only" radio on an all-photo album can only produce a blank map.
+export function hasVideoPoints(points) {
+  return Array.isArray(points) && points.some((p) => p?.media === "video");
+}

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -847,8 +847,12 @@ window.addEventListener("stateReady", () => {
   // Media filter radio buttons - initialize from state
   const mediaFilterRadios = MEDIA_FILTER_RADIO_IDS.map((id) => document.getElementById(id));
   if (mediaFilterRadios.every(Boolean)) {
-    const active = mediaFilterRadios.find((radio) => radio.value === state.umapMediaFilter);
-    (active || mediaFilterRadios[0]).checked = true;
+    const active =
+      mediaFilterRadios.find((radio) => radio.value === state.umapMediaFilter) ||
+      mediaFilterRadios.find((radio) => radio.value === DEFAULT_MEDIA_FILTER);
+    if (active) {
+      active.checked = true;
+    }
 
     mediaFilterRadios.forEach((radio) => {
       radio.addEventListener("change", async (e) => {
@@ -887,7 +891,14 @@ function reservedControlsHeight(visibleFallback, hiddenFallback) {
   return measured > 0 ? measured + 30 : visibleFallback;
 }
 
-const MEDIA_FILTER_RADIO_IDS = ["umapMediaFilterBothRadio", "umapMediaFilterImagesRadio", "umapMediaFilterVideosRadio"];
+// Listed in the order they appear in the control row.
+const MEDIA_FILTER_RADIO_IDS = ["umapMediaFilterImagesRadio", "umapMediaFilterVideosRadio", "umapMediaFilterBothRadio"];
+
+// Selected when nothing is persisted, and fallen back to when the stored
+// value isn't one we recognize. Matched by value rather than by position in
+// the list above, so reordering the radios in the UI cannot silently change
+// which one is the default.
+const DEFAULT_MEDIA_FILTER = "both";
 
 // Offer the filter only when there is something to filter.
 //
@@ -902,8 +913,8 @@ function updateMediaFilterAvailability() {
   }
   const albumHasVideos = hasVideoPoints(points);
 
-  if (!albumHasVideos && state.umapMediaFilter !== "both") {
-    setUmapMediaFilter("both");
+  if (!albumHasVideos && state.umapMediaFilter !== DEFAULT_MEDIA_FILTER) {
+    setUmapMediaFilter(DEFAULT_MEDIA_FILTER);
   }
 
   MEDIA_FILTER_RADIO_IDS.forEach((id) => {
@@ -913,7 +924,7 @@ function updateMediaFilterAvailability() {
     }
     radio.disabled = !albumHasVideos;
     if (!albumHasVideos) {
-      radio.checked = radio.value === "both";
+      radio.checked = radio.value === DEFAULT_MEDIA_FILTER;
     }
   });
   container.style.opacity = albumHasVideos ? "1" : "0.5";

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -309,6 +309,15 @@ export async function fetchUmapData() {
     const yMin = getPercentile(ys, 1);
     const yMax = getPercentile(ys, 99);
 
+    // Reconcile the filter against this album *before* the trace is built.
+    // The album may have no videos at all, in which case a persisted
+    // "videos only" would otherwise plot an empty trace. Doing it afterwards
+    // still ended up looking right, but only because the setUmapColorMode()
+    // at the end of this function happens to redraw trace 0 from the
+    // corrected filter — a rescue that reads like a coincidence and would
+    // stop working the moment that call moved or became conditional.
+    updateMediaFilterAvailability();
+
     // Prepare marker arrays
     const drawn = visiblePoints();
     const markerColors = drawn.map((p) => getClusterColor(p.cluster));
@@ -572,7 +581,13 @@ export async function fetchUmapData() {
         // Get all points in this cluster, then click through to whatever image
         // we showed as the landmark thumbnail (medoid when available, else the
         // 2D-position pick). Keeps display and navigation consistent.
-        const clusterPoints = points.filter((p) => p.cluster === clickedLandmarkCluster);
+        // Drawn members only. A landmark is placed from the visible members of
+        // its cluster, but the click target used to be chosen from *all* of
+        // them — so on a filtered map a mixed cluster resolved to a point that
+        // isn't on the plot. handleClusterClick then built its walk over the
+        // visible set with that hidden point as the start, and threw on the
+        // first distance calculation, leaving the spinner up for good.
+        const clusterPoints = visiblePoints().filter((p) => p.cluster === clickedLandmarkCluster);
         if (clusterPoints.length > 0) {
           const targetIndex = getLandmarkImageIndex(clickedLandmarkCluster, clusterPoints);
           if (state.umapClickSelectsCluster) {
@@ -598,10 +613,6 @@ export async function fetchUmapData() {
 
     window.umapPoints = points;
     state.dataChanged = false;
-
-    // The album may have no videos at all, in which case the filter is
-    // pointless and a stale "videos only" would render a blank map.
-    updateMediaFilterAvailability();
 
     // Dispatch event to notify that UMAP data has been loaded
     window.dispatchEvent(new CustomEvent("umapDataLoaded"));
@@ -874,21 +885,32 @@ window.addEventListener("stateReady", () => {
   }
 });
 
+// Height of the controls block before this file started measuring it. Used as
+// the fallback when the element isn't laid out yet (initial paint, jsdom), so
+// the numbers below still reproduce the original constants exactly.
+const UNMEASURED_CONTROLS_HEIGHT = 60;
+
 // Vertical space to reserve for the controls block below the plot.
 //
 // Measured rather than hardcoded. There used to be two independent magic
 // numbers here (110/40 and 130/60), so adding a control row meant remembering
 // to bump both — miss one and the new row is clipped in exactly one of
-// {fullscreen, windowed}. The constants survive only as fallbacks for when
-// the element isn't laid out yet (initial paint, jsdom).
-function reservedControlsHeight(visibleFallback, hiddenFallback) {
+// {fullscreen, windowed}.
+//
+// ``gap`` is what each call site needs *on top of* the block's own height, and
+// the two are genuinely different: the fullscreen branch reserves space inside
+// an already-sized window, while the windowed branch sizes the whole window
+// and so must also cover the 51px titlebar. Measured in Chromium against the
+// pre-existing layout, where the block was 60px: 110 - 60 = 50 for fullscreen,
+// 130 - 60 = 70 for windowed. Collapsing both to one allowance left the
+// windowed layout 3px of clearance instead of 23.
+function reservedControlsHeight(gap, hiddenFallback) {
   if (!state.umapControlsVisible) {
     return hiddenFallback;
   }
   const controls = document.getElementById("umapControls");
   const measured = controls ? Math.ceil(controls.getBoundingClientRect().height) : 0;
-  // +30 for the gap between the plot and the controls block.
-  return measured > 0 ? measured + 30 : visibleFallback;
+  return (measured > 0 ? measured : UNMEASURED_CONTROLS_HEIGHT) + gap;
 }
 
 // Listed in the order they appear in the control row.
@@ -1297,8 +1319,13 @@ function updateUmapColorModeAvailability(searchResults = []) {
 // thumbnail and click target change.
 function getLandmarkImageIndex(cluster, clusterPoints) {
   const labelInfo = getClusterLabelInfo(cluster);
-  if (labelInfo && typeof labelInfo.medoid_index === "number") {
-    return labelInfo.medoid_index;
+  const medoid = labelInfo?.medoid_index;
+  // The medoid comes from the labels endpoint, which computes it over every
+  // member of the cluster — so it can name a point the media filter is
+  // hiding. Only honour it when it is one of the points passed in (which the
+  // caller has already restricted to what's drawn).
+  if (typeof medoid === "number" && clusterPoints.some((p) => p.index === medoid)) {
+    return medoid;
   }
   return getLandmarkForCluster(clusterPoints).index;
 }
@@ -1639,7 +1666,13 @@ function proximityClusterOrder(clusterIndices, points, startIndex) {
 
 // Shared function for cluster clicks
 async function handleClusterClick(clickedIndex) {
-  const clickedPoint = points.find((p) => p.index === clickedIndex);
+  // Looked up among the drawn points, not all of them. The walk below is built
+  // over the visible set, so a start point that isn't in it throws on the
+  // first distance calculation — and because the spinner is shown just after
+  // this check, the failure presented as a spinner that never stopped. Bailing
+  // is right rather than defensive: there is nothing sensible to select from a
+  // point the user cannot see.
+  const clickedPoint = visiblePoints().find((p) => p.index === clickedIndex);
   if (!clickedPoint) {
     return;
   }
@@ -1853,7 +1886,7 @@ function setUmapWindowSize(sizeKey) {
       contentDiv.style.display = "block";
     }
     // controlsHeight: space reserved below the plot for UMAP controls
-    const controlsHeight = reservedControlsHeight(110, 40);
+    const controlsHeight = reservedControlsHeight(50, 40);
     // Measure how much vertical space the bottom Control/Search panels occupy.
     // The window covers the full viewport; its dark background fills the dead zone behind the panels.
     const bottomPanel = document.getElementById("controlPanel");
@@ -1893,7 +1926,7 @@ function setUmapWindowSize(sizeKey) {
     }
     const { width, height } = UMAP_SIZES[sizeKey];
     const bottomPadding = 8; // add breathing room under plot
-    const extraWindowHeight = reservedControlsHeight(130, 60);
+    const extraWindowHeight = reservedControlsHeight(70, 60);
     const desiredWindowHeight = height + extraWindowHeight + bottomPadding;
     win.style.width = width + 60 + "px";
     win.style.height = Math.min(desiredWindowHeight, window.innerHeight - 20) + "px"; // window taller, capped at viewport

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -15,13 +15,14 @@ import { switchAlbum } from "./settings.js";
 import { getCurrentSlideIndex, slideState } from "./slide-state.js";
 import {
   setUmapClickSelectsCluster,
+  setUmapMediaFilter,
   setUmapControlsVisible,
   setUmapExitFullscreenOnSelection,
   setUmapShowHoverThumbnails,
   setUmapShowLandmarks,
   state,
 } from "./state.js";
-import { findLandmarkClusterAt } from "./umap-helpers.js";
+import { filterPointsByMediaType, findLandmarkClusterAt, hasVideoPoints } from "./umap-helpers.js";
 import { checkUmapReindexOngoing, initUmapReindexButton } from "./umap-reindex.js";
 import { debounce, getPercentile, isColorLight, makeDraggable } from "./utils.js";
 
@@ -170,6 +171,19 @@ export function setUmapClickCallback(callback) {
 let points = [];
 let clusters = [];
 let colors = [];
+
+// The points the map should currently draw, after the images/videos filter.
+//
+// Deliberately a derived view rather than a second Plotly trace. `colorizeUmap`
+// hardcodes trace [0] in *both* branches — including the else-branch that
+// restores every point on "clear selection" — so a second trace would be
+// silently wiped there. `plotly_click` also has a `points[pt.pointIndex]`
+// fallback that uses a per-trace index and would resolve to the wrong image.
+// Keeping the trace count fixed means moveTraces, the HighlightedPoints
+// add/delete, the landmark traces and `customdata` all keep working untouched.
+function visiblePoints() {
+  return filterPointsByMediaType(points, state.umapMediaFilter);
+}
 let mapExists = false;
 let isShaded = false;
 let umapWindowHasBeenShown = false; // Track if window has been shown at least once
@@ -296,13 +310,14 @@ export async function fetchUmapData() {
     const yMax = getPercentile(ys, 99);
 
     // Prepare marker arrays
-    const markerColors = points.map((p) => getClusterColor(p.cluster));
-    const markerAlphas = points.map((p) => (p.cluster === -1 ? 0.08 : 0.75));
+    const drawn = visiblePoints();
+    const markerColors = drawn.map((p) => getClusterColor(p.cluster));
+    const markerAlphas = drawn.map((p) => (p.cluster === -1 ? 0.08 : 0.75));
 
-    // Main trace: all points
+    // Main trace: all points (subject to the media filter)
     const allPointsTrace = {
-      x: points.map((p) => p.x),
-      y: points.map((p) => p.y),
+      x: drawn.map((p) => p.x),
+      y: drawn.map((p) => p.y),
       mode: "markers",
       type: "scattergl",
       marker: {
@@ -310,7 +325,7 @@ export async function fetchUmapData() {
         opacity: markerAlphas,
         size: 5,
       },
-      customdata: points.map((p) => p.index),
+      customdata: drawn.map((p) => p.index),
       name: "All Points",
       hoverinfo: "none",
     };
@@ -584,6 +599,10 @@ export async function fetchUmapData() {
     window.umapPoints = points;
     state.dataChanged = false;
 
+    // The album may have no videos at all, in which case the filter is
+    // pointless and a stale "videos only" would render a blank map.
+    updateMediaFilterAvailability();
+
     // Dispatch event to notify that UMAP data has been loaded
     window.dispatchEvent(new CustomEvent("umapDataLoaded"));
 
@@ -643,9 +662,11 @@ export async function colorizeUmap({ highlight = false, searchResults = [] } = {
   if (highlight && searchResults.length > 0) {
     const searchSet = new Set(searchResults.map((r) => r.index));
 
-    // Split points into two groups
-    const regularPoints = points.filter((p) => !searchSet.has(p.index));
-    const highlightedPoints = points.filter((p) => searchSet.has(p.index));
+    // Split points into two groups. Both halves come from the filtered set,
+    // so a videos-only map cannot highlight an image that isn't drawn.
+    const drawn = visiblePoints();
+    const regularPoints = drawn.filter((p) => !searchSet.has(p.index));
+    const highlightedPoints = drawn.filter((p) => searchSet.has(p.index));
 
     // Update main trace with only regular points
     await Plotly.restyle(
@@ -709,21 +730,24 @@ export async function colorizeUmap({ highlight = false, searchResults = [] } = {
       await Plotly.deleteTraces(plotDiv, highlightTraceIdx);
     }
 
-    // Restore ALL points to main trace with normal coloring
-    const markerColors = points.map((p) => getClusterColor(p.cluster));
-    const markerAlphas = points.map((p) => (p.cluster === -1 ? 0.2 : 0.75));
-    const markerSizes = points.map(() => 5);
+    // Restore all *visible* points to the main trace with normal coloring.
+    // This branch runs on every "clear selection", so it is the one that
+    // would silently undo the media filter if it used the unfiltered list.
+    const drawn = visiblePoints();
+    const markerColors = drawn.map((p) => getClusterColor(p.cluster));
+    const markerAlphas = drawn.map((p) => (p.cluster === -1 ? 0.2 : 0.75));
+    const markerSizes = drawn.map(() => 5);
 
     await Plotly.restyle(
       "umapPlot",
       {
-        x: [points.map((p) => p.x)],
-        y: [points.map((p) => p.y)],
+        x: [drawn.map((p) => p.x)],
+        y: [drawn.map((p) => p.y)],
         "marker.color": [markerColors],
         "marker.opacity": [markerAlphas],
         "marker.size": [markerSizes],
         "marker.line.width": [0],
-        customdata: [points.map((p) => p.index)],
+        customdata: [drawn.map((p) => p.index)],
       },
       [0]
     );
@@ -819,7 +843,82 @@ window.addEventListener("stateReady", () => {
       }
     });
   }
+
+  // Media filter radio buttons - initialize from state
+  const mediaFilterRadios = MEDIA_FILTER_RADIO_IDS.map((id) => document.getElementById(id));
+  if (mediaFilterRadios.every(Boolean)) {
+    const active = mediaFilterRadios.find((radio) => radio.value === state.umapMediaFilter);
+    (active || mediaFilterRadios[0]).checked = true;
+
+    mediaFilterRadios.forEach((radio) => {
+      radio.addEventListener("change", async (e) => {
+        if (!e.target.checked) {
+          return;
+        }
+        setUmapMediaFilter(e.target.value);
+        // Redraw through the normal colorize path so an active search
+        // highlight is re-derived from the new visible set rather than being
+        // left pointing at hidden points.
+        await colorizeUmap({
+          highlight: state.searchType === "search" || state.searchType === "cluster",
+          searchResults: state.searchResults || [],
+        });
+        await updateCurrentImageMarker();
+        debouncedUpdateLandmarkTrace();
+      });
+    });
+  }
 });
+
+// Vertical space to reserve for the controls block below the plot.
+//
+// Measured rather than hardcoded. There used to be two independent magic
+// numbers here (110/40 and 130/60), so adding a control row meant remembering
+// to bump both — miss one and the new row is clipped in exactly one of
+// {fullscreen, windowed}. The constants survive only as fallbacks for when
+// the element isn't laid out yet (initial paint, jsdom).
+function reservedControlsHeight(visibleFallback, hiddenFallback) {
+  if (!state.umapControlsVisible) {
+    return hiddenFallback;
+  }
+  const controls = document.getElementById("umapControls");
+  const measured = controls ? Math.ceil(controls.getBoundingClientRect().height) : 0;
+  // +30 for the gap between the plot and the controls block.
+  return measured > 0 ? measured + 30 : visibleFallback;
+}
+
+const MEDIA_FILTER_RADIO_IDS = ["umapMediaFilterBothRadio", "umapMediaFilterImagesRadio", "umapMediaFilterVideosRadio"];
+
+// Offer the filter only when there is something to filter.
+//
+// A persisted "videos only" restored on an all-photo album would otherwise
+// render a blank map, which reads as "the semantic map is broken". The
+// controls are disabled rather than hidden so the control row keeps its
+// height — the window-sizing constants depend on that.
+function updateMediaFilterAvailability() {
+  const container = document.getElementById("umapMediaFilterContainer");
+  if (!container) {
+    return;
+  }
+  const albumHasVideos = hasVideoPoints(points);
+
+  if (!albumHasVideos && state.umapMediaFilter !== "both") {
+    setUmapMediaFilter("both");
+  }
+
+  MEDIA_FILTER_RADIO_IDS.forEach((id) => {
+    const radio = document.getElementById(id);
+    if (!radio) {
+      return;
+    }
+    radio.disabled = !albumHasVideos;
+    if (!albumHasVideos) {
+      radio.checked = radio.value === "both";
+    }
+  });
+  container.style.opacity = albumHasVideos ? "1" : "0.5";
+  container.title = albumHasVideos ? "" : "This album contains no videos";
+}
 
 // Helper function to update the "Exit fullscreen on selection" checkbox state
 function updateExitFullscreenCheckboxState() {
@@ -880,8 +979,12 @@ export async function updateCurrentImageMarker() {
   if (globalIndex === -1) {
     return;
   } // No current image
-  const currentPoint = points.find((p) => p.index === globalIndex);
+  // Looked up among the *drawn* points: with a media filter active the
+  // current slide may not be on the map, and a gold dot floating over
+  // nothing is worse than no dot at all.
+  const currentPoint = visiblePoints().find((p) => p.index === globalIndex);
   if (!currentPoint) {
+    Plotly.restyle("umapPlot", { x: [[]], y: [[]] }, markerTraceIndex);
     return;
   }
 
@@ -1013,7 +1116,7 @@ async function createUmapThumbnail({ x, y, index, cluster }) {
 
   // Find cluster color and calculate cluster size
   const clusterColor = getClusterColor(cluster);
-  const clusterSize = points.filter((p) => p.cluster === cluster).length;
+  const clusterSize = visiblePoints().filter((p) => p.cluster === cluster).length;
   const sizeStr = cluster === -1 ? "Unclustered" : `Cluster ${cluster} (size=${clusterSize})`;
   // Falls back gracefully when the labels endpoint hasn't populated this
   // cluster (or is unavailable).
@@ -1225,7 +1328,7 @@ function getLargestClustersInView(maxLandmarks = 10) {
 
   // Group points by cluster
   const clusterMap = new Map();
-  points.forEach((p) => {
+  visiblePoints().forEach((p) => {
     if (p.cluster === -1) {
       return;
     }
@@ -1517,14 +1620,18 @@ async function handleClusterClick(clickedIndex) {
 
   const clickedCluster = clickedPoint.cluster;
   const clusterColor = getClusterColor(clickedCluster);
-  let clusterIndices = points.filter((p) => p.cluster === clickedCluster).map((p) => p.index);
+  // Only the drawn members. Selecting a cluster on a videos-only map must not
+  // put images into the search results — the swiper would open one, and the
+  // gold current-image marker would land on a point that isn't rendered.
+  const drawn = visiblePoints();
+  let clusterIndices = drawn.filter((p) => p.cluster === clickedCluster).map((p) => p.index);
 
   // Remove clickedFilename from the list
   clusterIndices = clusterIndices.filter((fn) => fn !== clickedIndex);
 
   // --- Greedy random walk order from clicked point ---
   const sort_algorithm = clusterIndices.length > randomWalkMaxSize ? proximityClusterOrder : randomWalkClusterOrder;
-  const sortedClusterIndices = sort_algorithm([clickedIndex, ...clusterIndices], points, clickedIndex);
+  const sortedClusterIndices = sort_algorithm([clickedIndex, ...clusterIndices], drawn, clickedIndex);
 
   const clusterMembers = sortedClusterIndices.map((index) => ({
     index: index,
@@ -1714,7 +1821,7 @@ function setUmapWindowSize(sizeKey) {
       contentDiv.style.display = "block";
     }
     // controlsHeight: space reserved below the plot for UMAP controls
-    const controlsHeight = state.umapControlsVisible ? 110 : 40;
+    const controlsHeight = reservedControlsHeight(110, 40);
     // Measure how much vertical space the bottom Control/Search panels occupy.
     // The window covers the full viewport; its dark background fills the dead zone behind the panels.
     const bottomPanel = document.getElementById("controlPanel");
@@ -1754,7 +1861,7 @@ function setUmapWindowSize(sizeKey) {
     }
     const { width, height } = UMAP_SIZES[sizeKey];
     const bottomPadding = 8; // add breathing room under plot
-    const extraWindowHeight = state.umapControlsVisible ? 130 : 60;
+    const extraWindowHeight = reservedControlsHeight(130, 60);
     const desiredWindowHeight = height + extraWindowHeight + bottomPadding;
     win.style.width = width + 60 + "px";
     win.style.height = Math.min(desiredWindowHeight, window.innerHeight - 20) + "px"; // window taller, capped at viewport

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -1375,6 +1375,27 @@ let isRenderingLandmarks = false;
 let lastImagesJSON = null;
 let suppressRelayoutEvent = false; // Add this flag
 
+/**
+ * Remove any landmark thumbnails currently on the plot.
+ *
+ * Landmarks are two things: triangle marker traces, and thumbnails in
+ * ``layout.images``. Deleting the traces does not touch the images, so every
+ * path that bails out of drawing landmarks has to come through here or it
+ * leaves the thumbnails behind.
+ *
+ * ``lastImagesJSON`` is reset so the next draw is not mistaken for a no-op.
+ */
+function clearLandmarkImages(plotDiv) {
+  if (lastImagesJSON === null) {
+    return;
+  }
+  suppressRelayoutEvent = true;
+  Plotly.relayout(plotDiv, { images: [] }).then(() => {
+    suppressRelayoutEvent = false;
+    lastImagesJSON = null;
+  });
+}
+
 function updateLandmarkTrace() {
   if (isRenderingLandmarks) {
     return;
@@ -1413,19 +1434,19 @@ function updateLandmarkTrace() {
     }
 
     if (!landmarksVisible) {
-      if (lastImagesJSON !== null) {
-        suppressRelayoutEvent = true;
-        Plotly.relayout(plotDiv, { images: [] }).then(() => {
-          suppressRelayoutEvent = false;
-          lastImagesJSON = null;
-        });
-      }
+      clearLandmarkImages(plotDiv);
       return;
     }
 
     // Get clusters in view
     const clusters = getLargestClustersInView(100);
     if (!clusters.length) {
+      // The triangle traces were deleted above, but the thumbnails live in
+      // layout.images and need clearing separately — otherwise they hang over
+      // a region that no longer has any points under it. Reachable whenever
+      // the last cluster in view stops being drawn: most easily by switching
+      // the media filter to one that hides every member of it.
+      clearLandmarkImages(plotDiv);
       return;
     }
 

--- a/photomap/frontend/templates/modules/umap-floating-window.html
+++ b/photomap/frontend/templates/modules/umap-floating-window.html
@@ -226,16 +226,16 @@
         >
           <span id="umapMediaFilterLabel">Show:</span>
           <label style="display: flex; align-items: center; gap: 6px;">
-            <input type="radio" name="umapMediaFilter" id="umapMediaFilterBothRadio" value="both" checked />
-            Both
-          </label>
-          <label style="display: flex; align-items: center; gap: 6px;">
             <input type="radio" name="umapMediaFilter" id="umapMediaFilterImagesRadio" value="images" />
-            Images only
+            Images
           </label>
           <label style="display: flex; align-items: center; gap: 6px;">
             <input type="radio" name="umapMediaFilter" id="umapMediaFilterVideosRadio" value="videos" />
-            Videos only
+            Videos
+          </label>
+          <label style="display: flex; align-items: center; gap: 6px;">
+            <input type="radio" name="umapMediaFilter" id="umapMediaFilterBothRadio" value="both" checked />
+            Both
           </label>
         </div>
 

--- a/photomap/frontend/templates/modules/umap-floating-window.html
+++ b/photomap/frontend/templates/modules/umap-floating-window.html
@@ -217,6 +217,28 @@
           </div>
         </div>
 
+        <!-- Which media the map draws. Disabled (not hidden) for albums with
+             no videos, so the control row's height stays constant — the
+             window-sizing constants in umap.js depend on it. -->
+        <div
+          id="umapMediaFilterContainer"
+          style="display: flex; flex-direction: row; gap: 12px; align-items: center;"
+        >
+          <span id="umapMediaFilterLabel">Show:</span>
+          <label style="display: flex; align-items: center; gap: 6px;">
+            <input type="radio" name="umapMediaFilter" id="umapMediaFilterBothRadio" value="both" checked />
+            Both
+          </label>
+          <label style="display: flex; align-items: center; gap: 6px;">
+            <input type="radio" name="umapMediaFilter" id="umapMediaFilterImagesRadio" value="images" />
+            Images only
+          </label>
+          <label style="display: flex; align-items: center; gap: 6px;">
+            <input type="radio" name="umapMediaFilter" id="umapMediaFilterVideosRadio" value="videos" />
+            Videos only
+          </label>
+        </div>
+
         <!-- Rows 2-3: Checkboxes in 2 aligned columns -->
         <div
           id="umapColorModeContainer"

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 # Import fixtures so they're available to all tests
-from fixtures import client, new_album  # noqa: F401
+from fixtures import client, new_album, new_media_album  # noqa: F401
 
 
 @pytest.fixture(autouse=True)

--- a/tests/backend/fixtures.py
+++ b/tests/backend/fixtures.py
@@ -52,6 +52,44 @@ def new_album(client, tmp_path) -> dict:
     client.delete(f"/delete_album/{album_data['key']}")
 
 
+@pytest.fixture
+def new_media_album(client, tmp_path) -> dict:
+    """A temp album holding both the test images and the test videos.
+
+    Kept separate from ``new_album`` so existing suites see zero churn: they
+    keep their exact image counts, and only video tests pay the ffmpeg cost.
+    """
+    src_images = Path(__file__).parent / "test_images"
+    temp_dir = tmp_path / "media"
+    temp_dir.mkdir(parents=True, exist_ok=True)
+
+    for f in src_images.iterdir():
+        if f.is_file():
+            shutil.copy(f, temp_dir / f.name)
+    for f in TEST_MEDIA_DIR.iterdir():
+        if f.is_file():
+            shutil.copy(f, temp_dir / f.name)
+
+    album_data = {
+        "key": "test_media_album",
+        "name": "Test Media Album",
+        "image_paths": [temp_dir.as_posix()],
+        # The index deliberately lives inside the media directory, mirroring
+        # ``new_album`` — that is the layout that would let a frame cache
+        # placed next to the index get re-indexed as photos.
+        "index": (temp_dir / "embeddings.npz").as_posix(),
+        "umap_eps": 0.1,
+        "description": "A test album with videos",
+        "encoder_spec": "openai-clip:ViT-B/32",
+    }
+    response = client.post("/add_album/", json=album_data)
+    assert response.status_code == 201
+
+    yield {**album_data, "media_dir": temp_dir}
+
+    client.delete(f"/delete_album/{album_data['key']}")
+
+
 def poll_during_indexing(client, album_key, timeout=60):
     """Poll the index progress until it completes or times out."""
     start_time = time.time()

--- a/tests/backend/test_umap.py
+++ b/tests/backend/test_umap.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from pathlib import Path
 
 from fixtures import build_index, count_test_images, fetch_filename
@@ -22,3 +23,31 @@ def test_umap_construction(client, new_album, monkeypatch):
             in slides
         )
         assert point["cluster"] is not None
+
+
+def test_umap_data_reports_media_type(client, new_media_album, monkeypatch):
+    """The map needs a per-point media type to filter on.
+
+    Derived from the filename suffix rather than stored per-image, so no npz
+    change and no migration.
+    """
+    build_index(client, new_media_album)
+
+    response = client.get(f"umap_data/{new_media_album['key']}")
+    assert response.status_code == 200
+    points = response.json()
+
+    assert all("media" in point for point in points)
+    media_counts = Counter(point["media"] for point in points)
+    assert media_counts["video"] > 0, "the mixed album should contain videos"
+    assert media_counts["image"] == TEST_IMAGE_COUNT
+
+
+def test_umap_data_reports_image_only_albums_as_all_images(client, new_album, monkeypatch):
+    """An index predating video support must report "image" throughout."""
+    build_index(client, new_album)
+
+    points = client.get(f"umap_data/{new_album['key']}").json()
+
+    assert points
+    assert all(point["media"] == "image" for point in points)

--- a/tests/backend/test_umap.py
+++ b/tests/backend/test_umap.py
@@ -1,7 +1,10 @@
 from collections import Counter
 from pathlib import Path
 
+import pytest
 from fixtures import build_index, count_test_images, fetch_filename
+
+from photomap.backend.video import ffmpeg_exe
 
 TEST_IMAGE_COUNT = count_test_images()
 
@@ -25,11 +28,17 @@ def test_umap_construction(client, new_album, monkeypatch):
         assert point["cluster"] is not None
 
 
+@pytest.mark.skipif(
+    ffmpeg_exe() is None, reason="no bundled ffmpeg binary on this platform"
+)
 def test_umap_data_reports_media_type(client, new_media_album, monkeypatch):
     """The map needs a per-point media type to filter on.
 
     Derived from the filename suffix rather than stored per-image, so no npz
     change and no migration.
+
+    Skipped without ffmpeg: the videos would simply not be indexed and this
+    would fail rather than skip, unlike every other video test in the suite.
     """
     build_index(client, new_media_album)
 

--- a/tests/backend/test_video_guards.py
+++ b/tests/backend/test_video_guards.py
@@ -139,7 +139,9 @@ def test_search_still_accepts_an_image_query(client, new_album):
     )
 
     assert response.status_code == 200, response.text
-    assert len(response.json()) > 0
+    # Index into "results": the response is a SearchResultsResponse object, so
+    # len() over the whole payload counts its one key and is always truthy.
+    assert len(response.json()["results"]) > 0
 
 
 # --------------------------------------------------------------------------

--- a/tests/backend/test_video_indexing.py
+++ b/tests/backend/test_video_indexing.py
@@ -20,6 +20,7 @@ from fixtures import (
 )
 
 from photomap.backend.embeddings import Embeddings, _open_npz_file
+from photomap.backend.progress import progress_tracker
 from photomap.backend.video import VIDEO_METADATA_KEY, ffmpeg_exe
 from photomap.backend.video_cache import VideoFrameCache
 
@@ -39,6 +40,21 @@ pytestmark = pytest.mark.skipif(
 def _clear_frame_cache():
     yield
     VideoFrameCache("test_media_album").clear()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_completion_warnings():
+    """``progress_tracker`` is a module-level singleton shared by every test.
+
+    A notice queued but never consumed leaks into whichever run completes
+    next, which is how the "skipped files are reported" test came to pass:
+    it was reading the *previous* test's stranded warning, and failed as soon
+    as it ran on its own. Clearing on both sides makes each test's assertion
+    about its own run.
+    """
+    progress_tracker._completion_warnings.clear()
+    yield
+    progress_tracker._completion_warnings.clear()
 
 
 def _index_filenames(album) -> list[str]:
@@ -74,13 +90,33 @@ def test_unreadable_video_is_skipped_without_aborting(client, new_media_album):
 
 
 def test_skipped_files_are_reported_to_the_user(client, new_media_album):
-    """bad_files used to be collected and surfaced nowhere."""
+    """bad_files used to be collected and surfaced nowhere.
+
+    The notice has to be queued before ``complete_operation``, which is what
+    folds it into the ProgressInfo the poller reads and then clears the queue.
+    Queue it afterwards and it is stranded: invisible for this run, and
+    attached to whichever run finishes next.
+    """
     build_index(client, new_media_album)
 
     progress = client.get(f"/index_progress/{new_media_album['key']}").json()
 
-    assert progress["warning_message"]
-    assert "could not be read" in progress["warning_message"]
+    # Exactly one fixture (broken.mp4) is unreadable, so the wording is
+    # pinnable — including the verb agreement.
+    assert progress["warning_message"] == "1 file could not be read and was skipped."
+
+
+def test_a_clean_album_reports_no_warning(client, new_album):
+    """Nothing to skip must mean no notice at all, not an empty string.
+
+    Also the control for the test above: it fails if a notice from an earlier
+    run is still queued when this album completes.
+    """
+    build_index(client, new_album)
+
+    progress = client.get(f"/index_progress/{new_album['key']}").json()
+
+    assert progress["warning_message"] is None
 
 
 def test_video_metadata_records_duration_fps_and_resolution(client, new_media_album):
@@ -213,15 +249,36 @@ def test_videos_bypass_the_dimension_gate(client, tmp_path):
 
     embeddings = Embeddings(
         embeddings_path=media / "index" / "embeddings.npz",
-        # Far above anything the fixtures could satisfy.
+        # Both bands set far above anything the fixtures could satisfy. The
+        # byte floor matters as much as the pixel gate here: clip.mp4 is ~2 KB,
+        # under even the *default* min_image_bytes of 8192, so a small real
+        # video would be rejected on size alone without the early return.
         min_image_dimension=100_000,
-        min_image_bytes=0,
+        min_image_bytes=1_000_000,
     )
     found = embeddings.get_image_files(media)
     names = {p.name for p in found}
 
-    assert "clip.mp4" in names, "the video must survive an aggressive pixel gate"
+    assert "clip.mp4" in names, "the video must survive both gate bands"
     assert "building1.jpeg" not in names, "the gate must still reject small images"
+
+
+def test_a_small_video_survives_the_default_byte_floor(client, tmp_path):
+    """The fixtures are all smaller than the 8 KB default floor.
+
+    Worth its own case because it is the configuration users actually run,
+    and because the byte floor is checked before the pixel probe — so a
+    regression there would not show up in the aggressive-gate test above if
+    that test only raised min_image_dimension.
+    """
+    media = tmp_path / "smallvid"
+    media.mkdir()
+    shutil.copy(media_fixture_path("clip.webm"), media / "clip.webm")  # ~940 bytes
+
+    embeddings = Embeddings(embeddings_path=media / "index" / "embeddings.npz")
+    assert embeddings.min_image_bytes > (media / "clip.webm").stat().st_size
+
+    assert {p.name for p in embeddings.get_image_files(media)} == {"clip.webm"}
 
 
 def test_videos_never_enter_the_scan_reject_cache(client, tmp_path):

--- a/tests/backend/test_video_indexing.py
+++ b/tests/backend/test_video_indexing.py
@@ -1,0 +1,381 @@
+"""End-to-end: the directory walk now collects videos.
+
+This is the PR that turns the feature on, so these are the tests that prove a
+video actually makes it from disk into the index, gets a still, and behaves
+like a photo everywhere downstream.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import numpy as np
+import pytest
+from fixtures import (
+    build_index,
+    count_test_images,
+    count_test_media,
+    media_fixture_path,
+    poll_during_indexing,
+)
+
+from photomap.backend.embeddings import Embeddings, _open_npz_file
+from photomap.backend.video import VIDEO_METADATA_KEY, ffmpeg_exe
+from photomap.backend.video_cache import VideoFrameCache
+
+TEST_IMAGE_COUNT = count_test_images()
+TEST_MEDIA_COUNT = count_test_media()
+
+# broken.mp4 is deliberately truncated, so it is skipped rather than indexed.
+EXPECTED_VIDEO_COUNT = TEST_MEDIA_COUNT - 1
+EXPECTED_TOTAL = TEST_IMAGE_COUNT + EXPECTED_VIDEO_COUNT
+
+pytestmark = pytest.mark.skipif(
+    ffmpeg_exe() is None, reason="no bundled ffmpeg binary on this platform"
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_frame_cache():
+    yield
+    VideoFrameCache("test_media_album").clear()
+
+
+def _index_filenames(album) -> list[str]:
+    data = Embeddings.open_cached_embeddings(album["index"])
+    return [str(f) for f in data["filenames"]]
+
+
+# --------------------------------------------------------------------------
+# The walk
+# --------------------------------------------------------------------------
+
+
+def test_directory_scan_indexes_videos_alongside_images(client, new_media_album):
+    build_index(client, new_media_album)
+
+    names = {f.rsplit("/", 1)[-1] for f in _index_filenames(new_media_album)}
+
+    assert "clip.mp4" in names
+    assert "clip.webm" in names
+    assert "building1.jpeg" in names
+    assert len(names) == EXPECTED_TOTAL
+
+
+def test_unreadable_video_is_skipped_without_aborting(client, new_media_album):
+    """A truncated file must not take the rest of the album down with it."""
+    build_index(client, new_media_album)
+
+    names = {f.rsplit("/", 1)[-1] for f in _index_filenames(new_media_album)}
+
+    assert "broken.mp4" not in names
+    # ...and everything else still indexed.
+    assert len(names) == EXPECTED_TOTAL
+
+
+def test_skipped_files_are_reported_to_the_user(client, new_media_album):
+    """bad_files used to be collected and surfaced nowhere."""
+    build_index(client, new_media_album)
+
+    progress = client.get(f"/index_progress/{new_media_album['key']}").json()
+
+    assert progress["warning_message"]
+    assert "could not be read" in progress["warning_message"]
+
+
+def test_video_metadata_records_duration_fps_and_resolution(client, new_media_album):
+    build_index(client, new_media_album)
+
+    data = Embeddings.open_cached_embeddings(new_media_album["index"])
+    by_name = {
+        str(f).rsplit("/", 1)[-1]: m
+        for f, m in zip(data["filenames"], data["metadata"], strict=True)
+    }
+
+    info = by_name["clip.mp4"][VIDEO_METADATA_KEY]
+    assert info["duration"] == pytest.approx(2.0, abs=0.2)
+    assert info["fps"] == pytest.approx(10.0)
+    assert (info["width"], info["height"]) == (64, 64)
+    assert info["codec"] == "h264"
+    assert info["playable"] is True
+
+
+def test_images_carry_no_video_metadata(client, new_media_album):
+    build_index(client, new_media_album)
+
+    data = Embeddings.open_cached_embeddings(new_media_album["index"])
+    by_name = {
+        str(f).rsplit("/", 1)[-1]: m
+        for f, m in zip(data["filenames"], data["metadata"], strict=True)
+    }
+
+    assert VIDEO_METADATA_KEY not in by_name["building1.jpeg"]
+
+
+# --------------------------------------------------------------------------
+# The frame cache
+# --------------------------------------------------------------------------
+
+
+def test_still_frames_are_cached_at_index_time(client, new_media_album):
+    """Extraction must happen here, never in a request handler."""
+    build_index(client, new_media_album)
+
+    cache = VideoFrameCache(new_media_album["key"])
+    video = new_media_album["media_dir"] / "clip.mp4"
+    assert cache.get(video) is not None
+
+
+def test_cached_frames_are_not_reindexed_as_photos(client, new_media_album):
+    """The single sharpest trap in the feature.
+
+    Stills are full-resolution, so they sail through both gates. If the cache
+    ever lands inside a scanned tree, every still becomes a photo — and each
+    of those gets a still of its own, forever. Running the update twice and
+    asserting a stable count is what catches that.
+    """
+    build_index(client, new_media_album)
+    first = len(_index_filenames(new_media_album))
+
+    response = client.post(
+        "/update_index_async", json={"album_key": new_media_album["key"]}
+    )
+    assert response.status_code == 202
+    poll_during_indexing(client, new_media_album["key"])
+    _open_npz_file.cache_clear()
+
+    assert len(_index_filenames(new_media_album)) == first
+
+
+def test_deleting_a_video_removes_its_cached_frame(client, new_media_album):
+    build_index(client, new_media_album)
+
+    video = new_media_album["media_dir"] / "clip.mp4"
+    cache = VideoFrameCache(new_media_album["key"])
+    assert cache.get(video) is not None
+
+    # API indices are into the sorted order, not the stored order.
+    sorted_names = Embeddings.open_cached_embeddings(new_media_album["index"])[
+        "sorted_filenames"
+    ]
+    api_index = list(sorted_names).index(video.resolve().as_posix())
+
+    response = client.delete(
+        f"/delete_image/{new_media_album['key']}/{api_index}?move_to_trash=false"
+    )
+    assert response.status_code == 200
+    assert cache.get(video) is None
+
+
+def test_index_update_prunes_orphaned_frames(client, new_media_album):
+    """The one sweep that stands in for seven separate cleanups."""
+    build_index(client, new_media_album)
+
+    cache = VideoFrameCache(new_media_album["key"])
+    orphan = cache.directory / ("0" * 32 + ".jpg")
+    orphan.write_bytes(b"stale")
+    assert orphan.exists()
+
+    # Touch a file so the update has something to do and reaches a save.
+    shutil.copy(
+        media_fixture_path("clip.mp4"), new_media_album["media_dir"] / "extra.mp4"
+    )
+    response = client.post(
+        "/update_index_async", json={"album_key": new_media_album["key"]}
+    )
+    assert response.status_code == 202
+    poll_during_indexing(client, new_media_album["key"])
+
+    assert not orphan.exists()
+    # The real frames survived.
+    assert cache.get(new_media_album["media_dir"] / "clip.mp4") is not None
+
+
+# --------------------------------------------------------------------------
+# The dimension gate
+# --------------------------------------------------------------------------
+
+
+def test_videos_bypass_the_dimension_gate(client, tmp_path):
+    """A gate tuned to exclude thumbnails must not exclude clips.
+
+    The gate opens files with PIL, which raises on a video — and the caller
+    memoizes that rejection against (size, mtime), so a video rejected once
+    would stay invisible until the file itself changed.
+    """
+    media = tmp_path / "gated"
+    media.mkdir()
+    shutil.copy(media_fixture_path("clip.mp4"), media / "clip.mp4")
+    shutil.copy(
+        media_fixture_path("../test_images/building1.jpeg").resolve(),
+        media / "building1.jpeg",
+    )
+
+    embeddings = Embeddings(
+        embeddings_path=media / "index" / "embeddings.npz",
+        # Far above anything the fixtures could satisfy.
+        min_image_dimension=100_000,
+        min_image_bytes=0,
+    )
+    found = embeddings.get_image_files(media)
+    names = {p.name for p in found}
+
+    assert "clip.mp4" in names, "the video must survive an aggressive pixel gate"
+    assert "building1.jpeg" not in names, "the gate must still reject small images"
+
+
+def test_videos_never_enter_the_scan_reject_cache(client, tmp_path):
+    media = tmp_path / "rejects"
+    media.mkdir()
+    shutil.copy(media_fixture_path("clip.mp4"), media / "clip.mp4")
+
+    embeddings = Embeddings(
+        embeddings_path=media / "index" / "embeddings.npz",
+        min_image_dimension=100_000,
+        min_image_bytes=0,
+    )
+    sink: dict = {}
+    embeddings.get_image_files_from_directory(media, reject_sink=sink)
+
+    assert sink == {}
+
+
+def test_a_stale_scan_reject_cache_is_discarded_once(tmp_path):
+    """Users who ran an intermediate build must not stay poisoned.
+
+    A cache written while videos still went through the pixel gate can hold
+    permanent rejections for good files, and (size, mtime) only changes if the
+    file does.
+    """
+    from photomap.backend.util import atomic_savez
+
+    index_dir = tmp_path / "index"
+    index_dir.mkdir()
+    embeddings = Embeddings(embeddings_path=index_dir / "embeddings.npz")
+
+    atomic_savez(
+        index_dir / "scan_rejects.npz",
+        keys=np.array(["/some/clip.mp4"], dtype=str),
+        sizes=np.array([123], dtype=np.int64),
+        mtimes=np.array([1.0], dtype=np.float64),
+        min_dim=np.int64(embeddings.min_image_dimension),
+        min_bytes=np.int64(embeddings.min_image_bytes),
+        # No cache_version: written by a build that predates the bump.
+    )
+
+    assert embeddings._load_scan_rejects() == {}
+
+
+def test_a_current_scan_reject_cache_is_kept(tmp_path):
+    index_dir = tmp_path / "index2"
+    index_dir.mkdir()
+    embeddings = Embeddings(embeddings_path=index_dir / "embeddings.npz")
+
+    embeddings._save_scan_rejects({"/some/tiny.jpg": (10, 1.0)})
+
+    assert embeddings._load_scan_rejects() == {"/some/tiny.jpg": (10, 1.0)}
+
+
+# --------------------------------------------------------------------------
+# Downstream behaviour
+# --------------------------------------------------------------------------
+
+
+def test_retrieve_image_serves_videos_as_videos(client, new_media_album):
+    build_index(client, new_media_album)
+
+    sorted_names = list(
+        Embeddings.open_cached_embeddings(new_media_album["index"])["sorted_filenames"]
+    )
+    video_index = next(
+        i for i, name in enumerate(sorted_names) if str(name).endswith("clip.mp4")
+    )
+
+    payload = client.get(
+        f"/retrieve_image/{new_media_album['key']}/{video_index}"
+    ).json()
+
+    assert payload["media_type"] == "video"
+    assert payload["image_url"].startswith("video_frame/")
+    assert payload["video_url"].endswith("clip.mp4")
+    assert payload["video_info"]["codec"] == "h264"
+
+
+def test_thumbnails_render_for_indexed_videos(client, new_media_album):
+    build_index(client, new_media_album)
+
+    sorted_names = list(
+        Embeddings.open_cached_embeddings(new_media_album["index"])["sorted_filenames"]
+    )
+    video_index = next(
+        i for i, name in enumerate(sorted_names) if str(name).endswith("clip.mp4")
+    )
+
+    response = client.get(
+        f"/thumbnails/{new_media_album['key']}/{video_index}?size=64"
+    )
+    assert response.status_code == 200
+
+
+def test_umap_includes_videos(client, new_media_album):
+    build_index(client, new_media_album)
+
+    points = client.get(f"umap_data/{new_media_album['key']}").json()
+
+    assert len(points) == EXPECTED_TOTAL
+
+
+def test_index_metadata_counts_the_videos(client, new_media_album):
+    build_index(client, new_media_album)
+
+    payload = client.get(f"/index_metadata/{new_media_album['key']}").json()
+
+    assert payload["filename_count"] == EXPECTED_TOTAL
+    assert payload["video_count"] == EXPECTED_VIDEO_COUNT
+    assert payload["image_count"] == TEST_IMAGE_COUNT
+
+
+def test_image_search_matches_a_video_against_itself(client, new_media_album):
+    """Deterministic: a video's own frame is its own top match.
+
+    Asserts the embedding is real and reachable without claiming anything
+    semantic about CLIP's view of a test pattern.
+    """
+    import base64
+
+    build_index(client, new_media_album)
+
+    frame_path = VideoFrameCache(new_media_album["key"]).get(
+        new_media_album["media_dir"] / "clip.mp4"
+    )
+    payload = base64.b64encode(frame_path.read_bytes()).decode()
+
+    response = client.post(
+        f"/search_with_text_and_image/{new_media_album['key']}",
+        json={
+            "image_data": f"data:image/jpeg;base64,{payload}",
+            "positive_query": "",
+            "negative_query": "",
+            "image_weight": 1.0,
+        },
+    )
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert results, "the video's own frame should match something"
+
+    top = results[0]
+    sorted_names = list(
+        Embeddings.open_cached_embeddings(new_media_album["index"])["sorted_filenames"]
+    )
+    assert str(sorted_names[top["index"]]).endswith("clip.mp4")
+    assert top["score"] > 0.9
+
+
+def test_a_legacy_image_only_index_still_reports_images(client, new_album):
+    """Indexes predating video support need no migration."""
+    build_index(client, new_album)
+
+    payload = client.get(f"/retrieve_image/{new_album['key']}/0").json()
+
+    assert payload["media_type"] == "image"
+    assert payload["video_url"] == ""

--- a/tests/frontend/umap-harness.js
+++ b/tests/frontend/umap-harness.js
@@ -77,6 +77,27 @@ function resolveDiv(target) {
 }
 
 /**
+ * Point-in-time copy of a trace list, arrays included.
+ *
+ * `restyle` replaces whole arrays on a trace (`trace.x = […]`), so a one-level
+ * copy is enough to freeze what was plotted; nested marker objects are cloned
+ * too since restyle writes into them via dotted paths.
+ */
+function snapshotTraces(traces) {
+  return traces.map((t) => {
+    const copy = { ...t };
+    for (const [key, value] of Object.entries(copy)) {
+      if (Array.isArray(value)) {
+        copy[key] = [...value];
+      } else if (value && typeof value === "object") {
+        copy[key] = JSON.parse(JSON.stringify(value));
+      }
+    }
+    return copy;
+  });
+}
+
+/**
  * Install a fake `window.Plotly` and return it for assertions.
  *
  * Every method records its arguments on `.calls` and returns a resolved
@@ -90,8 +111,8 @@ export function installPlotlyMock() {
 
     newPlot(target, data, layout = {}, config = {}) {
       const div = resolveDiv(target);
-      // Deep-ish copy so a later restyle can't retroactively change what the
-      // test believes was plotted.
+      // A per-trace copy, so mutating div.data doesn't reach back into the
+      // caller's array.
       div.data = data.map((t) => ({ ...t }));
       div.layout = {
         ...layout,
@@ -100,7 +121,11 @@ export function installPlotlyMock() {
         images: layout.images || [],
       };
       attachEmitter(div);
-      calls.newPlot.push({ data: div.data, layout: div.layout, config });
+      // Recorded as a real snapshot, not a reference to div.data. Sharing the
+      // array meant a later restyle rewrote what the test believed was
+      // plotted — so an assertion about the *first* draw silently became an
+      // assertion about the final state, and could not fail.
+      calls.newPlot.push({ data: snapshotTraces(div.data), layout: { ...div.layout }, config });
       return Promise.resolve(div);
     },
 

--- a/tests/frontend/umap-harness.js
+++ b/tests/frontend/umap-harness.js
@@ -1,0 +1,207 @@
+// Test harness for umap.js.
+//
+// umap.js is the one frontend module with no unit tests, because it does DOM
+// work at *module scope* — it wires `onclick` handlers onto a dozen elements
+// the moment it is imported, and throws if any of them is missing. (This is
+// why umap-helpers.js exists at all: its header says the pure helpers were
+// split out "so they can be unit-tested without pulling in the full UMAP
+// module".) That left everything interesting in umap.js — trace ordering,
+// landmark rendering, the highlight split — reachable only through a browser.
+//
+// This harness makes the module importable under jsdom:
+//
+//   * `loadUmapDom()` installs the **real** template markup, read straight
+//     from umap-floating-window.html. The template contains no Jinja tags, so
+//     it can be used verbatim — which means the fixture cannot drift out of
+//     sync with the markup the app actually ships, the usual failure mode for
+//     a hand-copied DOM fixture.
+//
+//   * `installPlotlyMock()` provides the six Plotly calls umap.js makes, with
+//     enough real behaviour that trace bookkeeping works: traces are actually
+//     added, deleted and moved on `div.data`, and `relayout` merges into
+//     `div.layout`. Plotly's own methods return promises and umap.js chains
+//     off them, so these do too.
+//
+// Usage (the module mocks stay in the test file, since they are test-specific
+// and must be registered before the dynamic import):
+//
+//   loadUmapDom();
+//   const plotly = installPlotlyMock();
+//   const umap = await import(".../umap.js");
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const TEMPLATE = path.join(
+  HERE,
+  "..",
+  "..",
+  "photomap",
+  "frontend",
+  "templates",
+  "modules",
+  "umap-floating-window.html"
+);
+
+/**
+ * Install the real semantic-map markup into the document.
+ *
+ * `#showUmapBtn` is stubbed because it lives in the control panel rather than
+ * this template, and umap.js assigns to its `.onclick` at import time.
+ */
+export function loadUmapDom() {
+  const markup = readFileSync(TEMPLATE, "utf8");
+  document.body.innerHTML = `<button id="showUmapBtn"></button>${markup}`;
+}
+
+/** Minimal stand-in for a Plotly graph div's event emitter. */
+function attachEmitter(div) {
+  const listeners = new Map();
+  div.on = (event, cb) => {
+    if (!listeners.has(event)) {
+      listeners.set(event, []);
+    }
+    listeners.get(event).push(cb);
+  };
+  div.emit = (event, payload) => {
+    (listeners.get(event) || []).forEach((cb) => cb(payload));
+  };
+  div.removeAllListeners = () => listeners.clear();
+  return div;
+}
+
+function resolveDiv(target) {
+  return typeof target === "string" ? document.getElementById(target) : target;
+}
+
+/**
+ * Install a fake `window.Plotly` and return it for assertions.
+ *
+ * Every method records its arguments on `.calls` and returns a resolved
+ * promise, matching the shape umap.js chains off.
+ */
+export function installPlotlyMock() {
+  const calls = { newPlot: [], restyle: [], addTraces: [], deleteTraces: [], relayout: [], moveTraces: [] };
+
+  const Plotly = {
+    calls,
+
+    newPlot(target, data, layout = {}, config = {}) {
+      const div = resolveDiv(target);
+      // Deep-ish copy so a later restyle can't retroactively change what the
+      // test believes was plotted.
+      div.data = data.map((t) => ({ ...t }));
+      div.layout = {
+        ...layout,
+        xaxis: { range: [-10, 10], ...(layout.xaxis || {}) },
+        yaxis: { range: [-10, 10], ...(layout.yaxis || {}) },
+        images: layout.images || [],
+      };
+      attachEmitter(div);
+      calls.newPlot.push({ data: div.data, layout: div.layout, config });
+      return Promise.resolve(div);
+    },
+
+    restyle(target, update, traceIndices) {
+      const div = resolveDiv(target);
+      const indices = traceIndices === undefined ? div.data.map((_, i) => i) : [traceIndices].flat();
+      indices.forEach((i) => {
+        const trace = div.data[i];
+        if (!trace) {
+          return;
+        }
+        // Plotly's restyle takes each value wrapped in an array, one entry per
+        // targeted trace; unwrap the single-trace case the way it would.
+        Object.entries(update).forEach(([key, value]) => {
+          const unwrapped = Array.isArray(value) ? value[0] : value;
+          if (key.includes(".")) {
+            const [head, ...rest] = key.split(".");
+            trace[head] = trace[head] || {};
+            let node = trace[head];
+            while (rest.length > 1) {
+              const part = rest.shift();
+              node[part] = node[part] || {};
+              node = node[part];
+            }
+            node[rest[0]] = unwrapped;
+          } else {
+            trace[key] = unwrapped;
+          }
+        });
+      });
+      calls.restyle.push({ update, traceIndices });
+      return Promise.resolve(div);
+    },
+
+    addTraces(target, traces) {
+      const div = resolveDiv(target);
+      [traces].flat().forEach((t) => div.data.push({ ...t }));
+      calls.addTraces.push([traces].flat());
+      return Promise.resolve(div);
+    },
+
+    deleteTraces(target, indices) {
+      const div = resolveDiv(target);
+      // Descending, so earlier removals don't shift later indices.
+      [indices]
+        .flat()
+        .sort((a, b) => b - a)
+        .forEach((i) => div.data.splice(i, 1));
+      calls.deleteTraces.push([indices].flat());
+      return Promise.resolve(div);
+    },
+
+    moveTraces(target, from, to) {
+      const div = resolveDiv(target);
+      const [moved] = div.data.splice(from, 1);
+      div.data.splice(to, 0, moved);
+      calls.moveTraces.push({ from, to });
+      return Promise.resolve(div);
+    },
+
+    relayout(target, update) {
+      const div = resolveDiv(target);
+      div.layout = { ...div.layout, ...update };
+      calls.relayout.push(update);
+      return Promise.resolve(div);
+    },
+  };
+
+  global.Plotly = Plotly;
+  window.Plotly = Plotly;
+  return Plotly;
+}
+
+export function removePlotlyMock() {
+  delete global.Plotly;
+  delete window.Plotly;
+}
+
+/** The landmark thumbnails currently on the plot. */
+export function currentLandmarkImages(plotId = "umapPlot") {
+  return document.getElementById(plotId)?.layout?.images || [];
+}
+
+/** The landmark triangle trace, if one is currently plotted. */
+export function currentLandmarkTrace(plotId = "umapPlot") {
+  return (document.getElementById(plotId)?.data || []).find((t) => t.name === "Landmarks") || null;
+}
+
+/**
+ * A `fetch` stub that answers the two endpoints `fetchUmapData` calls.
+ *
+ * Cluster labels are answered as "not ok" so the caller falls back to the
+ * bare cluster string, which keeps tests independent of the labels feature.
+ */
+export function installFetchMock(points) {
+  const fetchMock = (url) => {
+    if (String(url).startsWith("umap_data/")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(points) });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  };
+  global.fetch = fetchMock;
+  return fetchMock;
+}

--- a/tests/frontend/umap-helpers.test.js
+++ b/tests/frontend/umap-helpers.test.js
@@ -2,7 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { findLandmarkClusterAt } from "../../photomap/frontend/static/javascript/umap-helpers.js";
+import {
+  MEDIA_FILTERS,
+  filterPointsByMediaType,
+  findLandmarkClusterAt,
+  hasVideoPoints,
+} from "../../photomap/frontend/static/javascript/umap-helpers.js";
 
 describe("findLandmarkClusterAt", () => {
   // Three landmarks at distinct positions, deliberately covering cluster ids
@@ -67,5 +72,71 @@ describe("findLandmarkClusterAt", () => {
   it("returns null when customdata is missing for a matched landmark", () => {
     const result = findLandmarkClusterAt({ x: 10, y: 10 }, landmarkXs, landmarkYs, [], halfSizeX, halfSizeY);
     expect(result).toBeNull();
+  });
+});
+
+describe("filterPointsByMediaType", () => {
+  const IMAGE = { index: 0, media: "image" };
+  const VIDEO = { index: 1, media: "video" };
+  const LEGACY = { index: 2 }; // no media field
+  const points = [IMAGE, VIDEO, LEGACY];
+
+  it("returns everything for 'both'", () => {
+    expect(filterPointsByMediaType(points, "both")).toEqual(points);
+  });
+
+  it("keeps only images for 'images'", () => {
+    expect(filterPointsByMediaType(points, "images")).toEqual([IMAGE, LEGACY]);
+  });
+
+  it("keeps only videos for 'videos'", () => {
+    expect(filterPointsByMediaType(points, "videos")).toEqual([VIDEO]);
+  });
+
+  it("treats a point with no media field as an image", () => {
+    // /umap_data only started reporting `media` when video support landed; a
+    // response cached from an older build must behave exactly as before.
+    expect(filterPointsByMediaType([LEGACY], "images")).toEqual([LEGACY]);
+    expect(filterPointsByMediaType([LEGACY], "videos")).toEqual([]);
+  });
+
+  it("shows everything for an unrecognized filter", () => {
+    // The safe failure mode for a filter — e.g. a value persisted by a newer
+    // build than the one now running.
+    expect(filterPointsByMediaType(points, "sideways")).toEqual(points);
+    expect(filterPointsByMediaType(points, undefined)).toEqual(points);
+  });
+
+  it("returns an empty array for a missing point list", () => {
+    expect(filterPointsByMediaType(undefined, "both")).toEqual([]);
+    expect(filterPointsByMediaType(null, "videos")).toEqual([]);
+    expect(filterPointsByMediaType([], "images")).toEqual([]);
+  });
+
+  it("does not mutate the input", () => {
+    const original = [...points];
+    filterPointsByMediaType(points, "videos");
+    expect(points).toEqual(original);
+  });
+
+  it("is one of the documented filter values", () => {
+    expect(MEDIA_FILTERS).toEqual(["both", "images", "videos"]);
+  });
+});
+
+describe("hasVideoPoints", () => {
+  it("detects a video among the points", () => {
+    expect(hasVideoPoints([{ media: "image" }, { media: "video" }])).toBe(true);
+  });
+
+  it("reports false for an all-image album", () => {
+    // Drives disabling the filter: a "videos only" radio on an all-photo
+    // album can only ever produce a blank map.
+    expect(hasVideoPoints([{ media: "image" }, {}])).toBe(false);
+  });
+
+  it("reports false for empty or missing input", () => {
+    expect(hasVideoPoints([])).toBe(false);
+    expect(hasVideoPoints(undefined)).toBe(false);
   });
 });

--- a/tests/frontend/umap-landmarks.test.js
+++ b/tests/frontend/umap-landmarks.test.js
@@ -1,0 +1,296 @@
+// Landmark rendering in umap.js, driven through the real module.
+//
+// See umap-harness.js for why this needs a harness at all: umap.js wires DOM
+// handlers at import time, so the document has to be standing before the
+// dynamic import below.
+//
+// The regression under test: a landmark is two separate things — a triangle
+// marker *trace* and a thumbnail in `layout.images`. Deleting the traces does
+// not remove the thumbnails, so any path that bails out of drawing landmarks
+// must clear the images too. When the media filter hid every point of the only
+// cluster in view, the thumbnail was left hovering over empty space.
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+import {
+  currentLandmarkImages,
+  currentLandmarkTrace,
+  installFetchMock,
+  installPlotlyMock,
+  loadUmapDom,
+  removePlotlyMock,
+} from "./umap-harness.js";
+
+const JS = "../../photomap/frontend/static/javascript";
+
+// One cluster of images and one of videos, far enough apart that both
+// landmarks can be brought into view independently.
+const POINTS = [
+  ...Array.from({ length: 12 }, (_, i) => ({
+    x: -20 + i * 0.05,
+    y: 1 + i * 0.05,
+    index: i,
+    cluster: 1,
+    media: "image",
+  })),
+  ...Array.from({ length: 12 }, (_, i) => ({
+    x: 6 + i * 0.05,
+    y: 2 + i * 0.05,
+    index: 100 + i,
+    cluster: 0,
+    media: "video",
+  })),
+];
+
+const mockState = {
+  album: "test-album",
+  dataChanged: true,
+  autotaggingEnabled: false,
+  umapMediaFilter: "both",
+  umapShowLandmarks: true,
+  umapShowHoverThumbnails: false,
+  umapExitFullscreenOnSelection: true,
+  umapClickSelectsCluster: true,
+  umapControlsVisible: true,
+  umapClickSelectsImage: false,
+  searchType: "clear",
+  searchResults: [],
+};
+
+const setUmapMediaFilter = jest.fn((v) => {
+  mockState.umapMediaFilter = v;
+});
+const setUmapShowLandmarks = jest.fn((v) => {
+  mockState.umapShowLandmarks = v;
+});
+
+jest.unstable_mockModule(`${JS}/state.js`, () => ({
+  state: mockState,
+  setUmapMediaFilter,
+  setUmapShowLandmarks,
+  setUmapClickSelectsCluster: jest.fn(),
+  setUmapControlsVisible: jest.fn(),
+  setUmapExitFullscreenOnSelection: jest.fn(),
+  setUmapShowHoverThumbnails: jest.fn(),
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+
+jest.unstable_mockModule(`${JS}/album-manager.js`, () => ({
+  albumManager: { fetchAvailableAlbums: jest.fn(() => Promise.resolve([])), setSwiperManager: jest.fn() },
+  checkAlbumIndex: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/back-stack.js`, () => ({
+  backStack: { markNextAsJump: jest.fn(), popOne: jest.fn(), init: jest.fn(), setNavigator: jest.fn() },
+}));
+jest.unstable_mockModule(`${JS}/cluster-utils.js`, () => ({
+  CLUSTER_PALETTE: ["#ff0000", "#00ff00", "#0000ff"],
+  getClusterLabelInfo: jest.fn(() => null),
+  getImageLabelInfo: jest.fn(() => null),
+  setClusterLabels: jest.fn(),
+  trackVocabBuildRequest: jest.fn((p) => p),
+}));
+jest.unstable_mockModule(`${JS}/search-ui.js`, () => ({ exitSearchMode: jest.fn() }));
+jest.unstable_mockModule(`${JS}/search.js`, () => ({
+  getImagePath: jest.fn(() => Promise.resolve("/photos/example.jpg")),
+  setSearchResults: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/settings.js`, () => ({ switchAlbum: jest.fn() }));
+jest.unstable_mockModule(`${JS}/slide-state.js`, () => ({
+  slideState: { navigateToIndex: jest.fn(), getCurrentSlide: jest.fn(() => ({ globalIndex: 0 })) },
+  getCurrentSlideIndex: jest.fn(() => [-1, 24, null]),
+}));
+jest.unstable_mockModule(`${JS}/umap-reindex.js`, () => ({
+  checkUmapReindexOngoing: jest.fn(),
+  initUmapReindexButton: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/utils.js`, () => ({
+  // The real debounce implementation, so the 500ms coalescing is genuinely
+  // exercised rather than stubbed away.
+  // The real debounce implementation, so rapid calls genuinely coalesce — but
+  // with the delay capped, because umap.js debounces landmark redraws by 500ms
+  // and waiting that out on every assertion would put this file an order of
+  // magnitude above the rest of the suite. The coalescing is what matters
+  // here; the exact interval is not what these tests are about.
+  debounce: (fn, delay) => {
+    const wait = Math.min(delay, 10);
+    let timer = null;
+    return function (...args) {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => fn.apply(this, args), wait);
+    };
+  },
+  getPercentile: (arr, p) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    return sorted[Math.floor(((p / 100) * (sorted.length - 1)) | 0)] ?? 0;
+  },
+  isColorLight: () => false,
+  makeDraggable: jest.fn(),
+  showToast: jest.fn(),
+}));
+
+describe("umap.js landmarks", () => {
+  let umap;
+  let plotly;
+
+  /** Bring both cluster landmarks into view and redraw them. */
+  async function showLandmarksAcross(xRange, yRange) {
+    const plotDiv = document.getElementById("umapPlot");
+    plotDiv.layout.xaxis.range = xRange;
+    plotDiv.layout.yaxis.range = yRange;
+
+    const checkbox = document.getElementById("umapShowLandmarks");
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change"));
+    await settle();
+  }
+
+  /**
+   * Let the landmark debounce fire and the Plotly promise chains settle.
+   *
+   * Real timers rather than fake ones: umap.js awaits `setTimeout(..., 0)` in
+   * a couple of places to yield to the browser, and under fake timers those
+   * awaits deadlock unless every advance is interleaved with a microtask
+   * drain. A real wait is both simpler and closer to what actually happens —
+   * cheap here only because the mocked debounce caps its delay.
+   */
+  async function settle() {
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  }
+
+  async function selectFilter(value) {
+    const radio = document.getElementById(
+      { both: "umapMediaFilterBothRadio", images: "umapMediaFilterImagesRadio", videos: "umapMediaFilterVideosRadio" }[
+        value
+      ]
+    );
+    radio.checked = true;
+    radio.dispatchEvent(new Event("change"));
+    await settle();
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    Object.assign(mockState, {
+      umapMediaFilter: "both",
+      umapShowLandmarks: true,
+      dataChanged: true,
+      searchType: "clear",
+      searchResults: [],
+    });
+
+    loadUmapDom();
+    plotly = installPlotlyMock();
+    installFetchMock(POINTS);
+
+    umap = await import(`${JS}/umap.js`);
+    window.dispatchEvent(new CustomEvent("stateReady"));
+
+    await umap.fetchUmapData();
+    await settle();
+  });
+
+  afterEach(() => {
+    removePlotlyMock();
+    delete global.fetch;
+    document.body.innerHTML = "";
+    jest.resetModules();
+  });
+
+  it("plots every point when the filter is Both", () => {
+    expect(document.getElementById("umapPlot").data[0].x).toHaveLength(POINTS.length);
+  });
+
+  describe("with both cluster landmarks in view", () => {
+    beforeEach(async () => {
+      await showLandmarksAcross([-40, 30], [-20, 35]);
+    });
+
+    it("draws one landmark per cluster", () => {
+      expect(currentLandmarkTrace().x).toHaveLength(2);
+      expect(currentLandmarkImages()).toHaveLength(2);
+    });
+
+    it("drops the video cluster's landmark when showing images only", async () => {
+      await selectFilter("images");
+
+      expect(currentLandmarkTrace().x).toHaveLength(1);
+      expect(currentLandmarkImages()).toHaveLength(1);
+      // The one left is the image cluster, over on the negative side.
+      expect(currentLandmarkTrace().x[0]).toBeLessThan(0);
+    });
+
+    it("drops the image cluster's landmark when showing videos only", async () => {
+      await selectFilter("videos");
+
+      expect(currentLandmarkTrace().x).toHaveLength(1);
+      expect(currentLandmarkImages()).toHaveLength(1);
+      expect(currentLandmarkTrace().x[0]).toBeGreaterThan(0);
+    });
+
+    it("restores both landmarks on the way back to Both", async () => {
+      await selectFilter("videos");
+      await selectFilter("both");
+
+      expect(currentLandmarkTrace().x).toHaveLength(2);
+      expect(currentLandmarkImages()).toHaveLength(2);
+    });
+  });
+
+  describe("when the filter empties the view", () => {
+    beforeEach(async () => {
+      // A window around the image cluster only, so the video cluster's
+      // landmark is off-screen. Selecting Videos then leaves nothing to draw.
+      await showLandmarksAcross([-30, -10], [-5, 10]);
+    });
+
+    it("starts with just the image cluster's landmark", () => {
+      expect(currentLandmarkTrace().x).toHaveLength(1);
+      expect(currentLandmarkImages()).toHaveLength(1);
+    });
+
+    it("removes the thumbnail, not just the triangle", async () => {
+      // The regression. Deleting the traces left layout.images untouched, so
+      // the thumbnail stayed put over a region with no points under it.
+      await selectFilter("videos");
+
+      expect(currentLandmarkTrace()).toBeNull();
+      expect(currentLandmarkImages()).toHaveLength(0);
+    });
+
+    it("clears the thumbnail via a relayout rather than by luck", async () => {
+      await selectFilter("videos");
+
+      const cleared = plotly.calls.relayout.filter((u) => Array.isArray(u.images) && u.images.length === 0);
+      expect(cleared.length).toBeGreaterThan(0);
+    });
+
+    it("brings the landmark back when the filter is widened again", async () => {
+      await selectFilter("videos");
+      await selectFilter("both");
+
+      expect(currentLandmarkTrace().x).toHaveLength(1);
+      expect(currentLandmarkImages()).toHaveLength(1);
+    });
+  });
+
+  describe("turning landmarks off", () => {
+    beforeEach(async () => {
+      await showLandmarksAcross([-40, 30], [-20, 35]);
+    });
+
+    it("removes both the triangles and the thumbnails", async () => {
+      expect(currentLandmarkImages()).toHaveLength(2);
+
+      const checkbox = document.getElementById("umapShowLandmarks");
+      checkbox.checked = false;
+      checkbox.dispatchEvent(new Event("change"));
+      await settle();
+
+      expect(currentLandmarkTrace()).toBeNull();
+      expect(currentLandmarkImages()).toHaveLength(0);
+    });
+  });
+});

--- a/tests/frontend/umap-media-filter.test.js
+++ b/tests/frontend/umap-media-filter.test.js
@@ -1,0 +1,353 @@
+// The media filter's effect on everything downstream of the plot.
+//
+// umap-helpers.test.js covers the pure predicate and umap-landmarks.test.js
+// covers landmark rendering. What was left untested is the part the filter is
+// actually dangerous in: the paths that turn a click into a *selection*. A
+// filtered map must never hand a hidden point to the swiper, and the trace must
+// survive a colorize/clear cycle — the else-branch of colorizeUmap restores
+// trace 0 from scratch on every "clear selection".
+//
+// See umap-harness.js for why umap.js needs a harness to be importable at all.
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+import { installFetchMock, installPlotlyMock, loadUmapDom, removePlotlyMock } from "./umap-harness.js";
+
+const JS = "../../photomap/frontend/static/javascript";
+
+// One cluster deliberately MIXED — 10 images and 3 videos sitting together.
+// This is the shape that breaks: a landmark is placed from the cluster's
+// visible members, so it appears under any filter, but resolving what to open
+// used to consider every member.
+// Indices below 100 are images; 100+ are videos.
+const MIXED_POINTS = [
+  ...Array.from({ length: 10 }, (_, i) => ({
+    x: 1 + i * 0.02,
+    y: 1 + i * 0.02,
+    index: i,
+    cluster: 1,
+    media: "image",
+  })),
+  ...Array.from({ length: 3 }, (_, i) => ({
+    x: 1.5 + i * 0.02,
+    y: 1.5 + i * 0.02,
+    index: 100 + i,
+    cluster: 1,
+    media: "video",
+  })),
+];
+
+const IMAGE_ONLY_POINTS = Array.from({ length: 12 }, (_, i) => ({
+  x: i * 0.05,
+  y: 1 + i * 0.05,
+  index: i,
+  cluster: 1,
+  media: "image",
+}));
+
+const mockState = {
+  album: "test-album",
+  dataChanged: true,
+  autotaggingEnabled: false,
+  umapMediaFilter: "both",
+  umapShowLandmarks: false,
+  umapShowHoverThumbnails: false,
+  umapExitFullscreenOnSelection: false,
+  umapClickSelectsCluster: true,
+  umapControlsVisible: true,
+  umapClickSelectsImage: false,
+  searchType: "clear",
+  searchResults: [],
+};
+
+const setUmapMediaFilter = jest.fn((v) => {
+  mockState.umapMediaFilter = v;
+});
+const setSearchResults = jest.fn();
+// Mutable so a test can put the swiper on a specific image.
+let currentSlideIndex = [-1, MIXED_POINTS.length, null];
+
+jest.unstable_mockModule(`${JS}/state.js`, () => ({
+  state: mockState,
+  setUmapMediaFilter,
+  setUmapShowLandmarks: jest.fn((v) => {
+    mockState.umapShowLandmarks = v;
+  }),
+  setUmapClickSelectsCluster: jest.fn(),
+  setUmapControlsVisible: jest.fn(),
+  setUmapExitFullscreenOnSelection: jest.fn(),
+  setUmapShowHoverThumbnails: jest.fn(),
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/album-manager.js`, () => ({
+  albumManager: { fetchAvailableAlbums: jest.fn(() => Promise.resolve([])), setSwiperManager: jest.fn() },
+  checkAlbumIndex: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/back-stack.js`, () => ({
+  backStack: { markNextAsJump: jest.fn(), popOne: jest.fn(), init: jest.fn(), setNavigator: jest.fn() },
+}));
+jest.unstable_mockModule(`${JS}/cluster-utils.js`, () => ({
+  CLUSTER_PALETTE: ["#ff0000", "#00ff00", "#0000ff"],
+  getClusterLabelInfo: jest.fn(() => null),
+  getImageLabelInfo: jest.fn(() => null),
+  setClusterLabels: jest.fn(),
+  trackVocabBuildRequest: jest.fn((p) => p),
+}));
+jest.unstable_mockModule(`${JS}/search-ui.js`, () => ({ exitSearchMode: jest.fn() }));
+jest.unstable_mockModule(`${JS}/search.js`, () => ({
+  getImagePath: jest.fn(() => Promise.resolve("/photos/example.jpg")),
+  setSearchResults,
+}));
+jest.unstable_mockModule(`${JS}/settings.js`, () => ({ switchAlbum: jest.fn() }));
+jest.unstable_mockModule(`${JS}/slide-state.js`, () => ({
+  slideState: { navigateToIndex: jest.fn(), getCurrentSlide: jest.fn(() => ({ globalIndex: 0 })) },
+  getCurrentSlideIndex: jest.fn(() => currentSlideIndex),
+}));
+jest.unstable_mockModule(`${JS}/umap-reindex.js`, () => ({
+  checkUmapReindexOngoing: jest.fn(),
+  initUmapReindexButton: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/utils.js`, () => ({
+  // Real debounce, capped so the 500ms landmark coalescing doesn't dominate
+  // the suite's runtime.
+  debounce: (fn, delay) => {
+    const wait = Math.min(delay, 10);
+    let timer = null;
+    return function (...args) {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => fn.apply(this, args), wait);
+    };
+  },
+  getPercentile: (arr, p) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    return sorted[Math.floor(((p / 100) * (sorted.length - 1)) | 0)] ?? 0;
+  },
+  isColorLight: () => false,
+  makeDraggable: jest.fn(),
+  showToast: jest.fn(),
+}));
+
+/** Real timers: umap.js awaits setTimeout(…, 0) in places that deadlock under fake ones. */
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+}
+
+const plotDiv = () => document.getElementById("umapPlot");
+const mainTrace = () => plotDiv().data[0];
+
+function selectFilter(value) {
+  const radio = document.getElementById(
+    { both: "umapMediaFilterBothRadio", images: "umapMediaFilterImagesRadio", videos: "umapMediaFilterVideosRadio" }[
+      value
+    ]
+  );
+  radio.checked = true;
+  radio.dispatchEvent(new Event("change"));
+}
+
+/** Indices handed to setSearchResults by the most recent selection. */
+function selectedIndices() {
+  const members = setSearchResults.mock.calls.at(-1)[0];
+  return members.map((m) => (typeof m === "number" ? m : m.index));
+}
+
+async function boot(points) {
+  loadUmapDom();
+  installPlotlyMock();
+  installFetchMock(points);
+  const umap = await import(`${JS}/umap.js`);
+  window.dispatchEvent(new CustomEvent("stateReady"));
+  await umap.fetchUmapData();
+  await settle();
+  return umap;
+}
+
+afterEach(() => {
+  removePlotlyMock();
+  delete global.fetch;
+  document.body.innerHTML = "";
+  jest.resetModules();
+});
+
+describe("selecting from a filtered map", () => {
+  let umap;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    Object.assign(mockState, {
+      umapMediaFilter: "both",
+      umapShowLandmarks: false,
+      umapClickSelectsCluster: true,
+      dataChanged: true,
+      searchType: "clear",
+      searchResults: [],
+    });
+    currentSlideIndex = [-1, MIXED_POINTS.length, null];
+    umap = await boot(MIXED_POINTS);
+  });
+
+  it("plots only the videos once the filter is set to Videos", async () => {
+    selectFilter("videos");
+    await settle();
+    expect(mainTrace().x).toHaveLength(3);
+    expect(mainTrace().customdata).toEqual([100, 101, 102]);
+  });
+
+  it("keeps images out of a cluster selection made by clicking a point", async () => {
+    selectFilter("videos");
+    await settle();
+
+    plotDiv().emit("plotly_click", {
+      points: [{ x: 1.5, y: 1.5, customdata: 100, pointIndex: 0, data: { name: "All Points" } }],
+    });
+    await settle();
+
+    expect(setSearchResults).toHaveBeenCalled();
+    expect(selectedIndices().every((i) => i >= 100)).toBe(true);
+  });
+
+  describe("clicking a landmark", () => {
+    beforeEach(async () => {
+      // Bring the cluster into view and draw its landmark, then hide the
+      // images so the cluster is mixed but only partly drawn.
+      plotDiv().layout.xaxis.range = [-5, 8];
+      plotDiv().layout.yaxis.range = [-5, 8];
+      const checkbox = document.getElementById("umapShowLandmarks");
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new Event("change"));
+      await settle();
+
+      selectFilter("videos");
+      await settle();
+    });
+
+    it("still offers a landmark for the partly-hidden cluster", () => {
+      const targets = plotDiv().data.find((t) => t.name === "LandmarkClickTargets");
+      expect(targets?.x?.length).toBeGreaterThan(0);
+    });
+
+    it("selects only drawn points, and does not throw", async () => {
+      // The regression: the landmark's click target was resolved from every
+      // member of the cluster, so it came back an image. handleClusterClick
+      // then built its walk over the visible set with that hidden point as the
+      // start and threw on the first distance calculation — which left
+      // setSearchResults uncalled, and with it the spinner (only hidden by the
+      // searchResultsChanged handler) up for good.
+      const targets = plotDiv().data.find((t) => t.name === "LandmarkClickTargets");
+      plotDiv().emit("plotly_click", {
+        points: [{ x: targets.x[0], y: targets.y[0], data: { name: "LandmarkClickTargets" } }],
+      });
+      await settle();
+
+      expect(setSearchResults).toHaveBeenCalled();
+      expect(selectedIndices()).not.toHaveLength(0);
+      expect(selectedIndices().every((i) => i >= 100)).toBe(true);
+    });
+
+    it("ignores a server-supplied medoid that the filter is hiding", async () => {
+      // getLandmarkImageIndex short-circuits on labelInfo.medoid_index, which
+      // the labels endpoint computes over the whole cluster.
+      const { getClusterLabelInfo } = await import(`${JS}/cluster-utils.js`);
+      getClusterLabelInfo.mockReturnValue({ medoid_index: 3 }); // an image
+
+      const targets = plotDiv().data.find((t) => t.name === "LandmarkClickTargets");
+      plotDiv().emit("plotly_click", {
+        points: [{ x: targets.x[0], y: targets.y[0], data: { name: "LandmarkClickTargets" } }],
+      });
+      await settle();
+
+      expect(setSearchResults).toHaveBeenCalled();
+      expect(selectedIndices()).not.toContain(3);
+      expect(selectedIndices().every((i) => i >= 100)).toBe(true);
+    });
+  });
+
+  it("hides the current-image marker when the filter hides that slide", async () => {
+    currentSlideIndex = [0, MIXED_POINTS.length, null]; // an image
+    selectFilter("videos");
+    await settle();
+    await umap.updateCurrentImageMarker();
+
+    const marker = plotDiv().data.find((t) => t.name === "Current Image");
+    expect(marker.x).toEqual([]);
+  });
+
+  it("shows the current-image marker when that slide is still drawn", async () => {
+    currentSlideIndex = [100, MIXED_POINTS.length, null]; // a video
+    selectFilter("videos");
+    await settle();
+    await umap.updateCurrentImageMarker();
+
+    const marker = plotDiv().data.find((t) => t.name === "Current Image");
+    expect(marker.x).toEqual([MIXED_POINTS.find((p) => p.index === 100).x]);
+  });
+
+  it("survives a colorize/clear cycle", async () => {
+    // colorizeUmap's else-branch rebuilds trace 0 from scratch on every
+    // "clear selection", which is the path that would silently restore the
+    // hidden points.
+    selectFilter("videos");
+    await settle();
+
+    await umap.colorizeUmap({ highlight: true, searchResults: [{ index: 100 }] });
+    await umap.colorizeUmap({ highlight: false, searchResults: [] });
+
+    expect(mainTrace().x).toHaveLength(3);
+    expect(mainTrace().customdata).toEqual([100, 101, 102]);
+  });
+
+  it("never highlights a point the filter is hiding", async () => {
+    selectFilter("videos");
+    await settle();
+
+    await umap.colorizeUmap({ highlight: true, searchResults: [{ index: 3 }, { index: 100 }] });
+
+    const highlighted = plotDiv().data.find((t) => t.name === "HighlightedPoints");
+    expect(highlighted.customdata).toEqual([100]);
+  });
+});
+
+describe("an album with no videos", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    Object.assign(mockState, {
+      // What localStorage restores after the user picked Videos elsewhere.
+      umapMediaFilter: "videos",
+      umapShowLandmarks: false,
+      dataChanged: true,
+      searchType: "clear",
+      searchResults: [],
+    });
+    currentSlideIndex = [-1, IMAGE_ONLY_POINTS.length, null];
+    await boot(IMAGE_ONLY_POINTS);
+  });
+
+  it("plots every point rather than an empty map", () => {
+    // Reconciling the filter has to happen before the trace is built. Doing it
+    // afterwards still looked right, but only because the colorize at the end
+    // of fetchUmapData happened to redraw trace 0 from the corrected filter.
+    expect(plotDiv().data[0].x).toHaveLength(IMAGE_ONLY_POINTS.length);
+  });
+
+  it("plots every point on the very first newPlot", () => {
+    const firstPlot = window.Plotly.calls.newPlot[0];
+    expect(firstPlot.data[0].x).toHaveLength(IMAGE_ONLY_POINTS.length);
+  });
+
+  it("resets the stored filter to both", () => {
+    expect(setUmapMediaFilter).toHaveBeenCalledWith("both");
+    expect(mockState.umapMediaFilter).toBe("both");
+  });
+
+  it("disables the radios and checks Both", () => {
+    expect(document.getElementById("umapMediaFilterVideosRadio").disabled).toBe(true);
+    expect(document.getElementById("umapMediaFilterImagesRadio").disabled).toBe(true);
+    expect(document.getElementById("umapMediaFilterBothRadio").checked).toBe(true);
+  });
+
+  it("explains why the control is unavailable", () => {
+    expect(document.getElementById("umapMediaFilterContainer").title).toMatch(/no videos/i);
+  });
+});


### PR DESCRIPTION
**PR 8 of 8** — the last one. Stacked on #361.

`/umap_data` reports a per-point `media` type, derived from the filename suffix (already in hand there), so there's no npz change and indexes predating video support report `"image"` throughout. The map window gains a **Show** radio group: Both / Images only / Videos only.

### Filter at the data layer, do not split into two traces

This was the main design call, and the two-trace version is a trap. Three concrete reasons, all verified in the source:

1. **`colorizeUmap` hardcodes trace `[0]` in *both* branches** — and its else-branch restores *every* point, running on each "clear selection". That branch would silently destroy a two-trace split every single time.
2. **`plotly_click`'s `points[pt.pointIndex]` fallback uses a per-trace index** and would resolve to the wrong image on a second scattergl trace.
3. **`updateLandmarkTrace` already juggles four traces plus `layout.images`**, locating them by name — a permanent trace at index 1 means auditing every literal `[0]` and every `data.length - 1`.

Keeping the trace count fixed means `moveTraces`, the `HighlightedPoints` add/delete and `customdata` all keep working, so **`plotly_click` and `plotly_hover` need zero changes**. That's the whole payoff.

### Consumers routed through `visiblePoints()`

- `colorizeUmap`, both branches, with the highlight set **intersected** with the visible set so a videos-only map can't highlight a hidden image
- landmark cluster selection, and the hover popup's cluster size
- the current-image marker, which now **hides** rather than drawing a gold dot over nothing when the current slide is filtered out
- `handleClusterClick` — unfiltered, selecting a cluster on a videos-only map would put images into the search results and open one in the swiper

### Window sizing

`setUmapWindowSize` now **measures** the controls block instead of consulting two independent magic numbers (`110/40` and `130/60`). Adding a row previously meant remembering to bump both, and missing one clipped the new row in exactly one of {fullscreen, windowed} — easy to miss in manual testing. The constants survive only as fallbacks for when the element isn't laid out yet.

### No-video albums

The radios are **disabled, not hidden** — hidden would make the row height conditional, which is precisely what the sizing code just stopped guessing at. A persisted "videos only" restored on an all-photo album resets to "both" rather than rendering a blank map and reading as "the semantic map is broken".

### Docs

README, `docs/index.md`, albums, basic-usage, troubleshooting, plus a new "Showing images, videos, or both" section in `semantic-map.md`.

**Tests:** 11 new frontend helper tests (including the legacy no-`media`-field point counting as an image, and an unrecognized filter falling through to showing everything) and 2 backend. Backend 611 passed, frontend 512 passed, ruff + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)