### PR TITLE
Derive a Cluster Strength for albums that have not set one

### DIFF
--- a/docs/user-guide/semantic-map.md
+++ b/docs/user-guide/semantic-map.md
@@ -18,7 +18,13 @@ The overall topology of the semantic map is fixed during the indexing process, b
 
 Until you set a value yourself, PhotoMapAI chooses one for the album and marks it **auto** beside the field. There is no single number that suits every collection: the map's coordinates have no fixed scale, and the same eps that carves a library of tens of thousands of photos into useful clusters can leave a few hundred photos entirely unclustered. The chosen value is derived from how tightly that album's own images sit together, taking the most generous clustering that does not merge the map into one giant cluster.
 
-Typing in the field replaces the derived value with yours, the **auto** marker disappears, and the album keeps your number from then on. If the eps is too low, you will see a lot of unclustered images, represented as faint gray dots; if it is too high, the map collapses toward a single color. Adjust the "Cluster Strength" field until the display is satisfactory — and clear the field back to empty if you would rather have the derived value again.
+Typing in the field replaces the derived value with yours, the **auto** marker disappears, and the album keeps your number from then on. If the eps is too low, you will see a lot of unclustered images, represented as faint gray dots; if it is too high, the map collapses toward a single color. Adjust the "Cluster Strength" field until the display is satisfactory.
+
+!!! tip "Clear the field to get a value chosen for you"
+
+    Deleting everything in the "Cluster Strength" box — leaving it empty — hands the album back to PhotoMapAI, which picks a reasonable value from that album's own map and marks it **auto**. Nothing is lost by trying it: if you prefer your own number, type it back in.
+
+    This is worth doing on albums you created before this feature existed. Those albums all carry a saved Cluster Strength, so they will not show the **auto** marker until you clear the field once, even though the value they carry may be one nobody chose deliberately. Small albums are where it matters most: a number that clusters tens of thousands of photos nicely can leave a few hundred photos completely unclustered.
 
 ### Interpreting Clusters
 

--- a/docs/user-guide/semantic-map.md
+++ b/docs/user-guide/semantic-map.md
@@ -12,11 +12,13 @@ In the second phase, PhotoMapAI applies an algorithm known as DBSCAN [Density-Ba
 
 ### Tuning Clusters
 
-The overall topology of the semantic map is fixed during the indexing process, but the clustering phase can be adjusted on the fly. At the bottom of the semantic map window is a field labeled "Cluster Strength," and contains a floating point value ranging from 0.0 to 1.0. This parameter (technically called epsilon, or "eps") controls the clustering size. Higher values of eps will create a smaller number of large clusters, while lower values will create a larger number of small clusters.
+The overall topology of the semantic map is fixed during the indexing process, but the clustering phase can be adjusted on the fly. At the bottom of the semantic map window is a field labeled "Cluster Strength," containing a floating point value. This parameter (technically called epsilon, or "eps") controls the clustering size. Higher values of eps will create a smaller number of large clusters, while lower values will create a larger number of small clusters.
 
 <img src="../../img/photomap_semantic_map_eps.png" width="480" class="img-hover-zoom">
 
-The default value of eps is 0.07, which empirically seems to work well for collections of a few tens of thousands of photographs. For smaller collections, you may wish to increase eps to 0.1 through 0.5. If the eps is too low, you may also see a lot of unclustered images, which are represented as faint gray dots. If you initially don't see much when you pull up the semantic map, gradually increase the "Cluster Strength" field until the display is satisfactory.
+Until you set a value yourself, PhotoMapAI chooses one for the album and marks it **auto** beside the field. There is no single number that suits every collection: the map's coordinates have no fixed scale, and the same eps that carves a library of tens of thousands of photos into useful clusters can leave a few hundred photos entirely unclustered. The chosen value is derived from how tightly that album's own images sit together, taking the most generous clustering that does not merge the map into one giant cluster.
+
+Typing in the field replaces the derived value with yours, the **auto** marker disappears, and the album keeps your number from then on. If the eps is too low, you will see a lot of unclustered images, represented as faint gray dots; if it is too high, the map collapses toward a single color. Adjust the "Cluster Strength" field until the display is satisfactory — and clear the field back to empty if you would rather have the derived value again.
 
 ### Interpreting Clusters
 
@@ -105,4 +107,4 @@ When a cluster is selected, the image search results will be sorted according to
 
 There will often be images that can't be assigned to any cluster. These appear as light gray dots in scatterplot. Click on one of these to highlight the unclustered images and browse through them.
 
-You can decrease the number of unclustered images by increasing EPS. This will cluster the images more aggressively and also merge existing clusters. Experiment until you find the setting that works best for you.
+You can decrease the number of unclustered images by increasing EPS. This will cluster the images more aggressively and also merge existing clusters. Experiment until you find the setting that works best for you — the derived starting point aims for a balance between the two, so both raising and lowering it are useful.

--- a/photomap/backend/cluster_eps.py
+++ b/photomap/backend/cluster_eps.py
@@ -1,0 +1,307 @@
+"""Choosing the DBSCAN epsilon for an album's semantic map.
+
+``eps`` is the one clustering parameter with no album-independent right
+answer.  UMAP's output coordinates have no fixed scale — their span grows as
+the point count shrinks — so an eps that carves a 40,000-image library into
+useful clusters labels a 200-image album as *entirely* unclustered.  That is
+not hypothetical: a 240-image album at the old 0.07 default produced zero
+clusters and 100% noise, which reads as "the semantic map is broken".
+
+The adaptive rule here is a refinement of the median k-distance heuristic
+(the standard DBSCAN eps rule, and what InvokeAI's image map uses): instead
+of taking the median outright, candidate eps values are drawn from the
+k-distance distribution and the **largest one whose biggest cluster still
+stays under a share of the album** is chosen.
+
+Why the extra step: the median makes about half the points core points by
+construction, which lands around 25-35% noise on a large library — much more
+unclustered than a hand-tuned eps gives.  Walking up the quantiles instead
+stops right before one cluster swallows the map, which is the real trade-off
+a user is making when they nudge the Cluster Strength control.  Measured
+against a set of real albums, the rule reproduces hand-tuned values on the
+large ones (0.119 vs a hand-set 0.12 on 38k images; 0.051 vs 0.05 on 86k)
+while rescuing the small ones.
+
+Nothing here is cached in memory: the caller holds the coordinates, and the
+resolved value is cached on disk by :func:`cached_adaptive_cluster_eps`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from .util import atomic_savez
+
+logger = logging.getLogger(__name__)
+
+# DBSCAN min_samples the app uses everywhere. Mirrored by the routers.
+DEFAULT_CLUSTER_MIN_SAMPLES = 10
+
+# Fallback when the coordinates cannot support a k-distance at all (fewer
+# points than neighbors, or every point coincident). Matches the historical
+# album default, so a degenerate album behaves exactly as it used to.
+FALLBACK_CLUSTER_EPS = 0.2
+
+# Quantiles of the k-distance distribution, ascending, that the scan walks.
+# Coarse on purpose: each step costs a DBSCAN fit, and the resulting eps
+# values are within a few percent of each other near the knee anyway.
+CANDIDATE_QUANTILES: tuple[int, ...] = (40, 50, 60, 70, 80, 90)
+
+# A cluster holding more than this share of the album is a blob, not a
+# cluster: it is what the map looks like just before every point merges into
+# one component. Measured on real albums, this is also the knee — the last
+# candidate below it consistently landed on the value a human had tuned by
+# hand.
+MAX_TOP_CLUSTER_SHARE = 0.25
+
+# eps is clamped to this fraction of the coordinate span, and *only* when the
+# value was derived rather than typed by a user (see resolve_cluster_eps).
+# A derived eps a quarter as wide as the whole map means there is no density
+# structure to find, and clustering at that radius says nothing.
+#
+# InvokeAI's image map uses 0.05 here, and copying that number was a mistake
+# worth recording: it suits a *median* k-distance, which sits low in the
+# distribution. The scan below deliberately climbs past the median, so 0.05
+# clamped values that were correct — on a map of five well-separated blobs it
+# overrode the scan's answer outright, and on real albums it collapsed the
+# tuning for the smallest one. The pair budget below, not this, is what
+# bounds memory; this is only a sanity bound on an automatically chosen
+# number, so it is set where it catches absurdity and nothing else.
+MAX_EPS_SPAN_FRACTION = 0.25
+
+# sklearn's DBSCAN materializes every point's radius neighborhood as int64
+# index arrays, so its peak memory tracks the neighbor-pair count rather than
+# the point count. 50M pairs is roughly 400MB.
+MAX_NEIGHBOR_PAIRS = 50_000_000
+
+# Hard floor for the pair-budget shrink. A fully coincident map cannot meet
+# the budget at any positive radius, so the loop needs a bound to terminate.
+MIN_BUDGETED_EPS = 1e-6
+
+# Floor for any resolved eps: DBSCAN at 0 clusters nothing, and the UI's
+# spinner will not accept a smaller number either.
+MIN_CLUSTER_EPS = 0.01
+
+_CACHE_FILENAME = "umap_eps_auto.npz"
+
+
+def _k_distances(coords: np.ndarray, min_samples: int) -> np.ndarray | None:
+    """Each point's distance to its ``min_samples``-th nearest neighbor.
+
+    ``None`` when the map is too small to have one. Imported lazily because
+    importing sklearn's neighbors module is not free and most requests never
+    reach here.
+    """
+    n_points = coords.shape[0]
+    k = min(min_samples, n_points - 1)
+    if k < 1:
+        return None
+
+    from sklearn.neighbors import NearestNeighbors
+
+    # k + 1 neighbors because the first neighbor of a point is itself.
+    distances, _ = NearestNeighbors(n_neighbors=k + 1).fit(coords).kneighbors(coords)
+    return distances[:, -1]
+
+
+def _top_cluster_share(coords: np.ndarray, eps: float, min_samples: int) -> float:
+    """Share of the album held by the largest cluster at ``eps``.
+
+    Noise (label -1) is excluded, so an eps that clusters nothing scores 0
+    and the scan keeps climbing.
+    """
+    from sklearn.cluster import DBSCAN
+
+    labels = DBSCAN(eps=eps, min_samples=min_samples).fit(coords).labels_
+    clustered = labels[labels != -1]
+    if clustered.size == 0:
+        return 0.0
+    return float(np.bincount(clustered).max()) / float(labels.size)
+
+
+def adaptive_cluster_eps(
+    coords: np.ndarray, min_samples: int = DEFAULT_CLUSTER_MIN_SAMPLES
+) -> float:
+    """Pick an eps for ``coords``: the loosest one that has not yet collapsed
+    the map into a single cluster.
+
+    Candidates are quantiles of the k-distance distribution, so they are
+    expressed in the units of *these* coordinates — which is what makes the
+    result independent of album size and of UMAP's arbitrary output scale.
+    The scan walks them upward and keeps the last one whose largest cluster
+    is under :data:`MAX_TOP_CLUSTER_SHARE`.
+
+    If even the smallest candidate is over that share the map has no
+    structure to separate (a few dozen near-identical images, say); the
+    smallest candidate is returned, since going lower only converts the blob
+    into noise without revealing anything.
+    """
+    distances = _k_distances(coords, min_samples)
+    if distances is None:
+        return FALLBACK_CLUSTER_EPS
+
+    candidates = [float(np.percentile(distances, q)) for q in CANDIDATE_QUANTILES]
+    # Coincident points give zero k-distances, and eps=0 clusters nothing.
+    candidates = [eps for eps in candidates if eps > 0]
+    if not candidates:
+        return FALLBACK_CLUSTER_EPS
+
+    best = candidates[0]
+    for eps in candidates:
+        if _top_cluster_share(coords, eps, min_samples) > MAX_TOP_CLUSTER_SHARE:
+            # Every later candidate is larger and so at least as blobby;
+            # stopping here is what bounds the scan to a few DBSCAN fits.
+            break
+        best = eps
+    return best
+
+
+def _shrink_eps_to_pair_budget(coords: np.ndarray, eps: float) -> float:
+    """Shrink ``eps`` until DBSCAN's neighbor-pair count fits the budget.
+
+    A span-based bound cannot do this job: a dense blob concentrates most of
+    its pairs in a small region, so a modest eps on a wide map can still
+    materialize billions of them. Counting pairs with a KD-tree is cheap, so
+    the guard measures the thing it is actually protecting.
+
+    This is why the guard exists at all: the Cluster Strength control lets a
+    user ask for an eps far looser than an album can afford, and on a
+    six-figure album that is an out-of-memory crash rather than a slow
+    response.
+    """
+    if coords.shape[0] < 2:
+        return eps
+
+    from sklearn.neighbors import KDTree
+
+    tree = KDTree(coords)
+    while eps > MIN_BUDGETED_EPS:
+        pairs = int(tree.query_radius(coords, r=eps, count_only=True).sum())
+        if pairs <= MAX_NEIGHBOR_PAIRS:
+            return eps
+        eps *= 0.7
+    return eps
+
+
+def resolve_cluster_eps(
+    coords: np.ndarray,
+    eps: float | None = None,
+    min_samples: int = DEFAULT_CLUSTER_MIN_SAMPLES,
+) -> float:
+    """The eps that will actually be used for ``coords``.
+
+    ``None`` means "no one has chosen a value" — the album has never had its
+    Cluster Strength adjusted — and resolves to :func:`adaptive_cluster_eps`.
+
+    The two clamps are deliberately not applied alike:
+
+    * The **span clamp** applies only to a derived value. A number the user
+      typed is theirs to keep; silently retuning it would make the control
+      lie about what it does.
+    * The **pair budget** applies to every value, derived or typed, because
+      it is a memory bound rather than a quality opinion. It is applied last
+      so nothing can re-inflate eps past it.
+
+    Every caller that clusters an album must route through this, so that
+    ``/umap_data`` and ``/cluster_labels`` agree on cluster ids for the same
+    request — they hand back ids that the UI joins on.
+    """
+    if eps is None:
+        eps = adaptive_cluster_eps(coords, min_samples)
+        span = float(np.ptp(coords, axis=0).max()) if coords.shape[0] > 1 else 0.0
+        if span > 0:
+            eps = min(eps, span * MAX_EPS_SPAN_FRACTION)
+    return _shrink_eps_to_pair_budget(coords, max(eps, MIN_CLUSTER_EPS))
+
+
+def resolve_album_cluster_eps(
+    coords: np.ndarray | None,
+    cache_dir: Path,
+    requested: float | None = None,
+    stored: float | None = None,
+    min_samples: int = DEFAULT_CLUSTER_MIN_SAMPLES,
+) -> float:
+    """Resolve the eps for one album request: ``requested`` beats ``stored``
+    beats adaptive.
+
+    ``requested`` is the query parameter (the Cluster Strength control sends
+    it on every fetch), ``stored`` the album's saved ``umap_eps``.  Both are
+    ``None`` for an album nobody has tuned, which is what selects the
+    adaptive value.
+
+    The single entry point every clustering caller shares: ``/umap_data``,
+    ``/cluster_labels`` and ``/get_umap_eps`` must agree on the number, or
+    the cluster ids the first two return refer to different clusterings and
+    the map's hover labels attach to the wrong blobs.
+
+    ``coords`` may be ``None`` or empty — an album can be configured before
+    it is indexed, and the semantic map is opened on exactly that album while
+    the first index runs. With nothing to cluster there is nothing to derive
+    from and nothing to protect against, so the number passes through
+    unclamped and no cache entry is written.
+    """
+    eps = requested if requested is not None else stored
+    if coords is None or coords.shape[0] == 0:
+        return eps if eps is not None else FALLBACK_CLUSTER_EPS
+    if eps is None:
+        return cached_adaptive_cluster_eps(coords, cache_dir, min_samples)
+    return resolve_cluster_eps(coords, eps, min_samples)
+
+
+def _coords_fingerprint(coords: np.ndarray, min_samples: int) -> str:
+    """Identity of a (coordinates, min_samples) pair for cache validation.
+
+    Hashes the coordinate bytes rather than trusting the file's mtime: a
+    re-index writes new coordinates for the same album at the same path, and
+    a stale adaptive eps would then cluster the new map at the old scale.
+    Hashing a six-figure album's coordinates is about a megabyte of blake2b,
+    far below the cost of the scan it guards.
+    """
+    digest = hashlib.blake2b(np.ascontiguousarray(coords, dtype=np.float32).tobytes(), digest_size=16)
+    digest.update(str(min_samples).encode("ascii"))
+    return digest.hexdigest()
+
+
+def cached_adaptive_cluster_eps(
+    coords: np.ndarray,
+    cache_dir: Path,
+    min_samples: int = DEFAULT_CLUSTER_MIN_SAMPLES,
+) -> float:
+    """:func:`resolve_cluster_eps` with ``eps=None``, memoized on disk.
+
+    The scan is a few seconds on a six-figure album — fine once, wasteful on
+    every open of the semantic map. The cache sits beside ``umap.npz`` (it
+    describes the same coordinates and dies with them) and is keyed by a
+    fingerprint of those coordinates, so a re-index invalidates it.
+
+    Cache failures are logged and swallowed: recomputing is always correct,
+    just slower.
+    """
+    cache_path = cache_dir / _CACHE_FILENAME
+    fingerprint = _coords_fingerprint(coords, min_samples)
+
+    try:
+        if cache_path.exists():
+            with np.load(cache_path, allow_pickle=False) as data:
+                if str(data["fingerprint"]) == fingerprint:
+                    return float(data["eps"])
+    except Exception as e:
+        logger.warning(f"Ignoring unreadable adaptive-eps cache {cache_path}: {e}")
+
+    eps = resolve_cluster_eps(coords, None, min_samples)
+
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        atomic_savez(
+            cache_path,
+            eps=np.float64(eps),
+            fingerprint=np.array(fingerprint),
+        )
+    except OSError as e:
+        logger.warning(f"Could not save adaptive-eps cache {cache_path}: {e}")
+
+    return eps

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -85,7 +85,17 @@ class Album(BaseModel):
             "id 'none' is InvokeAI's Uncategorized bucket."
         ),
     )
-    umap_eps: float = Field(default=0.2, description="UMAP epsilon parameter")
+    umap_eps: float | None = Field(
+        default=None,
+        description=(
+            "DBSCAN epsilon for the semantic map's clustering. None means "
+            "'not chosen': the value is derived from the album's own UMAP "
+            "coordinates (see backend/cluster_eps.py), which is what keeps "
+            "small albums from clustering into nothing. Adjusting Cluster "
+            "Strength in the UI stores a number here and the derived value "
+            "is no longer consulted."
+        ),
+    )
     description: str = Field(default="", description="Album description")
     encoder_spec: str = Field(
         # Resolved per-host: OpenCLIP ViT-L-14 on CUDA/macOS, lighter OpenAI CLIP
@@ -262,7 +272,11 @@ class Album(BaseModel):
             source_type=data.get("source_type", "directory"),
             image_paths=data.get("image_paths", []),
             index=data["index"],
-            umap_eps=data.get("umap_eps", 0.07),
+            # Absent from the YAML means nobody chose one, which is exactly
+            # what None asks the map to derive. The old 0.07 fallback here
+            # was a number for *every* album regardless of size, which is
+            # what left small albums with no clusters at all.
+            umap_eps=data.get("umap_eps"),
             description=data.get("description", ""),
             # Legacy YAML albums predate the encoder_spec field; their indexes
             # were built with the original CLIP, so fall back to that to stay
@@ -696,7 +710,7 @@ def create_album(
     name: str,
     image_paths: list[str] | None,
     index: str | None,
-    umap_eps: float,
+    umap_eps: float | None = None,
     description: str = "",
     encoder_spec: str | None = None,
     min_search_score: float | None = None,

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -565,8 +565,15 @@ class ConfigManager:
 
             config.albums[album.key] = album
             self._config = config
-            self.save_config()
-            self._config = None  # Clear cache to ensure fresh reads
+            try:
+                self.save_config()
+            finally:
+                # Invalidated even when the save raised. The cached config now
+                # holds a change that is not on disk, and leaving it in place
+                # lets a later, unrelated save write out an edit the caller
+                # was told had failed — a stored Cluster Strength that came
+                # back from the dead when the album was next renamed, for one.
+                self._config = None  # Clear cache to ensure fresh reads
             return True
 
     def update_album(self, album: Album) -> bool:
@@ -586,8 +593,15 @@ class ConfigManager:
 
             config.albums[album.key] = album
             self._config = config
-            self.save_config()
-            self._config = None  # Clear cache to ensure fresh reads
+            try:
+                self.save_config()
+            finally:
+                # Invalidated even when the save raised. The cached config now
+                # holds a change that is not on disk, and leaving it in place
+                # lets a later, unrelated save write out an edit the caller
+                # was told had failed — a stored Cluster Strength that came
+                # back from the dead when the album was next renamed, for one.
+                self._config = None  # Clear cache to ensure fresh reads
             return True
 
     def delete_album(self, key: str) -> bool:
@@ -607,8 +621,15 @@ class ConfigManager:
 
             del config.albums[key]
             self._config = config
-            self.save_config()
-            self._config = None  # Clear cache to ensure fresh reads
+            try:
+                self.save_config()
+            finally:
+                # Invalidated even when the save raised. The cached config now
+                # holds a change that is not on disk, and leaving it in place
+                # lets a later, unrelated save write out an edit the caller
+                # was told had failed — a stored Cluster Strength that came
+                # back from the dead when the album was next renamed, for one.
+                self._config = None  # Clear cache to ensure fresh reads
             return True
 
     def get_photo_albums_dict(self) -> dict[str, str]:

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -244,7 +244,6 @@ class Album(BaseModel):
             "source_type": self.source_type,
             "image_paths": self.image_paths,
             "index": self.index,
-            "umap_eps": self.umap_eps,
             "description": self.description,
             "encoder_spec": self.encoder_spec,
             "min_search_score": self.min_search_score,
@@ -253,6 +252,14 @@ class Album(BaseModel):
             "min_image_dimension": self.min_image_dimension,
             "min_image_bytes": self.min_image_bytes,
         }
+        # A derived Cluster Strength is written as an *absent* key rather
+        # than an explicit null. Both mean the same thing to this codebase,
+        # but versions before umap_eps became nullable parse a null into a
+        # non-nullable float field and refuse to load the whole config —
+        # i.e. writing null here would stop an older PhotoMapAI from
+        # starting at all, on a config file the two share.
+        if self.umap_eps is not None:
+            data["umap_eps"] = self.umap_eps
         # Keep directory-album YAML free of irrelevant InvokeAI keys.
         if self.source_type == "invokeai_board":
             data["invokeai_url"] = self.invokeai_url

--- a/photomap/backend/embeddings.py
+++ b/photomap/backend/embeddings.py
@@ -12,6 +12,7 @@ import functools
 import gc
 import logging
 import os
+import threading
 import warnings
 from collections import deque
 from collections.abc import Callable, Generator
@@ -106,6 +107,25 @@ LAST_UPDATED_FILENAME = "last_updated"
 # thumbnail population that is as many header opens as the album has photos,
 # on every single update.
 SCAN_REJECTS_FILENAME = "scan_rejects.npz"
+
+# One lock per umap.npz path, so two threads cannot both decide the cache is
+# stale and both refit. Keyed by resolved path rather than by Embeddings
+# instance: every request builds its own instance for the same album, so an
+# instance-level lock would guard nothing.
+_UMAP_BUILD_LOCKS: dict[Path, threading.Lock] = {}
+_UMAP_BUILD_LOCKS_GUARD = threading.Lock()
+
+
+def _umap_build_lock(cache_file: Path) -> threading.Lock:
+    """The rebuild lock for one ``umap.npz``, created on first use.
+
+    Never evicted: one lock object per album per process is nothing, and
+    dropping one while a thread still holds it would let a later caller build
+    a second, unrelated lock and defeat the exclusion.
+    """
+    key = cache_file.resolve()
+    with _UMAP_BUILD_LOCKS_GUARD:
+        return _UMAP_BUILD_LOCKS.setdefault(key, threading.Lock())
 
 # Bump to discard every existing scan-reject cache once. Version 1 retires
 # caches written while videos still went through the pixel gate, which could
@@ -1827,21 +1847,43 @@ class Embeddings(BaseModel):
     @property
     def umap_embeddings(self) -> np.ndarray:
         """
-        Load UMAP embeddings from disk.
+        Load UMAP embeddings from disk, rebuilding the cache when it is stale.
+
+        Rebuilds are serialized per index path. Callers reach this from worker
+        threads (the semantic map fetches ``/umap_data`` and ``/cluster_labels``
+        in parallel, and both resolve coordinates off the event loop), and the
+        freshness check is a check-then-act on an mtime that is not written
+        until the fit *finishes* — so without the lock both callers see the
+        same stale cache and both fit.
+
+        That is not merely wasteful. ``UMAP`` is constructed without a
+        ``random_state``, so two fits of the same input produce *different*
+        layouts; the two endpoints would then return cluster ids describing
+        different coordinate sets, which is exactly the divergence the map's
+        hover labels rely on not happening.
 
         Returns:
             np.ndarray: The UMAP embeddings.
         """
         cache_file = self.embeddings_path.parent / "umap.npz"
-        if (
-            not cache_file.exists()
-            or cache_file.stat().st_mtime < self.embeddings_path.stat().st_mtime
-        ):  # If UMAP index does not exist or is outdated, create it
+        if not self._umap_cache_is_stale(cache_file):
+            return np.load(cache_file, allow_pickle=True)["umap"]
+
+        with _umap_build_lock(cache_file):
+            # Re-check under the lock: whoever held it before us has almost
+            # certainly just written the cache we were about to rebuild.
+            if not self._umap_cache_is_stale(cache_file):
+                return np.load(cache_file, allow_pickle=True)["umap"]
             embeddings = self.open_cached_embeddings(self.embeddings_path)["embeddings"]
             logger.info(f"Creating UMAP index for {embeddings.shape[0]} embeddings")
             return self.create_umap_index(embeddings)
-        data = np.load(cache_file, allow_pickle=True)
-        return data["umap"]
+
+    def _umap_cache_is_stale(self, cache_file: Path) -> bool:
+        """Whether ``umap.npz`` is missing or older than the index it describes."""
+        return (
+            not cache_file.exists()
+            or cache_file.stat().st_mtime < self.embeddings_path.stat().st_mtime
+        )
 
     @property
     def indexes(self) -> dict[str, np.ndarray]:

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -124,11 +124,27 @@ def album_umap_coords(embeddings: Embeddings):
     map is opened on exactly that album while its first index runs. Letting
     the ``FileNotFoundError`` out turns that into a 500 on a screen the user
     is watching indexing progress from.
+
+    Blocking, and not always cheaply: ``umap_embeddings`` is a *rebuild* and
+    not a read whenever ``umap.npz`` is missing or older than
+    ``embeddings.npz``, which is the state any rewrite of the index leaves
+    behind (an image delete, an ``update_images`` run). Async callers must go
+    through :func:`album_umap_coords_async`.
     """
     try:
         return embeddings.umap_embeddings
     except FileNotFoundError:
         return None
+
+
+async def album_umap_coords_async(embeddings: Embeddings):
+    """:func:`album_umap_coords` off the event loop.
+
+    Note this cannot be spelled ``asyncio.to_thread(f, album_umap_coords(e))``
+    at the call site: the argument would be evaluated — and the UMAP possibly
+    refitted, for minutes — before the thread is ever spawned.
+    """
+    return await asyncio.to_thread(album_umap_coords, embeddings)
 
 
 def validate_image_access(album_config, image_path: Path) -> bool:
@@ -481,7 +497,7 @@ async def get_umap_eps(request: UmapEpsGetRequest):
     if album_config.umap_eps is not None:
         return {"success": True, "eps": album_config.umap_eps, "auto": False}
 
-    coords = album_umap_coords(get_embeddings_for_album(request.album))
+    coords = await album_umap_coords_async(get_embeddings_for_album(request.album))
     if coords is None or coords.shape[0] == 0:
         # Not indexed yet: nothing to derive from, and the map will be empty
         # regardless. The historical default keeps the spinner showing a

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -357,11 +357,15 @@ async def update_album(album_data: dict) -> JSONResponse:
             name=album_data["name"],
             image_paths=album_data.get("image_paths"),
             index=index,
-            # Omitted means "leave it derived" — see Album.umap_eps. The old
-            # 0.07 fallback materialized a number on every edit, so an album
-            # that had never had its Cluster Strength touched acquired one
-            # the moment anything else about it was saved.
-            umap_eps=album_data.get("umap_eps"),
+            # Omitted means "keep whatever the album already has", the same
+            # rule as index and the InvokeAI password above: the edit form
+            # has no Cluster Strength control and never sends this key, so
+            # anything else here loses the user's tuning the moment they
+            # rename the album. An explicit null is still a clear — that is
+            # how /set_umap_eps hands an album back to the derived value.
+            umap_eps=album_data.get(
+                "umap_eps", existing.umap_eps if existing else None
+            ),
             description=album_data.get("description", ""),
             encoder_spec=album_data.get("encoder_spec"),
             min_search_score=album_data.get("min_search_score"),

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import shutil
@@ -8,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from ..cluster_eps import FALLBACK_CLUSTER_EPS, cached_adaptive_cluster_eps
 from ..config import Album, create_album, default_board_index_path, get_config_manager
 from ..embeddings import Embeddings
 from ..encoders import default_encoder_spec
@@ -16,7 +18,11 @@ from ..video_cache import VideoFrameCache
 
 class UmapEpsSetRequest(BaseModel):
     album: str
-    eps: float
+    # None clears the album's stored Cluster Strength, putting it back to a
+    # value derived from the album's own coordinates. Without this the UI
+    # would be a one-way door: once a number is typed there is no way back
+    # to the derived value short of editing the config file.
+    eps: float | None = None
 
 
 class UmapEpsGetRequest(BaseModel):
@@ -108,6 +114,21 @@ def get_embeddings_for_album(album_key: str) -> Embeddings:
         min_image_bytes=album_config.min_image_bytes,
         album_key=album_key,
     )
+
+
+def album_umap_coords(embeddings: Embeddings):
+    """An album's cached UMAP coordinates, or ``None`` if it has no index yet.
+
+    Every eps-resolving endpoint needs these, and every one of them can be
+    called on an album that is configured but not yet indexed — the semantic
+    map is opened on exactly that album while its first index runs. Letting
+    the ``FileNotFoundError`` out turns that into a 500 on a screen the user
+    is watching indexing progress from.
+    """
+    try:
+        return embeddings.umap_embeddings
+    except FileNotFoundError:
+        return None
 
 
 def validate_image_access(album_config, image_path: Path) -> bool:
@@ -320,7 +341,11 @@ async def update_album(album_data: dict) -> JSONResponse:
             name=album_data["name"],
             image_paths=album_data.get("image_paths"),
             index=index,
-            umap_eps=album_data.get("umap_eps", 0.07),
+            # Omitted means "leave it derived" — see Album.umap_eps. The old
+            # 0.07 fallback materialized a number on every edit, so an album
+            # that had never had its Cluster Strength touched acquired one
+            # the moment anything else about it was saved.
+            umap_eps=album_data.get("umap_eps"),
             description=album_data.get("description", ""),
             encoder_spec=album_data.get("encoder_spec"),
             min_search_score=album_data.get("min_search_score"),
@@ -420,6 +445,11 @@ async def set_locationiq_key(request: LocationIQSetRequest):
     "/set_umap_eps/", tags=["Albums"], dependencies=[Depends(require_no_lock)]
 )
 async def set_umap_eps(request: UmapEpsSetRequest):
+    """Store an album's Cluster Strength, or clear it back to derived.
+
+    ``eps: null`` is the clear: the album stops carrying a number and
+    ``/get_umap_eps`` starts deriving one again.
+    """
     album_config = config_manager.get_album(request.album)
     if not album_config:
         raise HTTPException(status_code=404, detail="Album not found")
@@ -430,10 +460,39 @@ async def set_umap_eps(request: UmapEpsSetRequest):
 
 @album_router.post("/get_umap_eps/", tags=["Albums"])
 async def get_umap_eps(request: UmapEpsGetRequest):
+    """The Cluster Strength value the semantic map should show for an album.
+
+    Returns a number either way, plus ``auto`` saying where it came from: a
+    stored ``umap_eps`` (the user has tuned this album) or one derived from
+    the album's UMAP coordinates. The frontend fills its spinner from this
+    and then passes the number explicitly to ``/umap_data`` and
+    ``/cluster_labels``, so all three agree on the clustering without either
+    of those endpoints having to resolve it a second time.
+
+    Deriving costs a k-distance pass plus a handful of DBSCAN fits — seconds
+    on a six-figure album — so it runs in a thread and is memoized on disk
+    against the coordinates it was computed from.
+    """
     check_album_lock(request.album)  # May raise a 403 exception
     album_config = config_manager.get_album(request.album)
     if not album_config:
         raise HTTPException(status_code=404, detail="Album not found")
-    return {"success": True, "eps": album_config.umap_eps}
+
+    if album_config.umap_eps is not None:
+        return {"success": True, "eps": album_config.umap_eps, "auto": False}
+
+    coords = album_umap_coords(get_embeddings_for_album(request.album))
+    if coords is None or coords.shape[0] == 0:
+        # Not indexed yet: nothing to derive from, and the map will be empty
+        # regardless. The historical default keeps the spinner showing a
+        # usable number rather than blank.
+        return {"success": True, "eps": FALLBACK_CLUSTER_EPS, "auto": True}
+
+    eps = await asyncio.to_thread(
+        cached_adaptive_cluster_eps,
+        coords,
+        Path(album_config.index).parent,
+    )
+    return {"success": True, "eps": eps, "auto": True}
 
 

--- a/photomap/backend/routers/cluster_labels.py
+++ b/photomap/backend/routers/cluster_labels.py
@@ -17,7 +17,7 @@ from fastapi.responses import JSONResponse
 
 from ..cluster_eps import resolve_album_cluster_eps
 from ..cluster_labels import compute_image_label, get_or_build_cluster_labels
-from .album import AlbumDep, EmbeddingsDep, album_umap_coords
+from .album import AlbumDep, EmbeddingsDep, album_umap_coords_async
 
 cluster_labels_router = APIRouter()
 
@@ -54,10 +54,14 @@ async def get_cluster_labels(
     # endpoints diverge and the hover-label feature breaks.
     # In a thread for the same reason the label build below is: deriving an
     # eps runs several DBSCAN fits, which is seconds of CPU on a large album
-    # and would otherwise hold the event loop.
+    # and would otherwise hold the event loop. Loading the coordinates is
+    # awaited separately rather than passed as an argument here — an argument
+    # is evaluated *before* the thread is spawned, and loading them can mean
+    # refitting UMAP outright (see album_umap_coords).
+    coords = await album_umap_coords_async(embeddings)
     cluster_eps = await asyncio.to_thread(
         resolve_album_cluster_eps,
-        album_umap_coords(embeddings),
+        coords,
         Path(album_config.index).parent,
         cluster_eps,
         album_config.umap_eps,

--- a/photomap/backend/routers/cluster_labels.py
+++ b/photomap/backend/routers/cluster_labels.py
@@ -10,12 +10,14 @@ exactly so cluster IDs returned here match cluster IDs returned by
 """
 
 import asyncio
+from pathlib import Path
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
+from ..cluster_eps import resolve_album_cluster_eps
 from ..cluster_labels import compute_image_label, get_or_build_cluster_labels
-from .album import AlbumDep, EmbeddingsDep
+from .album import AlbumDep, EmbeddingsDep, album_umap_coords
 
 cluster_labels_router = APIRouter()
 
@@ -34,7 +36,8 @@ async def get_cluster_labels(
     Args:
         album_key: Album to label.
         cluster_eps: DBSCAN epsilon. Omit (or send ``None``) to use the
-            album's persisted ``umap_eps`` — the same resolution
+            album's persisted ``umap_eps``, or a value derived from its
+            coordinates when that has never been set — the same resolution
             ``/umap_data`` uses, so cluster IDs align between the two
             endpoints.
         cluster_min_samples: DBSCAN min_samples. Same constraint.
@@ -45,11 +48,21 @@ async def get_cluster_labels(
         `{"labels": {"<cluster_id>": {"label": str, "alternates": [str, ...],
         "score": float}, ...}}`. Cluster `-1` (DBSCAN noise) is omitted.
     """
-    # Mirror ``routers/umap.py``'s eps fallback so ``/cluster_labels`` and
-    # ``/umap_data`` resolve to the same value for the same request.
-    # If they disagree, the cluster IDs returned by the two endpoints
-    # diverge and the hover-label feature breaks.
-    cluster_eps = cluster_eps if cluster_eps is not None else album_config.umap_eps
+    # Resolve through the same helper ``routers/umap.py`` uses, against the
+    # same coordinates, so ``/cluster_labels`` and ``/umap_data`` agree for
+    # a given request. If they disagree the cluster IDs returned by the two
+    # endpoints diverge and the hover-label feature breaks.
+    # In a thread for the same reason the label build below is: deriving an
+    # eps runs several DBSCAN fits, which is seconds of CPU on a large album
+    # and would otherwise hold the event loop.
+    cluster_eps = await asyncio.to_thread(
+        resolve_album_cluster_eps,
+        album_umap_coords(embeddings),
+        Path(album_config.index).parent,
+        cluster_eps,
+        album_config.umap_eps,
+        cluster_min_samples,
+    )
     labels = await asyncio.to_thread(
         get_or_build_cluster_labels,
         embeddings,

--- a/photomap/backend/routers/umap.py
+++ b/photomap/backend/routers/umap.py
@@ -1,5 +1,6 @@
 # UMAP Routes
 
+import asyncio
 from pathlib import Path
 
 import numpy as np
@@ -7,6 +8,7 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from sklearn.cluster import DBSCAN
 
+from ..cluster_eps import resolve_album_cluster_eps
 from ..config import get_config_manager
 from ..media_types import media_type_for
 from .album import AlbumDep, EmbeddingsDep
@@ -29,24 +31,33 @@ async def get_umap_data(
     Args:
         album_key: The key of the album to retrieve data for.
         cluster_eps: Epsilon parameter for DBSCAN clustering. Omit (or send
-            ``None``) to use the album's persisted ``umap_eps`` from YAML.
+            ``None``) to use the album's persisted ``umap_eps``, or — when
+            that has never been set — a value derived from the album's own
+            coordinates.
         cluster_min_samples: Min samples parameter for DBSCAN clustering.
 
     Returns:
         JSONResponse containing a list of points with x, y, index, and cluster ID.
     """
-    # When the caller doesn't override eps, fall back to the album's
-    # persisted ``umap_eps``. This used to be dead code: the parameter
-    # defaulted to ``0.07``, so ``cluster_eps is not None`` was always
-    # true and ``album_config.umap_eps`` was silently ignored. The
-    # corresponding parameter on ``/cluster_labels`` is kept in lockstep
-    # so the two endpoints resolve identical eps values for the same
-    # request — otherwise the cluster IDs they return would disagree
-    # and the hover-label feature would break.
-    cluster_eps = cluster_eps if cluster_eps is not None else album_config.umap_eps
-
     # Load cached UMAP embeddings (will compute/cache if missing)
     umap_embeddings = embeddings.umap_embeddings
+
+    # Resolve eps against the coordinates: query parameter, else the album's
+    # persisted value, else derived. ``/cluster_labels`` resolves through the
+    # same helper for the same request — if the two disagree, the cluster ids
+    # they return refer to different clusterings and the hover labels attach
+    # to the wrong blobs.
+    # Threaded: deriving an eps runs several DBSCAN fits, seconds of CPU on a
+    # large album, and this endpoint is fetched while the map is opening.
+    cluster_eps = await asyncio.to_thread(
+        resolve_album_cluster_eps,
+        umap_embeddings,
+        Path(album_config.index).parent,
+        cluster_eps,
+        album_config.umap_eps,
+        cluster_min_samples,
+    )
+
     embeddings = embeddings.open_cached_embeddings(embeddings.embeddings_path)
     filenames = embeddings["filenames"]
     filename_map = embeddings["filename_map"]

--- a/photomap/backend/routers/umap.py
+++ b/photomap/backend/routers/umap.py
@@ -39,8 +39,12 @@ async def get_umap_data(
     Returns:
         JSONResponse containing a list of points with x, y, index, and cluster ID.
     """
-    # Load cached UMAP embeddings (will compute/cache if missing)
-    umap_embeddings = embeddings.umap_embeddings
+    # Load cached UMAP embeddings (will compute/cache if missing). Threaded
+    # because "compute if missing" is a full UMAP fit, which is minutes on a
+    # large album: the map is fetched in parallel with /cluster_labels, so
+    # leaving this one on the event loop would stall the server no matter what
+    # the other endpoint does.
+    umap_embeddings = await asyncio.to_thread(lambda: embeddings.umap_embeddings)
 
     # Resolve eps against the coordinates: query parameter, else the album's
     # persisted value, else derived. ``/cluster_labels`` resolves through the

--- a/photomap/backend/util.py
+++ b/photomap/backend/util.py
@@ -83,13 +83,21 @@ class BoundedLRU(Generic[K, V]):
 def atomic_savez(path: Path, **arrays: Any) -> None:
     """Write a ``.npz`` archive to ``path`` atomically.
 
-    Writes to a sibling ``<name>.tmp`` and then ``Path.replace``s into place,
-    so a crash or concurrent reader never sees a half-written file. Callers
-    that previously called ``np.savez(path, ...)`` directly risked leaving a
+    Writes to a sibling temp file and then ``Path.replace``s into place, so a
+    crash or concurrent reader never sees a half-written file. Callers that
+    previously called ``np.savez(path, ...)`` directly risked leaving a
     truncated index that the next read would fail to load.
+
+    The temp name carries the pid and thread id rather than being a fixed
+    ``<name>.tmp``: two threads writing the same target would otherwise open
+    the *same* temp file, interleave their writes, and rename a corrupt
+    archive into place — which, for a cache whose freshness is judged by
+    mtime, is a permanently poisoned file rather than a transient error.
+    Concurrent writers of one path now simply race to rename, and the winner's
+    file is whole.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
         with tmp_path.open("wb") as fh:
             np.savez(fh, **arrays)

--- a/photomap/frontend/static/css/umap-floating-window.css
+++ b/photomap/frontend/static/css/umap-floating-window.css
@@ -248,6 +248,26 @@
   outline: none;
 }
 
+/* Marks a Cluster Strength the map derived rather than one the user chose.
+   Deliberately quiet — it explains the number in the spinner, it is not a
+   control. `hidden` is honored explicitly because the flex display on the
+   surrounding row would otherwise override it. */
+.umap-eps-auto-badge {
+  margin-left: 4px;
+  padding: 0 5px;
+  border: 1px solid #4a9eff;
+  border-radius: 8px;
+  color: #80c0ff;
+  font-size: 0.7em;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  vertical-align: middle;
+}
+
+.umap-eps-auto-badge[hidden] {
+  display: none;
+}
+
 #umapClickBehaviorContainer,
 #umapMediaFilterContainer {
   font-size: 0.85em;

--- a/photomap/frontend/static/javascript/album-manager.js
+++ b/photomap/frontend/static/javascript/album-manager.js
@@ -1170,7 +1170,10 @@ export class AlbumManager {
       newAlbum = {
         key: formData.key,
         name: formData.name,
-        umap_eps: 0.1,
+        // umap_eps is deliberately omitted: the semantic map derives a
+        // Cluster Strength from the album's own coordinates until the user
+        // sets one. A number sent here would be that setting, and a fixed
+        // one leaves small albums with no clusters at all.
         description: formData.description,
         encoder_spec: formData.encoder_spec,
         source_type: "invokeai_board",
@@ -1192,7 +1195,7 @@ export class AlbumManager {
         name: formData.name,
         image_paths: paths,
         index: indexPath,
-        umap_eps: 0.1,
+        // Omitted for the same reason as the board branch above.
         description: formData.description,
         encoder_spec: formData.encoder_spec,
       };

--- a/photomap/frontend/static/javascript/bookmarks.js
+++ b/photomap/frontend/static/javascript/bookmarks.js
@@ -869,7 +869,10 @@ class BookmarkManager {
           name: albumConfig.name,
           image_paths: updatedPaths,
           index: albumConfig.index,
-          umap_eps: albumConfig.umap_eps || 0.07,
+          // `?? null` rather than `|| 0.07`: an album whose Cluster Strength
+          // has never been set carries null, and adding a folder to it must
+          // not quietly pin it to a number.
+          umap_eps: albumConfig.umap_eps ?? null,
           description: albumConfig.description || "",
         },
       });

--- a/photomap/frontend/static/javascript/settings.js
+++ b/photomap/frontend/static/javascript/settings.js
@@ -97,7 +97,9 @@ function populateAlbumOptions(albums) {
     option.value = album.key;
     option.textContent = album.name;
     option.dataset.embeddingsFile = album.embeddings_file; // Store embeddings path
-    option.dataset.umapEps = album.umap_eps || 0.07; // Store EPS
+    // Empty when the album has no stored Cluster Strength — the semantic map
+    // asks the server for a derived one rather than assuming a number here.
+    option.dataset.umapEps = album.umap_eps ?? "";
     elements.albumSelect.appendChild(option);
   });
 }

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -273,6 +273,10 @@ document.getElementById("umapEpsSpinner").oninput = async () => {
     clearTimeout(epsUpdateTimer);
   }
   epsUpdateTimer = setTimeout(async () => {
+    // Cleared as the save starts, not left holding a fired timer's handle:
+    // it is what tells the rest of the module an edit is still pending, and
+    // a stale handle would read as "forever mid-edit" after the first edit.
+    epsUpdateTimer = null;
     await fetch("set_umap_eps/", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -295,20 +299,37 @@ function readSpinnerEps() {
   return raw === "" ? null : parseFloat(raw);
 }
 
-// Ask the server what this album's Cluster Strength resolves to and show it.
-async function refreshResolvedEps() {
+// Whether the semantic map is on screen. Worth re-checking after any await:
+// rendering Plotly into a hidden container leaves a plot nobody asked for and
+// consumes the dataChanged flag the next open relies on to redraw.
+function umapWindowIsOpen() {
+  return document.getElementById("umapFloatingWindow")?.style.display === "block";
+}
+
+// Ask the server what an album's Cluster Strength resolves to and show it.
+// Returns whether the spinner now holds that album's resolved value.
+//
+// The album is pinned for the round-trip rather than read from `state` on the
+// way back: resolving can mean deriving, which on a large album is seconds to
+// minutes, and the user is free to switch albums while it runs. Writing a
+// late reply into the shared spinner would show one album's number — and its
+// auto badge — against another album's map.
+async function refreshResolvedEps(albumKey = state.album) {
   try {
     const response = await fetch("get_umap_eps/", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ album: state.album }),
+      body: JSON.stringify({ album: albumKey }),
     });
     const data = await response.json();
-    if (data.success) {
-      applyResolvedEps(data);
+    if (!data.success || state.album !== albumKey) {
+      return false;
     }
+    applyResolvedEps(data);
+    return true;
   } catch (err) {
     console.warn("Could not fetch the resolved cluster strength:", err);
+    return false;
   }
 }
 
@@ -2263,21 +2284,41 @@ document.addEventListener("DOMContentLoaded", () => {
 // is showing; otherwise the dataChanged flag makes toggleUmapWindow's show
 // path refetch, without rendering Plotly into a hidden container here.
 window.addEventListener("albumIndexUpdated", async (e) => {
-  if (e.detail?.albumKey === state.album) {
-    state.dataChanged = true;
-    const umapWindow = document.getElementById("umapFloatingWindow");
-    if (umapWindow?.style.display === "block") {
-      // Re-resolve the strength before redrawing. New coordinates invalidate
-      // a derived one (the server keys its memo on them), and fetchUmapData
-      // sends whatever the spinner holds — so skipping this clusters the new
-      // map at the old album's number while the badge still reads "auto".
-      // The album that was empty when the map opened is the case that bites:
-      // its spinner holds the not-indexed-yet fallback, which is exactly the
-      // fixed value that leaves a small album with no clusters at all.
-      await refreshResolvedEps();
-      fetchUmapData();
-    }
+  const albumKey = state.album;
+  if (e.detail?.albumKey !== albumKey) {
+    return;
   }
+  state.dataChanged = true;
+  if (!umapWindowIsOpen()) {
+    return;
+  }
+  // Re-resolve the strength before redrawing. New coordinates invalidate a
+  // derived one (the server keys its memo on them), and fetchUmapData sends
+  // whatever the spinner holds — so skipping this clusters the new map at the
+  // old number while the badge still reads "auto". The album that was empty
+  // when the map opened is the case that bites: its spinner holds the
+  // not-indexed-yet fallback, exactly the kind of fixed value that leaves a
+  // small album with no clusters at all.
+  //
+  // Skipped while an edit is pending: the spinner belongs to whoever is
+  // typing in it, and the number they are mid-way through is about to become
+  // a stored one that no derived value can override. The debounce redraws
+  // against the new coordinates a moment later anyway.
+  if (epsUpdateTimer === null && !(await refreshResolvedEps(albumKey))) {
+    console.warn("Redrawing the semantic map with the previous cluster strength.");
+  }
+  // Re-check rather than trust the checks above: resolving is a round-trip
+  // that can take minutes on a large album, and the user is free to switch
+  // albums or close the window while it runs.
+  if (state.album !== albumKey || !umapWindowIsOpen()) {
+    return;
+  }
+  // Re-arm rather than rely on the flag set before the await: any redraw that
+  // completed during it (a debounced save, an album switch) has since cleared
+  // the flag, and fetchUmapData would silently no-op on the one redraw this
+  // listener exists to guarantee.
+  state.dataChanged = true;
+  await fetchUmapData();
 });
 window.addEventListener("albumChanged", (e) => {
   // A "refresh" is the same album re-indexed in place: the map reload is

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -2262,11 +2262,19 @@ document.addEventListener("DOMContentLoaded", () => {
 // Album Management): the map data is stale. Reload right away if the window
 // is showing; otherwise the dataChanged flag makes toggleUmapWindow's show
 // path refetch, without rendering Plotly into a hidden container here.
-window.addEventListener("albumIndexUpdated", (e) => {
+window.addEventListener("albumIndexUpdated", async (e) => {
   if (e.detail?.albumKey === state.album) {
     state.dataChanged = true;
     const umapWindow = document.getElementById("umapFloatingWindow");
     if (umapWindow?.style.display === "block") {
+      // Re-resolve the strength before redrawing. New coordinates invalidate
+      // a derived one (the server keys its memo on them), and fetchUmapData
+      // sends whatever the spinner holds — so skipping this clusters the new
+      // map at the old album's number while the badge still reads "auto".
+      // The album that was empty when the map opened is the case that bites:
+      // its spinner holds the not-indexed-yet fallback, which is exactly the
+      // fixed value that leaves a small album with no clusters at all.
+      await refreshResolvedEps();
       fetchUmapData();
     }
   }

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -233,10 +233,42 @@ function hideUmapSpinner() {
   document.getElementById("umapSpinner").style.display = "none";
 }
 
+// Fill the Cluster Strength spinner from what the server resolved for this
+// album, and mark whether that value was derived or is the user's own.
+// Exported for the tests; every caller that loads an album goes through it so
+// the badge can never disagree with the number beside it.
+export function applyResolvedEps(data) {
+  const epsSpinner = document.getElementById("umapEpsSpinner");
+  if (epsSpinner && typeof data?.eps === "number") {
+    epsSpinner.value = data.eps;
+  }
+  setEpsAutoBadge(Boolean(data?.auto));
+}
+
+function setEpsAutoBadge(isAuto) {
+  const badge = document.getElementById("umapEpsAutoBadge");
+  if (badge) {
+    badge.hidden = !isAuto;
+  }
+}
+
 // --- EPS Spinner Debounce ---
 let epsUpdateTimer = null;
 document.getElementById("umapEpsSpinner").oninput = async () => {
-  const eps = parseFloat(document.getElementById("umapEpsSpinner").value) || 0.07;
+  // An empty field means "go back to deriving it" — otherwise the only way
+  // out of a value you typed once would be to edit the config file. null is
+  // sent verbatim; a numeric fallback here is what used to pin every album
+  // to 0.07 the moment the field was cleared.
+  const eps = readSpinnerEps();
+  if (eps !== null && Number.isNaN(eps)) {
+    return; // mid-typing garbage ("-", "0.") — wait for something parseable
+  }
+  // Typing a number is what turns a derived strength into a chosen one, so
+  // the badge goes immediately rather than after the debounced save. Clearing
+  // the field keeps it until the derived value comes back below.
+  if (eps !== null) {
+    setEpsAutoBadge(false);
+  }
   if (epsUpdateTimer) {
     clearTimeout(epsUpdateTimer);
   }
@@ -246,10 +278,39 @@ document.getElementById("umapEpsSpinner").oninput = async () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ album: state.album, eps }),
     });
+    if (eps === null) {
+      // Put the derived number back in the field before redrawing, so the
+      // map is fetched with the value the user can actually see.
+      await refreshResolvedEps();
+    }
     state.dataChanged = true;
     await fetchUmapData();
   }, 1000);
 };
+
+// The spinner's value as a number, or null when the field is empty.
+// NaN means the field holds something not yet parseable.
+function readSpinnerEps() {
+  const raw = document.getElementById("umapEpsSpinner").value.trim();
+  return raw === "" ? null : parseFloat(raw);
+}
+
+// Ask the server what this album's Cluster Strength resolves to and show it.
+async function refreshResolvedEps() {
+  try {
+    const response = await fetch("get_umap_eps/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ album: state.album }),
+    });
+    const data = await response.json();
+    if (data.success) {
+      applyResolvedEps(data);
+    }
+  } catch (err) {
+    console.warn("Could not fetch the resolved cluster strength:", err);
+  }
+}
 
 // --- Main UMAP Data Fetch and Plot ---
 export async function fetchUmapData() {
@@ -261,7 +322,11 @@ export async function fetchUmapData() {
   }
   showUmapSpinner();
   try {
-    const eps = parseFloat(document.getElementById("umapEpsSpinner").value) || 0.07;
+    // Omitted from the query entirely when the field is empty, so the server
+    // derives the strength. Substituting a number here would quietly cluster
+    // at something the user never chose and the spinner never showed.
+    const eps = readSpinnerEps();
+    const epsQuery = eps !== null && !Number.isNaN(eps) ? `?cluster_eps=${eps}` : "";
     const album = encodeURIComponent(state.album);
     // Fetch UMAP data and cluster labels in parallel. Labels are best-effort:
     // a failure leaves clusterLabels empty and the hover popup falls back to
@@ -274,16 +339,13 @@ export async function fetchUmapData() {
     // waiting more than a few seconds, so the UI doesn't look frozen.
     const labelsPromise = state.autotaggingEnabled
       ? trackVocabBuildRequest(
-          fetch(`cluster_labels/${album}?cluster_eps=${eps}`).catch((err) => {
+          fetch(`cluster_labels/${album}${epsQuery}`).catch((err) => {
             console.warn("Cluster labels fetch failed:", err);
             return null;
           })
         )
       : Promise.resolve(null);
-    const [response, labelsResponse] = await Promise.all([
-      fetch(`umap_data/${album}?cluster_eps=${eps}`),
-      labelsPromise,
-    ]);
+    const [response, labelsResponse] = await Promise.all([fetch(`umap_data/${album}${epsQuery}`), labelsPromise]);
     points = await response.json();
     if (labelsResponse?.ok) {
       try {
@@ -1123,10 +1185,7 @@ async function initializeUmapWindow() {
   });
   const data = await result.json();
   if (data.success) {
-    const epsSpinner = document.getElementById("umapEpsSpinner");
-    if (epsSpinner) {
-      epsSpinner.value = data.eps;
-    }
+    applyResolvedEps(data);
   }
   state.dataChanged = true;
   lastUnshadedSize = "medium"; // Reset to medium on album change
@@ -1788,10 +1847,7 @@ export async function toggleUmapWindow(show = null) {
       console.error("Failed to fetch UMAP EPS value:", data.message);
       return;
     }
-    const epsSpinner = document.getElementById("umapEpsSpinner");
-    if (epsSpinner) {
-      epsSpinner.value = data.eps;
-    }
+    applyResolvedEps(data);
     await fetchUmapData();
   }
 }

--- a/photomap/frontend/templates/modules/umap-floating-window.html
+++ b/photomap/frontend/templates/modules/umap-floating-window.html
@@ -183,16 +183,24 @@
           <div id="umapEpsContainer" style="display: none; padding: 0px">
             <button id="umapClusterInfoBtn" type="button" class="umap-info-btn" title="Cluster information">i</button>
             <label for="umapEpsSpinner">Cluster Strength</label>
+            <!-- max was 1.0, but a derived strength for a small album can
+                 legitimately exceed it: UMAP spreads few points over a wide
+                 area, so the distances that separate clusters are larger.
+                 A lower ceiling would display a number the map is not
+                 actually clustering with. -->
             <input
               type="number"
               id="umapEpsSpinner"
               min="0.01"
-              max="1.0"
+              max="3.0"
               step="0.01"
               value="0.1"
               autocomplete="off"
               style="width: 60px"
             />
+            <!-- Shown while the strength is derived rather than chosen;
+                 umap.js clears it as soon as the user edits the spinner. -->
+            <span id="umapEpsAutoBadge" class="umap-eps-auto-badge" hidden>auto</span>
           </div>
           <div id="umapClickBehaviorContainer" style="display: flex; flex-direction: row; gap: 12px;">
             <label style="display: flex; align-items: center; gap: 6px;">

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -152,7 +152,9 @@ def test_album_routes(client):
     assert response.json() == {"success": True, "eps": 0.50}
     response = client.post("/get_umap_eps", json={"album": album.key})
     assert response.status_code == 200
-    assert response.json() == {"success": True, "eps": 0.50}
+    # ``auto`` false: the value was stored by the caller above, not derived
+    # from the album's coordinates.
+    assert response.json() == {"success": True, "eps": 0.50, "auto": False}
 
     # Check that we can delete the album
     response = client.delete(f"/delete_album/{album.key}")

--- a/tests/backend/test_cluster_eps.py
+++ b/tests/backend/test_cluster_eps.py
@@ -1,0 +1,227 @@
+"""Tests for the adaptive DBSCAN epsilon.
+
+The fixtures are synthetic point clouds rather than real UMAP output, because
+what the rule has to get right is a *shape*: well-separated blobs must
+cluster, a structureless cloud must not collapse into one blob, and the scale
+of the coordinates must not matter — which is the whole reason a fixed eps
+fails on small albums.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from sklearn.cluster import DBSCAN
+
+from photomap.backend.cluster_eps import (
+    CANDIDATE_QUANTILES,
+    DEFAULT_CLUSTER_MIN_SAMPLES,
+    FALLBACK_CLUSTER_EPS,
+    MAX_EPS_SPAN_FRACTION,
+    MAX_NEIGHBOR_PAIRS,
+    MAX_TOP_CLUSTER_SHARE,
+    MIN_CLUSTER_EPS,
+    _k_distances,
+    adaptive_cluster_eps,
+    cached_adaptive_cluster_eps,
+    resolve_album_cluster_eps,
+    resolve_cluster_eps,
+)
+
+
+def blobs(n_per_blob=40, n_blobs=5, spread=0.15, scale=1.0, seed=0):
+    """``n_blobs`` tight gaussian blobs on a circle of radius ``scale``."""
+    rng = np.random.default_rng(seed)
+    angles = np.linspace(0, 2 * np.pi, n_blobs, endpoint=False)
+    centers = np.stack([np.cos(angles), np.sin(angles)], axis=1) * scale
+    points = [c + rng.normal(0, spread * scale, size=(n_per_blob, 2)) for c in centers]
+    return np.vstack(points).astype(np.float32)
+
+
+def cluster_stats(coords, eps, min_samples=DEFAULT_CLUSTER_MIN_SAMPLES):
+    labels = DBSCAN(eps=eps, min_samples=min_samples).fit(coords).labels_
+    clustered = labels[labels != -1]
+    top = float(np.bincount(clustered).max()) / labels.size if clustered.size else 0.0
+    return len(set(clustered.tolist())), float((labels == -1).mean()), top
+
+
+def test_finds_the_blobs():
+    coords = blobs()
+    n_clusters, noise, _ = cluster_stats(coords, adaptive_cluster_eps(coords))
+    assert n_clusters == 5
+    assert noise < 0.2
+
+
+def test_is_scale_invariant():
+    """The same shape at 100x the coordinate span must cluster the same way.
+
+    This is the property a fixed eps lacks and the reason small albums broke:
+    UMAP's output scale depends on the point count, so an eps tuned on one
+    album is meaningless on another.
+    """
+    small = blobs(scale=1.0)
+    large = blobs(scale=100.0)
+
+    eps_small = adaptive_cluster_eps(small)
+    eps_large = adaptive_cluster_eps(large)
+
+    assert cluster_stats(small, eps_small)[0] == cluster_stats(large, eps_large)[0] == 5
+    # Scaling the coordinates scales the chosen eps by the same factor.
+    assert eps_large == pytest.approx(eps_small * 100, rel=0.05)
+
+
+def test_a_tiny_album_still_clusters():
+    """The failure this feature exists to fix: 200-odd points, where a fixed
+    0.07 produced zero clusters and 100% noise."""
+    coords = blobs(n_per_blob=40, n_blobs=5, scale=8.0)
+    assert cluster_stats(coords, 0.07)[0] == 0  # the old fixed default
+
+    n_clusters, noise, _ = cluster_stats(coords, adaptive_cluster_eps(coords))
+    assert n_clusters > 1
+    assert noise < 0.3
+
+
+def test_stops_before_one_cluster_swallows_the_map():
+    """On a map with structure, the scan stops climbing while the biggest
+    cluster is still a cluster rather than a blob."""
+    coords = blobs(n_per_blob=80, n_blobs=6, spread=0.08)
+    _, _, top = cluster_stats(coords, adaptive_cluster_eps(coords))
+    assert top <= MAX_TOP_CLUSTER_SHARE + 0.01
+
+
+def test_structureless_cloud_does_not_climb():
+    """A single gaussian cloud has nothing to separate, so every candidate is
+    over the share cap. The documented fallback is the *smallest* candidate:
+    climbing would only merge the map faster, and going lower just converts
+    the blob into noise without revealing anything."""
+    rng = np.random.default_rng(1)
+    coords = rng.normal(0, 1, size=(600, 2)).astype(np.float32)
+
+    distances = _k_distances(coords, DEFAULT_CLUSTER_MIN_SAMPLES)
+    smallest_candidate = float(np.percentile(distances, CANDIDATE_QUANTILES[0]))
+
+    assert adaptive_cluster_eps(coords) == pytest.approx(smallest_candidate)
+
+
+def test_degenerate_inputs_fall_back_rather_than_raise():
+    # Fewer points than min_samples: no k-distance exists.
+    assert adaptive_cluster_eps(np.zeros((3, 2), dtype=np.float32)) == FALLBACK_CLUSTER_EPS
+    # Every point identical: every k-distance is 0, and eps=0 clusters nothing.
+    assert adaptive_cluster_eps(np.ones((50, 2), dtype=np.float32)) == FALLBACK_CLUSTER_EPS
+    assert adaptive_cluster_eps(np.empty((0, 2), dtype=np.float32)) == FALLBACK_CLUSTER_EPS
+
+
+# ---------------------------------------------------------------------------
+# resolve_cluster_eps: which clamps apply to which values
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_eps_is_not_span_clamped():
+    """A number the user typed is theirs to keep.
+
+    The span clamp would silently retune a stored Cluster Strength on a small
+    album — 0.9 on a 50-point map becomes 0.33 — which makes the control lie
+    about what it does. It applies to derived values only.
+    """
+    coords = blobs(n_per_blob=10, n_blobs=5, scale=1.0)  # span ~2
+    assert resolve_cluster_eps(coords, 0.9) == pytest.approx(0.9)
+
+
+def test_derived_eps_is_span_clamped():
+    """Sparse enough that the derived eps would otherwise span a quarter of
+    the map — which is the "no structure here" case the clamp is for."""
+    rng = np.random.default_rng(3)
+    coords = rng.uniform(0, 1, size=(30, 2)).astype(np.float32)
+    span = float(np.ptp(coords, axis=0).max())
+
+    assert adaptive_cluster_eps(coords) > span * MAX_EPS_SPAN_FRACTION
+    assert resolve_cluster_eps(coords, None) == pytest.approx(span * MAX_EPS_SPAN_FRACTION)
+
+
+def test_span_clamp_leaves_a_well_structured_map_alone():
+    """The clamp is a bound on absurdity, not a second opinion: on a map with
+    real clusters it must not override what the scan chose."""
+    coords = blobs(n_per_blob=60)
+    assert resolve_cluster_eps(coords, None) == pytest.approx(adaptive_cluster_eps(coords))
+
+
+def test_resolved_eps_never_goes_below_the_ui_floor():
+    coords = blobs()
+    assert resolve_cluster_eps(coords, 0.0) >= MIN_CLUSTER_EPS
+
+
+def test_pair_budget_shrinks_an_absurd_eps():
+    """The guard the Cluster Strength control needs: asking for a radius that
+    covers the whole map is an out-of-memory crash on a large album, not a
+    slow response."""
+    rng = np.random.default_rng(2)
+    coords = rng.normal(0, 1, size=(12_000, 2)).astype(np.float32)
+
+    from sklearn.neighbors import KDTree
+
+    resolved = resolve_cluster_eps(coords, 50.0)  # every point sees every other
+    pairs = int(KDTree(coords).query_radius(coords, r=resolved, count_only=True).sum())
+
+    assert resolved < 50.0
+    assert pairs <= MAX_NEIGHBOR_PAIRS
+
+
+def test_pair_budget_leaves_a_reasonable_eps_alone():
+    coords = blobs()
+    assert resolve_cluster_eps(coords, 0.3) == pytest.approx(0.3)
+
+
+# ---------------------------------------------------------------------------
+# Album-level resolution and caching
+# ---------------------------------------------------------------------------
+
+
+def test_requested_beats_stored_beats_derived(tmp_path):
+    coords = blobs()
+    derived = resolve_album_cluster_eps(coords, tmp_path)
+
+    assert resolve_album_cluster_eps(coords, tmp_path, requested=0.3) == pytest.approx(0.3)
+    assert resolve_album_cluster_eps(coords, tmp_path, stored=0.4) == pytest.approx(0.4)
+    assert resolve_album_cluster_eps(coords, tmp_path, requested=0.3, stored=0.4) == pytest.approx(0.3)
+    assert resolve_album_cluster_eps(coords, tmp_path) == pytest.approx(derived)
+
+
+def test_derived_value_is_cached_on_disk(tmp_path, monkeypatch):
+    coords = blobs()
+    first = cached_adaptive_cluster_eps(coords, tmp_path)
+    assert (tmp_path / "umap_eps_auto.npz").exists()
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("recomputed despite a warm cache")
+
+    monkeypatch.setattr("photomap.backend.cluster_eps.resolve_cluster_eps", _boom)
+    assert cached_adaptive_cluster_eps(coords, tmp_path) == pytest.approx(first)
+
+
+def test_cache_is_keyed_on_the_coordinates(tmp_path):
+    """A re-index writes new coordinates to the same path. Serving the old
+    value would cluster the new map at the old scale."""
+    first = cached_adaptive_cluster_eps(blobs(scale=1.0), tmp_path)
+    second = cached_adaptive_cluster_eps(blobs(scale=50.0), tmp_path)
+    assert second != pytest.approx(first)
+
+
+def test_cache_is_keyed_on_min_samples(tmp_path):
+    coords = blobs(n_per_blob=60)
+    assert cached_adaptive_cluster_eps(coords, tmp_path, min_samples=5) != pytest.approx(
+        cached_adaptive_cluster_eps(coords, tmp_path, min_samples=25)
+    )
+
+
+def test_unreadable_cache_is_ignored_not_fatal(tmp_path):
+    (tmp_path / "umap_eps_auto.npz").write_bytes(b"not an npz")
+    assert cached_adaptive_cluster_eps(blobs(), tmp_path) > 0
+
+
+def test_unwritable_cache_dir_still_returns_a_value(tmp_path, monkeypatch):
+    """Caching is an optimization; losing it must not lose the feature."""
+    monkeypatch.setattr(
+        "photomap.backend.cluster_eps.atomic_savez",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")),
+    )
+    assert cached_adaptive_cluster_eps(blobs(), Path(tmp_path)) > 0

--- a/tests/backend/test_cluster_eps_router.py
+++ b/tests/backend/test_cluster_eps_router.py
@@ -338,3 +338,31 @@ def test_an_explicit_null_in_an_update_still_clears(client, new_album):
     assert response.status_code == 200
 
     assert get_config_manager().get_album(key).umap_eps is None
+
+
+def test_a_failed_set_umap_eps_does_not_come_back_later(client, new_album, monkeypatch):
+    """A write the user was told had failed must not become durable.
+
+    `set_umap_eps` mutates the Album object the config manager has cached, so
+    a save that raises leaves the cache holding a value that is not on disk.
+    The next unrelated edit reads that value forward — and now that an
+    omitted `umap_eps` means "keep what is stored", it gets written out.
+    """
+    key = new_album["key"]
+
+    def _no_disk(*args, **kwargs):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr("photomap.backend.config.atomic_write_text", _no_disk)
+    with pytest.raises(RuntimeError):
+        client.post("/set_umap_eps/", json={"album": key, "eps": 0.99})
+    monkeypatch.undo()
+
+    # The album kept the value it had on disk, not the one that failed.
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(0.1)
+
+    response = client.post(
+        "/update_album/", json=_album_edit_payload(key, name="Renamed")
+    )
+    assert response.status_code == 200
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(0.1)

--- a/tests/backend/test_cluster_eps_router.py
+++ b/tests/backend/test_cluster_eps_router.py
@@ -7,6 +7,8 @@ return are joined by the UI: a mismatch attaches hover labels to the wrong
 blobs.
 """
 
+import asyncio
+import os
 from pathlib import Path
 
 import numpy as np
@@ -14,6 +16,7 @@ import pytest
 import yaml
 from fixtures import build_index
 
+from photomap.backend import embeddings as embeddings_module
 from photomap.backend.config import get_config_manager
 
 
@@ -184,3 +187,79 @@ def test_a_derived_eps_is_written_as_an_absent_key(client, new_album):
 
     stored = yaml.safe_load(get_config_manager().config_path.read_text())
     assert "umap_eps" not in stored["albums"][new_album["key"]]
+
+
+# ---------------------------------------------------------------------------
+# The coordinate load is a rebuild in disguise
+# ---------------------------------------------------------------------------
+
+
+def _stale_umap_cache(album_key):
+    """Leave ``umap.npz`` older than ``embeddings.npz``, as any rewrite of the
+    index does — deleting an image, an ``update_images`` run.
+
+    That is the state in which ``Embeddings.umap_embeddings`` stops being a
+    read and becomes a full UMAP refit.
+    """
+    album = get_config_manager().get_album(album_key)
+    index_path = Path(album.index)
+    umap_path = index_path.parent / "umap.npz"
+    newer = umap_path.stat().st_mtime + 100
+    os.utime(index_path, (newer, newer))
+
+
+def _spy_on_umap_refit(monkeypatch):
+    """Record which kind of thread each UMAP refit happens on.
+
+    ``asyncio.get_running_loop()`` succeeds only on the thread running the
+    event loop, so it distinguishes "inside the endpoint coroutine" from
+    "inside a worker" without depending on thread names.
+    """
+    threads = []
+    real = embeddings_module.Embeddings.create_umap_index
+
+    def spy(self, embeddings):
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            threads.append("worker")
+        else:
+            threads.append("event-loop")
+        return real(self, embeddings)
+
+    monkeypatch.setattr(embeddings_module.Embeddings, "create_umap_index", spy)
+    return threads
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda client, key: client.post("/get_umap_eps/", json={"album": key}),
+        lambda client, key: client.get(f"/cluster_labels/{key}"),
+        lambda client, key: client.get(f"/umap_data/{key}"),
+    ],
+    ids=["get_umap_eps", "cluster_labels", "umap_data"],
+)
+def test_a_stale_umap_cache_is_rebuilt_off_the_event_loop(
+    client, new_album, monkeypatch, call
+):
+    """Loading an album's coordinates can refit UMAP outright, which is
+    minutes on a large album. Doing that in the endpoint coroutine stalls
+    every other request — including the indexing-progress polling on the very
+    screen the semantic map is opened from.
+
+    Note this cannot be left to ``asyncio.to_thread(f, album_umap_coords(e))``:
+    the argument is evaluated before the thread is spawned.
+    """
+    build_index(client, new_album)
+    _clear_stored_eps(new_album["key"])
+    _stale_umap_cache(new_album["key"])
+
+    threads = _spy_on_umap_refit(monkeypatch)
+
+    assert call(client, new_album["key"]).status_code == 200
+
+    # Non-vacuous: the refit really did happen, it just happened elsewhere.
+    assert threads, "expected the stale cache to trigger a UMAP refit"
+    assert "event-loop" not in threads
+

--- a/tests/backend/test_cluster_eps_router.py
+++ b/tests/backend/test_cluster_eps_router.py
@@ -1,0 +1,171 @@
+"""Endpoint behavior for the derived Cluster Strength.
+
+``/get_umap_eps`` is what fills the semantic map's spinner, and
+``/umap_data`` + ``/cluster_labels`` are what cluster with the result. What
+these tests pin down is that all three agree, because the ids the first two
+return are joined by the UI: a mismatch attaches hover labels to the wrong
+blobs.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from fixtures import build_index
+
+from photomap.backend.config import get_config_manager
+
+
+def _clear_stored_eps(album_key):
+    """Put an album back into the derived state (``umap_eps`` unset)."""
+    manager = get_config_manager()
+    album = manager.get_album(album_key)
+    album.umap_eps = None
+    manager.update_album(album)
+
+
+def test_get_umap_eps_reports_a_stored_value_as_not_auto(client, new_album):
+    # The fixture album stores 0.1, so nothing is derived for it.
+    response = client.post("/get_umap_eps/", json={"album": new_album["key"]})
+    assert response.status_code == 200
+    assert response.json() == {"success": True, "eps": 0.1, "auto": False}
+
+
+def test_get_umap_eps_derives_a_value_when_none_is_stored(client, new_album):
+    build_index(client, new_album)
+    _clear_stored_eps(new_album["key"])
+
+    response = client.post("/get_umap_eps/", json={"album": new_album["key"]})
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["auto"] is True
+    assert body["eps"] > 0
+    # Derived from this album's own coordinates, so it is not the old fixed
+    # default that used to be handed to every album regardless of size.
+    assert body["eps"] != 0.07
+
+
+def test_derived_eps_is_stable_across_calls(client, new_album):
+    """The spinner would jitter, and the label cache would miss on every
+    open, if the derived value moved between requests."""
+    build_index(client, new_album)
+    _clear_stored_eps(new_album["key"])
+
+    first = client.post("/get_umap_eps/", json={"album": new_album["key"]}).json()
+    second = client.post("/get_umap_eps/", json={"album": new_album["key"]}).json()
+    assert first["eps"] == pytest.approx(second["eps"])
+
+
+def test_umap_data_and_cluster_labels_resolve_the_same_derived_eps(
+    client, new_album, monkeypatch
+):
+    build_index(client, new_album)
+    _clear_stored_eps(new_album["key"])
+
+    seen = {}
+
+    def fake_get_or_build(embeddings, *, cluster_eps, cluster_min_samples, top_k):
+        seen["labels_eps"] = cluster_eps
+        return {}
+
+    monkeypatch.setattr(
+        "photomap.backend.routers.cluster_labels.get_or_build_cluster_labels",
+        fake_get_or_build,
+    )
+
+    # Record the eps ``/umap_data`` actually clusters with, rather than the
+    # one it resolved — those are the same only if the router uses what it
+    # resolved, which is the property under test.
+    from photomap.backend.routers import umap as umap_router
+
+    real_dbscan = umap_router.DBSCAN
+
+    def recording_dbscan(*, eps, min_samples):
+        seen["umap_eps"] = eps
+        return real_dbscan(eps=eps, min_samples=min_samples)
+
+    monkeypatch.setattr(umap_router, "DBSCAN", recording_dbscan)
+
+    assert client.get(f"/umap_data/{new_album['key']}").status_code == 200
+    assert client.get(f"/cluster_labels/{new_album['key']}").status_code == 200
+
+    assert seen["umap_eps"] == pytest.approx(seen["labels_eps"])
+
+
+def test_an_explicit_eps_still_wins_over_the_derived_one(client, new_album, monkeypatch):
+    build_index(client, new_album)
+    _clear_stored_eps(new_album["key"])
+
+    captured = {}
+
+    def fake_get_or_build(embeddings, *, cluster_eps, cluster_min_samples, top_k):
+        captured["eps"] = cluster_eps
+        return {}
+
+    monkeypatch.setattr(
+        "photomap.backend.routers.cluster_labels.get_or_build_cluster_labels",
+        fake_get_or_build,
+    )
+
+    client.get(f"/cluster_labels/{new_album['key']}?cluster_eps=0.42")
+    assert captured["eps"] == pytest.approx(0.42)
+
+
+def test_empty_album_reports_a_usable_eps(client, new_album):
+    """No index yet means no coordinates to derive from. The spinner still
+    needs a number rather than a blank or a 500."""
+    _clear_stored_eps(new_album["key"])
+
+    response = client.post("/get_umap_eps/", json={"album": new_album["key"]})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["auto"] is True
+    assert body["eps"] > 0
+
+
+def test_derived_eps_survives_a_reindex(client, new_album, tmp_path):
+    """The cache is keyed on the coordinates, so new ones must produce a
+    freshly derived value rather than the stale one."""
+    build_index(client, new_album)
+    _clear_stored_eps(new_album["key"])
+    first = client.post("/get_umap_eps/", json={"album": new_album["key"]}).json()["eps"]
+
+    # Rewrite the cached UMAP coordinates at a different scale, exactly as a
+    # re-index would, and confirm the endpoint notices.
+    album = get_config_manager().get_album(new_album["key"])
+    umap_path = Path(album.index).parent / "umap.npz"
+    coords = np.load(umap_path)["umap"]
+    np.savez(umap_path, umap=coords * 25.0)
+
+    second = client.post("/get_umap_eps/", json={"album": new_album["key"]}).json()["eps"]
+    assert second != pytest.approx(first)
+
+
+def test_clearing_the_stored_eps_returns_the_album_to_derived(client, new_album):
+    """The UI's way back: without it, typing a number once would pin the
+    album to it forever short of editing the config file."""
+    build_index(client, new_album)
+
+    # The fixture album stores 0.1.
+    before = client.post("/get_umap_eps/", json={"album": new_album["key"]}).json()
+    assert before == {"success": True, "eps": 0.1, "auto": False}
+
+    response = client.post(
+        "/set_umap_eps/", json={"album": new_album["key"], "eps": None}
+    )
+    assert response.status_code == 200
+
+    after = client.post("/get_umap_eps/", json={"album": new_album["key"]}).json()
+    assert after["auto"] is True
+    assert after["eps"] != 0.1
+
+
+def test_cleared_eps_survives_a_config_reload(client, new_album):
+    """`umap_eps: null` has to round-trip through the YAML, or the album
+    would silently reacquire a number on the next restart."""
+    client.post("/set_umap_eps/", json={"album": new_album["key"], "eps": None})
+
+    manager = get_config_manager()
+    manager.reload_config()
+    assert manager.get_album(new_album["key"]).umap_eps is None

--- a/tests/backend/test_cluster_eps_router.py
+++ b/tests/backend/test_cluster_eps_router.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import yaml
 from fixtures import build_index
 
 from photomap.backend.config import get_config_manager
@@ -169,3 +170,17 @@ def test_cleared_eps_survives_a_config_reload(client, new_album):
     manager = get_config_manager()
     manager.reload_config()
     assert manager.get_album(new_album["key"]).umap_eps is None
+
+
+def test_a_derived_eps_is_written_as_an_absent_key(client, new_album):
+    """Not `umap_eps: null`: a PhotoMapAI predating the nullable field parses
+    an explicit null into a non-nullable float and refuses to load the config,
+    so writing one would stop the older version from starting on a config file
+    the two share."""
+    client.post("/set_umap_eps/", json={"album": new_album["key"], "eps": None})
+
+    album = get_config_manager().get_album(new_album["key"])
+    assert "umap_eps" not in album.to_dict()
+
+    stored = yaml.safe_load(get_config_manager().config_path.read_text())
+    assert "umap_eps" not in stored["albums"][new_album["key"]]

--- a/tests/backend/test_cluster_eps_router.py
+++ b/tests/backend/test_cluster_eps_router.py
@@ -263,3 +263,78 @@ def test_a_stale_umap_cache_is_rebuilt_off_the_event_loop(
     assert threads, "expected the stale cache to trigger a UMAP refit"
     assert "event-loop" not in threads
 
+# ---------------------------------------------------------------------------
+# Album edits must not discard a tuned Cluster Strength
+# ---------------------------------------------------------------------------
+
+
+def _album_edit_payload(album_key, **overrides):
+    """The payload the album-manager edit form actually sends.
+
+    ``saveAlbumChanges()`` builds it from the fields the form has, and the
+    form has no Cluster Strength control — so ``umap_eps`` is absent, which
+    is the whole point of the tests below.
+    """
+    album = get_config_manager().get_album(album_key)
+    payload = {
+        "key": album_key,
+        "name": album.name,
+        "description": album.description,
+        "encoder_spec": album.encoder_spec,
+        "image_paths": album.image_paths,
+        "index": album.index,
+        "min_image_dimension": album.min_image_dimension,
+        "min_image_bytes": album.min_image_bytes,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_editing_an_album_keeps_a_tuned_cluster_strength(client, new_album):
+    """Renaming an album must not undo the user's tuning.
+
+    The edit form omits ``umap_eps``, so an update that treats "absent" as
+    "clear it" throws the number away the moment anything else about the
+    album is saved — while the docs promise the album keeps it.
+    """
+    key = new_album["key"]
+    client.post("/set_umap_eps/", json={"album": key, "eps": 0.55})
+
+    response = client.post(
+        "/update_album/", json=_album_edit_payload(key, name="Renamed")
+    )
+    assert response.status_code == 200
+
+    assert get_config_manager().get_album(key).name == "Renamed"
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(0.55)
+    assert client.post("/get_umap_eps/", json={"album": key}).json() == {
+        "success": True,
+        "eps": 0.55,
+        "auto": False,
+    }
+
+
+def test_editing_an_album_leaves_a_derived_strength_derived(client, new_album):
+    """The other half: preserving an omitted value must not resurrect one for
+    an album that never had it."""
+    key = new_album["key"]
+    client.post("/set_umap_eps/", json={"album": key, "eps": None})
+
+    response = client.post("/update_album/", json=_album_edit_payload(key))
+    assert response.status_code == 200
+
+    assert get_config_manager().get_album(key).umap_eps is None
+
+
+def test_an_explicit_null_in_an_update_still_clears(client, new_album):
+    """Absent means "keep"; null means "clear". Bookmarks send the album's
+    own value back verbatim, so both spellings have to keep working."""
+    key = new_album["key"]
+    client.post("/set_umap_eps/", json={"album": key, "eps": 0.55})
+
+    response = client.post(
+        "/update_album/", json=_album_edit_payload(key, umap_eps=None)
+    )
+    assert response.status_code == 200
+
+    assert get_config_manager().get_album(key).umap_eps is None

--- a/tests/backend/test_umap.py
+++ b/tests/backend/test_umap.py
@@ -1,9 +1,13 @@
+import os
+import time
 from collections import Counter
 from pathlib import Path
 
+import numpy as np
 import pytest
 from fixtures import build_index, count_test_images, fetch_filename
 
+from photomap.backend.util import atomic_savez
 from photomap.backend.video import ffmpeg_exe
 
 TEST_IMAGE_COUNT = count_test_images()
@@ -60,3 +64,87 @@ def test_umap_data_reports_image_only_albums_as_all_images(client, new_album, mo
 
     assert points
     assert all(point["media"] == "image" for point in points)
+
+
+# ---------------------------------------------------------------------------
+# Concurrent rebuilds of a stale umap.npz
+# ---------------------------------------------------------------------------
+
+
+def test_a_stale_umap_cache_is_rebuilt_exactly_once(tmp_path, monkeypatch):
+    """Two threads finding the same stale cache must not both refit.
+
+    The semantic map fetches ``/umap_data`` and ``/cluster_labels`` in
+    parallel and both resolve coordinates off the event loop, so both can hit
+    the freshness check before either has written a result. The check reads an
+    mtime that is not updated until the fit *finishes*, so it cannot serialize
+    them on its own.
+
+    Two fits is not just wasted work: ``UMAP`` is built without a
+    ``random_state``, so the two layouts differ, and the endpoints would hand
+    back cluster ids describing different coordinates — the divergence the
+    map's hover labels depend on not happening.
+    """
+    import threading
+
+    from photomap.backend.embeddings import Embeddings
+
+    index_path = tmp_path / "embeddings.npz"
+    umap_path = tmp_path / "umap.npz"
+    rng = np.random.default_rng(0)
+    vectors = rng.normal(size=(40, 8)).astype(np.float32)
+    index_path.write_bytes(b"")  # only its mtime matters here
+    # The index reader wants a full archive; this test is about the lock, so
+    # stub it rather than construct one.
+    monkeypatch.setattr(
+        Embeddings,
+        "open_cached_embeddings",
+        staticmethod(lambda path: {"embeddings": vectors}),
+    )
+    # A cache that exists but predates the index: the state any rewrite of
+    # the index leaves behind.
+    atomic_savez(umap_path, umap=np.zeros((40, 2), dtype=np.float32))
+    old = index_path.stat().st_mtime - 100
+    os.utime(umap_path, (old, old))
+
+    concurrent = 0
+    peak = 0
+    calls = 0
+    guard = threading.Lock()
+    started = threading.Barrier(2)
+
+    def slow_fit(self, embeddings):
+        nonlocal concurrent, peak, calls
+        with guard:
+            concurrent += 1
+            peak = max(peak, concurrent)
+            calls += 1
+        # Hold the "fit" open long enough that a second thread would overlap
+        # if nothing excluded it.
+        time.sleep(0.3)
+        coords = np.ones((embeddings.shape[0], 2), dtype=np.float32)
+        atomic_savez(umap_path, umap=coords)
+        with guard:
+            concurrent -= 1
+        return coords
+
+    monkeypatch.setattr(Embeddings, "create_umap_index", slow_fit)
+
+    results = []
+
+    def load():
+        emb = Embeddings(embeddings_path=index_path, album_key="concurrent")
+        started.wait(timeout=5)
+        results.append(emb.umap_embeddings)
+
+    threads = [threading.Thread(target=load) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert peak == 1, "two threads refit the same stale UMAP cache concurrently"
+    assert calls == 1, "the second caller refit instead of reading what the first wrote"
+    assert len(results) == 2
+    # Both callers get the same coordinates, which is the point.
+    assert np.array_equal(results[0], results[1])

--- a/tests/frontend/umap-eps-auto.test.js
+++ b/tests/frontend/umap-eps-auto.test.js
@@ -79,14 +79,6 @@ jest.unstable_mockModule(`${JS}/utils.js`, () => ({
   showToast: jest.fn(),
 }));
 
-// Let the async event listeners settle: they await a fetch before redrawing,
-// so a bare dispatch returns before any of it has happened.
-const flushAsync = async () => {
-  for (let i = 0; i < 5; i++) {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-};
-
 const spinner = () => document.getElementById("umapEpsSpinner");
 const badge = () => document.getElementById("umapEpsAutoBadge");
 
@@ -173,49 +165,6 @@ describe("Cluster Strength auto badge", () => {
     expect(cleared).toBeDefined();
     expect(spinner().value).toBe("0.49");
     expect(badge().hidden).toBe(false);
-  });
-
-  it("re-resolves the strength when the album finishes re-indexing", async () => {
-    // New coordinates mean a new derived value, and fetchUmapData sends
-    // whatever the spinner holds. The album that was empty when the map
-    // opened is the case that bites: its spinner holds the not-indexed-yet
-    // fallback, which is the kind of fixed number that leaves a small album
-    // with no clusters at all -- under an "auto" badge claiming otherwise.
-    const calls = [];
-    global.fetch = (url) => {
-      calls.push(String(url));
-      if (String(url).startsWith("get_umap_eps")) {
-        return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, eps: 0.49, auto: true }) });
-      }
-      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-    };
-
-    // The map is open, showing the fallback it got for an unindexed album.
-    document.getElementById("umapFloatingWindow").style.display = "block";
-    umap.applyResolvedEps({ success: true, eps: 0.2, auto: true });
-
-    window.dispatchEvent(new CustomEvent("albumIndexUpdated", { detail: { albumKey: mockState.album } }));
-    await flushAsync();
-
-    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
-    expect(spinner().value).toBe("0.49");
-    // The redraw must use the freshly resolved number, not the stale one.
-    const mapFetch = calls.find((u) => u.startsWith("umap_data/"));
-    expect(mapFetch).toContain("cluster_eps=0.49");
-  });
-
-  it("leaves another album's re-index alone", async () => {
-    const calls = [];
-    global.fetch = (url) => {
-      calls.push(String(url));
-      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
-    };
-    document.getElementById("umapFloatingWindow").style.display = "block";
-
-    window.dispatchEvent(new CustomEvent("albumIndexUpdated", { detail: { albumKey: "some-other-album" } }));
-    await flushAsync();
-
-    expect(calls).toEqual([]);
   });
 
   it("accepts a derived value above the old 1.0 ceiling", () => {

--- a/tests/frontend/umap-eps-auto.test.js
+++ b/tests/frontend/umap-eps-auto.test.js
@@ -1,0 +1,178 @@
+// The "auto" marker beside Cluster Strength.
+//
+// The number in that spinner now has two possible origins — a value the user
+// saved, or one the server derived from the album's coordinates — and the
+// badge is the only thing that tells them apart. What matters is that the
+// badge can never disagree with the number next to it: it must appear with a
+// derived value, stay away from a stored one, and vanish the moment the user
+// takes the number over.
+//
+// See umap-harness.js for why umap.js needs a harness to be importable at all.
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+import { installFetchMock, installPlotlyMock, loadUmapDom, removePlotlyMock } from "./umap-harness.js";
+
+const JS = "../../photomap/frontend/static/javascript";
+
+const mockState = {
+  album: "test-album",
+  dataChanged: true,
+  autotaggingEnabled: false,
+  umapMediaFilter: "both",
+  umapShowLandmarks: false,
+  umapShowHoverThumbnails: false,
+  umapExitFullscreenOnSelection: false,
+  umapClickSelectsCluster: true,
+  umapControlsVisible: true,
+  umapClickSelectsImage: false,
+  searchType: "clear",
+  searchResults: [],
+};
+
+jest.unstable_mockModule(`${JS}/state.js`, () => ({
+  state: mockState,
+  setUmapMediaFilter: jest.fn(),
+  setUmapShowLandmarks: jest.fn(),
+  setUmapClickSelectsCluster: jest.fn(),
+  setUmapControlsVisible: jest.fn(),
+  setUmapExitFullscreenOnSelection: jest.fn(),
+  setUmapShowHoverThumbnails: jest.fn(),
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/album-manager.js`, () => ({
+  albumManager: { fetchAvailableAlbums: jest.fn(() => Promise.resolve([])), setSwiperManager: jest.fn() },
+  checkAlbumIndex: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/back-stack.js`, () => ({
+  backStack: { markNextAsJump: jest.fn(), popOne: jest.fn(), init: jest.fn(), setNavigator: jest.fn() },
+}));
+jest.unstable_mockModule(`${JS}/cluster-utils.js`, () => ({
+  CLUSTER_PALETTE: ["#ff0000", "#00ff00", "#0000ff"],
+  getClusterLabelInfo: jest.fn(() => null),
+  getImageLabelInfo: jest.fn(() => null),
+  setClusterLabels: jest.fn(),
+  trackVocabBuildRequest: jest.fn((p) => p),
+}));
+jest.unstable_mockModule(`${JS}/search-ui.js`, () => ({ exitSearchMode: jest.fn() }));
+jest.unstable_mockModule(`${JS}/search.js`, () => ({
+  getImagePath: jest.fn(() => Promise.resolve("/photos/example.jpg")),
+  setSearchResults: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/settings.js`, () => ({ switchAlbum: jest.fn() }));
+jest.unstable_mockModule(`${JS}/slide-state.js`, () => ({
+  slideState: { navigateToIndex: jest.fn(), getCurrentSlide: jest.fn(() => ({ globalIndex: 0 })) },
+  getCurrentSlideIndex: jest.fn(() => [-1, 0, null]),
+}));
+jest.unstable_mockModule(`${JS}/umap-reindex.js`, () => ({
+  checkUmapReindexOngoing: jest.fn(),
+  initUmapReindexButton: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/utils.js`, () => ({
+  debounce: (fn) => fn,
+  getPercentile: (arr, p) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    return sorted[Math.floor(((p / 100) * (sorted.length - 1)) | 0)] ?? 0;
+  },
+  isColorLight: () => false,
+  makeDraggable: jest.fn(),
+  showToast: jest.fn(),
+}));
+
+const spinner = () => document.getElementById("umapEpsSpinner");
+const badge = () => document.getElementById("umapEpsAutoBadge");
+
+async function boot() {
+  loadUmapDom();
+  installPlotlyMock();
+  installFetchMock([]);
+  return import(`${JS}/umap.js`);
+}
+
+afterEach(() => {
+  removePlotlyMock();
+  delete global.fetch;
+  document.body.innerHTML = "";
+  jest.resetModules();
+});
+
+describe("Cluster Strength auto badge", () => {
+  let umap;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    umap = await boot();
+  });
+
+  it("shows the derived value and marks it auto", () => {
+    umap.applyResolvedEps({ success: true, eps: 0.49, auto: true });
+
+    expect(spinner().value).toBe("0.49");
+    expect(badge().hidden).toBe(false);
+  });
+
+  it("leaves the badge off for a value the user stored", () => {
+    umap.applyResolvedEps({ success: true, eps: 0.2, auto: false });
+
+    expect(spinner().value).toBe("0.2");
+    expect(badge().hidden).toBe(true);
+  });
+
+  it("clears the badge as soon as the spinner is edited", () => {
+    umap.applyResolvedEps({ success: true, eps: 0.49, auto: true });
+    expect(badge().hidden).toBe(false);
+
+    spinner().value = "0.3";
+    spinner().dispatchEvent(new Event("input"));
+
+    // Immediately, not after the debounced save: from the keystroke on, the
+    // number on screen is the user's.
+    expect(badge().hidden).toBe(true);
+  });
+
+  it("re-marks a derived value after the user's album switch", () => {
+    umap.applyResolvedEps({ success: true, eps: 0.2, auto: false });
+    umap.applyResolvedEps({ success: true, eps: 0.49, auto: true });
+
+    expect(badge().hidden).toBe(false);
+  });
+
+  it("sends null when the field is cleared, and shows what comes back", async () => {
+    // The way back to a derived strength. `|| 0.07` here used to turn an
+    // empty field into a stored 0.07 — the very number that leaves small
+    // albums with no clusters.
+    const calls = [];
+    global.fetch = (url, options) => {
+      calls.push({ url: String(url), body: options?.body ? JSON.parse(options.body) : null });
+      if (String(url).startsWith("get_umap_eps")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, eps: 0.49, auto: true }) });
+      }
+      if (String(url).startsWith("umap_data/")) {
+        // The redraw that follows the save; it needs a points array.
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) });
+    };
+
+    umap.applyResolvedEps({ success: true, eps: 0.2, auto: false });
+    spinner().value = "";
+    spinner().dispatchEvent(new Event("input"));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    // Matched on the payload rather than on "the only save": a debounced
+    // save from an earlier test's module instance can still land here.
+    const cleared = calls.find((c) => c.url.startsWith("set_umap_eps") && c.body.eps === null);
+    expect(cleared).toBeDefined();
+    expect(spinner().value).toBe("0.49");
+    expect(badge().hidden).toBe(false);
+  });
+
+  it("accepts a derived value above the old 1.0 ceiling", () => {
+    // Small albums legitimately derive past it; the spinner must not silently
+    // display something other than what the map clustered with.
+    umap.applyResolvedEps({ success: true, eps: 1.19, auto: true });
+
+    expect(spinner().value).toBe("1.19");
+    expect(Number(spinner().max)).toBeGreaterThanOrEqual(1.19);
+  });
+});

--- a/tests/frontend/umap-eps-auto.test.js
+++ b/tests/frontend/umap-eps-auto.test.js
@@ -79,6 +79,14 @@ jest.unstable_mockModule(`${JS}/utils.js`, () => ({
   showToast: jest.fn(),
 }));
 
+// Let the async event listeners settle: they await a fetch before redrawing,
+// so a bare dispatch returns before any of it has happened.
+const flushAsync = async () => {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
 const spinner = () => document.getElementById("umapEpsSpinner");
 const badge = () => document.getElementById("umapEpsAutoBadge");
 
@@ -165,6 +173,49 @@ describe("Cluster Strength auto badge", () => {
     expect(cleared).toBeDefined();
     expect(spinner().value).toBe("0.49");
     expect(badge().hidden).toBe(false);
+  });
+
+  it("re-resolves the strength when the album finishes re-indexing", async () => {
+    // New coordinates mean a new derived value, and fetchUmapData sends
+    // whatever the spinner holds. The album that was empty when the map
+    // opened is the case that bites: its spinner holds the not-indexed-yet
+    // fallback, which is the kind of fixed number that leaves a small album
+    // with no clusters at all -- under an "auto" badge claiming otherwise.
+    const calls = [];
+    global.fetch = (url) => {
+      calls.push(String(url));
+      if (String(url).startsWith("get_umap_eps")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, eps: 0.49, auto: true }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    };
+
+    // The map is open, showing the fallback it got for an unindexed album.
+    document.getElementById("umapFloatingWindow").style.display = "block";
+    umap.applyResolvedEps({ success: true, eps: 0.2, auto: true });
+
+    window.dispatchEvent(new CustomEvent("albumIndexUpdated", { detail: { albumKey: mockState.album } }));
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
+    expect(spinner().value).toBe("0.49");
+    // The redraw must use the freshly resolved number, not the stale one.
+    const mapFetch = calls.find((u) => u.startsWith("umap_data/"));
+    expect(mapFetch).toContain("cluster_eps=0.49");
+  });
+
+  it("leaves another album's re-index alone", async () => {
+    const calls = [];
+    global.fetch = (url) => {
+      calls.push(String(url));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    };
+    document.getElementById("umapFloatingWindow").style.display = "block";
+
+    window.dispatchEvent(new CustomEvent("albumIndexUpdated", { detail: { albumKey: "some-other-album" } }));
+    await flushAsync();
+
+    expect(calls).toEqual([]);
   });
 
   it("accepts a derived value above the old 1.0 ceiling", () => {

--- a/tests/frontend/umap-reindex-refresh.test.js
+++ b/tests/frontend/umap-reindex-refresh.test.js
@@ -1,0 +1,274 @@
+// What the semantic map does when the album it is showing finishes indexing.
+//
+// The listener re-resolves the Cluster Strength before redrawing, because new
+// coordinates invalidate a derived one and the redraw sends whatever the
+// spinner holds. That resolve is a round trip which, on a large album, means
+// deriving from scratch — so everything checked before it has to be checked
+// again after it. These tests are each one thing that can move in that window.
+//
+// Separate file, and the module is imported exactly ONCE: umap.js registers
+// window listeners at module scope and nothing unregisters them, so a
+// per-test re-import would leave several live listeners all reacting to one
+// dispatched event and racing each other through the shared spinner.
+
+import { jest, describe, it, expect, beforeAll, afterAll, beforeEach } from "@jest/globals";
+
+import { installFetchMock, installPlotlyMock, loadUmapDom, removePlotlyMock } from "./umap-harness.js";
+
+const JS = "../../photomap/frontend/static/javascript";
+
+const mockState = {
+  album: "test-album",
+  dataChanged: true,
+  autotaggingEnabled: false,
+  umapMediaFilter: "both",
+  umapShowLandmarks: false,
+  umapShowHoverThumbnails: false,
+  umapExitFullscreenOnSelection: false,
+  umapClickSelectsCluster: true,
+  umapControlsVisible: true,
+  umapClickSelectsImage: false,
+  searchType: "clear",
+  searchResults: [],
+};
+
+jest.unstable_mockModule(`${JS}/state.js`, () => ({
+  state: mockState,
+  setUmapMediaFilter: jest.fn(),
+  setUmapShowLandmarks: jest.fn(),
+  setUmapClickSelectsCluster: jest.fn(),
+  setUmapControlsVisible: jest.fn(),
+  setUmapExitFullscreenOnSelection: jest.fn(),
+  setUmapShowHoverThumbnails: jest.fn(),
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/album-manager.js`, () => ({
+  albumManager: { fetchAvailableAlbums: jest.fn(() => Promise.resolve([])), setSwiperManager: jest.fn() },
+  checkAlbumIndex: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/back-stack.js`, () => ({
+  backStack: { markNextAsJump: jest.fn(), popOne: jest.fn(), init: jest.fn(), setNavigator: jest.fn() },
+}));
+jest.unstable_mockModule(`${JS}/cluster-utils.js`, () => ({
+  CLUSTER_PALETTE: ["#ff0000", "#00ff00", "#0000ff"],
+  getClusterLabelInfo: jest.fn(() => null),
+  getImageLabelInfo: jest.fn(() => null),
+  setClusterLabels: jest.fn(),
+  trackVocabBuildRequest: jest.fn((p) => p),
+}));
+jest.unstable_mockModule(`${JS}/search-ui.js`, () => ({ exitSearchMode: jest.fn() }));
+jest.unstable_mockModule(`${JS}/search.js`, () => ({
+  getImagePath: jest.fn(() => Promise.resolve("/photos/example.jpg")),
+  setSearchResults: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/settings.js`, () => ({ switchAlbum: jest.fn() }));
+jest.unstable_mockModule(`${JS}/slide-state.js`, () => ({
+  slideState: { navigateToIndex: jest.fn(), getCurrentSlide: jest.fn(() => ({ globalIndex: 0 })) },
+  getCurrentSlideIndex: jest.fn(() => [-1, 0, null]),
+}));
+jest.unstable_mockModule(`${JS}/umap-reindex.js`, () => ({
+  checkUmapReindexOngoing: jest.fn(),
+  initUmapReindexButton: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/utils.js`, () => ({
+  debounce: (fn) => fn,
+  getPercentile: (arr, p) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    return sorted[Math.floor(((p / 100) * (sorted.length - 1)) | 0)] ?? 0;
+  },
+  isColorLight: () => false,
+  makeDraggable: jest.fn(),
+  showToast: jest.fn(),
+}));
+
+const spinner = () => document.getElementById("umapEpsSpinner");
+const badge = () => document.getElementById("umapEpsAutoBadge");
+const mapWindow = () => document.getElementById("umapFloatingWindow");
+
+// Let the async listener settle: it awaits a fetch before redrawing, so a
+// bare dispatch returns long before any of it has happened.
+const flushAsync = async () => {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
+const reindexed = (albumKey) => window.dispatchEvent(new CustomEvent("albumIndexUpdated", { detail: { albumKey } }));
+
+// A fetch mock whose get_umap_eps reply is held open until released, so a
+// test can act inside the window the real resolve leaves open.
+function deferredEpsFetch(eps) {
+  let release;
+  const held = new Promise((resolve) => {
+    release = resolve;
+  });
+  const calls = [];
+  global.fetch = async (url) => {
+    calls.push(String(url));
+    if (String(url).startsWith("get_umap_eps")) {
+      await held;
+      return { ok: true, json: () => Promise.resolve({ success: true, eps, auto: true }) };
+    }
+    return { ok: true, json: () => Promise.resolve([]) };
+  };
+  return { calls, release: () => release() };
+}
+
+function immediateFetch({ eps = 0.49, epsFails = false } = {}) {
+  const calls = [];
+  global.fetch = (url) => {
+    calls.push(String(url));
+    if (String(url).startsWith("get_umap_eps")) {
+      return epsFails
+        ? Promise.reject(new Error("connection lost"))
+        : Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, eps, auto: true }) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+  };
+  return calls;
+}
+
+const drewMap = (calls) => calls.some((u) => u.startsWith("umap_data/"));
+
+let umap;
+
+beforeAll(async () => {
+  loadUmapDom();
+  installPlotlyMock();
+  installFetchMock([]);
+  umap = await import(`${JS}/umap.js`);
+});
+
+afterAll(() => {
+  removePlotlyMock();
+  delete global.fetch;
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockState.album = "test-album";
+  mockState.dataChanged = true;
+  mapWindow().style.display = "block";
+  // The map is showing a derived strength for an album that had none.
+  umap.applyResolvedEps({ success: true, eps: 0.2, auto: true });
+});
+
+describe("albumIndexUpdated on the album being shown", () => {
+  it("re-resolves the strength and redraws with it", async () => {
+    const calls = immediateFetch({ eps: 0.49 });
+
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
+    expect(spinner().value).toBe("0.49");
+    expect(badge().hidden).toBe(false);
+    // The redraw must carry the freshly resolved number, not the stale one.
+    expect(calls.find((u) => u.startsWith("umap_data/"))).toContain("cluster_eps=0.49");
+  });
+
+  it("ignores a re-index of some other album", async () => {
+    const calls = immediateFetch();
+
+    reindexed("some-other-album");
+    await flushAsync();
+
+    expect(calls).toEqual([]);
+    expect(spinner().value).toBe("0.2");
+  });
+
+  it("redraws with the previous strength, loudly, when resolving fails", async () => {
+    const calls = immediateFetch({ epsFails: true });
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    reindexed("test-album");
+    await flushAsync();
+
+    // The coordinates really did change, so a stale-eps redraw still beats
+    // leaving the old plot up — but it must not pass silently.
+    expect(drewMap(calls)).toBe(true);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("leaves the spinner alone while an edit is pending", async () => {
+    const calls = immediateFetch({ eps: 0.49 });
+
+    // The user types a strength; the debounced save is now pending.
+    spinner().value = "0.55";
+    spinner().dispatchEvent(new Event("input"));
+    reindexed("test-album");
+    await flushAsync();
+
+    // Overwriting here would move the number under the cursor and re-show
+    // "auto" for a value that is about to become the user's own.
+    expect(spinner().value).toBe("0.55");
+    expect(badge().hidden).toBe(true);
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(false);
+  });
+
+  it("resumes re-resolving once the pending edit has been saved", async () => {
+    // The pending-edit guard keys off the debounce handle, so it has to be
+    // cleared when the timer fires — otherwise one edit disables the
+    // re-resolve for the rest of the session.
+    global.fetch = (url) =>
+      Promise.resolve(
+        String(url).startsWith("get_umap_eps")
+          ? { ok: true, json: () => Promise.resolve({ success: true, eps: 0.49, auto: true }) }
+          : { ok: true, json: () => Promise.resolve([]) }
+      );
+    spinner().value = "0.55";
+    spinner().dispatchEvent(new Event("input"));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    const calls = immediateFetch({ eps: 0.49 });
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
+  });
+});
+
+describe("while the post-re-index resolve is in flight", () => {
+  it("does not write album A's strength into album B's spinner", async () => {
+    const { calls, release } = deferredEpsFetch(0.49);
+
+    reindexed("test-album");
+    await flushAsync();
+    // The user switches albums while the derive runs. setAlbum() assigns
+    // state.album synchronously, so this is what the listener sees on wake.
+    mockState.album = "other-album";
+    release();
+    await flushAsync();
+
+    expect(spinner().value).toBe("0.2");
+    expect(drewMap(calls)).toBe(false);
+  });
+
+  it("does not redraw into a window the user has since closed", async () => {
+    const { calls, release } = deferredEpsFetch(0.49);
+
+    reindexed("test-album");
+    await flushAsync();
+    mapWindow().style.display = "none";
+    release();
+    await flushAsync();
+
+    expect(drewMap(calls)).toBe(false);
+    // The flag survives for the next open, which re-resolves on its own.
+    expect(mockState.dataChanged).toBe(true);
+  });
+
+  it("still redraws when another fetch cleared dataChanged mid-flight", async () => {
+    const { calls, release } = deferredEpsFetch(0.49);
+
+    reindexed("test-album");
+    await flushAsync();
+    // Any redraw finishing inside the window clears the flag; that must not
+    // swallow the one redraw this listener exists to guarantee.
+    mockState.dataChanged = false;
+    release();
+    await flushAsync();
+
+    expect(drewMap(calls)).toBe(true);
+  });
+});


### PR DESCRIPTION
Adapts the adaptive-eps idea from InvokeAI's image map (`image_index/projection.py`), with the rule re-tuned against real PhotoMapAI albums.

## The problem

`eps` had one fixed default for every album. UMAP's coordinates have no fixed scale — their span grows as the point count shrinks — so the value that carves a large library into useful clusters labels a small album as entirely unclustered. On a real 240-image album the stored 0.07 produced **0 clusters and 100% unclustered**, which reads as a broken semantic map rather than a setting to adjust.

## What changed

`umap_eps` becomes nullable, meaning *nobody has chosen one*. Those albums resolve to a value derived from their own coordinates, marked **auto** beside the Cluster Strength field. Typing a number stores it and takes over; clearing the field hands it back — previously a typed value was a one-way door with no way back to a default.

`/get_umap_eps`, `/umap_data` and `/cluster_labels` all resolve through one helper, so the cluster ids the last two return can't refer to different clusterings (the UI joins on them for hover labels).

## The rule, and why not the median

`backend/cluster_eps.py` draws candidates from the k-distance distribution and takes the largest whose biggest cluster still holds under a quarter of the album.

The plain median k-distance — the standard heuristic, and what InvokeAI uses — makes half the points core points by construction, which lands at ~30% unclustered on a large library, materially worse than a hand-tuned eps. Walking up to the knee instead reproduces hand-tuning where it exists and fixes it where it is broken:

| album | N | stored | result | derived | result |
|---|---|---|---|---|---|
| public | 240 | 0.07 | **0 / 100% / 0%** | 0.491 | 9 / 17% / 18% |
| invoke-boards | 199 | 0.40 | 6 / 49% / 12% | 0.530 | 6 / 27% / 26% |
| keepers | 1658 | 0.20 | 44 / 27% / 10% | 0.239 | 27 / 14% / 16% |
| recent_invoke | 19018 | 0.07 | 518 / 23% / 1% | 0.105 | 376 / 7% / 11% |
| family | 38202 | 0.12 | 458 / 4% / 9% | **0.119** | 460 / 4% / 9% |
| invoke | 85578 | 0.05 | 1059 / 14% / 14% | **0.051** | 1034 / 13% / 14% |

*(clusters / unclustered% / biggest-cluster%)*

## Two clamps, applied asymmetrically on purpose

- **Neighbour-pair budget** (KD-tree, ≤50M pairs) applies to *every* eps, typed or derived. It is a memory bound: the Cluster Strength control can always ask a six-figure album for a radius it cannot afford, which is an out-of-memory crash rather than a slow response. PhotoMapAI had no equivalent guard before.
- **Span clamp** applies to *derived* values only. A number the user typed is theirs to keep; retuning it silently would make the control lie about what it does.

The span fraction was copied as 0.05 from InvokeAI and had to be raised to 0.25: that figure suits a median-based rule, and against a scan that deliberately climbs higher it overrode correct answers outright — it clamped a map of five well-separated blobs, and would have tripled the unclustered share on the smallest real album. Tests pin both halves.

## Cost

A k-distance pass plus at most six DBSCAN fits: 2.4s on 122k points, 0.6s on 38k. It runs in a thread and is memoized beside `umap.npz`, keyed by a fingerprint of the coordinates so a re-index invalidates it. Second request is ~1ms.

## Downgrade safety

A derived strength is written as an **absent** key rather than `umap_eps: null`. A PhotoMapAI predating the nullable field parses an explicit null into a non-nullable float and refuses to load the whole config — i.e. writing one would stop the older version from starting, on a config file the two share. Absent is what it already handles.

## Verification

- 695 backend tests, 584 frontend tests, ruff + eslint + prettier clean.
- Driven end-to-end through the real app on the 240-image album: 0 clusters / 240 unclustered at the old fixed 0.07 → 9 clusters / 41 unclustered derived, second request served from the memo in 1ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)