### PR TITLE
Treat an album update as a patch, not a replacement

### DIFF
--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -42,6 +42,18 @@ def default_board_index_path(album_key: str) -> Path:
     return data_dir / "indexes" / album_key / "embeddings.npz"
 
 
+def default_min_search_score(encoder_spec: str) -> float:
+    """The sensible score floor for ``encoder_spec``'s encoder family.
+
+    SigLIP's cosine similarities live an order of magnitude below CLIP's, so
+    a floor tuned for one family hides every result under the other. Callers
+    that need to know whether a re-resolve is warranted compare this across
+    two specs rather than comparing the specs themselves — swapping one CLIP
+    model for another must not discard a score the user tuned by hand.
+    """
+    return 0.005 if encoder_spec.startswith("siglip:") else 0.2
+
+
 class Album(BaseModel):
     """Represents a photo album configuration."""
 
@@ -183,9 +195,7 @@ class Album(BaseModel):
     @model_validator(mode="after")
     def _resolve_min_search_score(self) -> "Album":
         if self.min_search_score is None:
-            self.min_search_score = (
-                0.005 if self.encoder_spec.startswith("siglip:") else 0.2
-            )
+            self.min_search_score = default_min_search_score(self.encoder_spec)
         return self
 
     @model_validator(mode="after")

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -369,6 +369,15 @@ async def update_album(album_data: dict) -> JSONResponse:
     """
     try:
         existing = config_manager.get_album(album_data["key"])
+        # Answered here rather than by the failed write at the end: with
+        # patch semantics there is nothing to patch, and the half-built
+        # Album that a partial payload produces raises out of create_album
+        # as a 500 before the write is ever reached. Both shapes of payload
+        # deserve the same 404.
+        if existing is None:
+            raise HTTPException(
+                status_code=404, detail=f"Album '{album_data['key']}' not found"
+            )
 
         def kept(field: str, default: Any = None) -> Any:
             """The payload's value for ``field``, else the stored one.
@@ -438,7 +447,11 @@ async def update_album(album_data: dict) -> JSONResponse:
         ) != default_min_search_score(existing.encoder_spec)
         album = create_album(
             key=album_data["key"],
-            name=album_data["name"],
+            # Patched like every other field. Reading it straight out of the
+            # payload contradicted the rule this endpoint documents, and a
+            # payload without it raised a bare KeyError that surfaced as a
+            # 500 whose detail was the word "name".
+            name=kept("name"),
             # Board albums derive their directories from the InvokeAI root,
             # so theirs are never carried over: a non-empty list suppresses
             # that derivation, which would pin the album to its old root the
@@ -458,9 +471,14 @@ async def update_album(album_data: dict) -> JSONResponse:
             # Left to the model to re-resolve when the encoder family changed
             # and the payload said nothing: carrying the other family's floor
             # over makes the new encoder look like it returns nothing.
+            # ``is None`` rather than ``not in``: ``kept`` treats a null as
+            # absent, so testing presence made the two halves disagree — an
+            # explicit null suppressed the re-resolve *and* fell through to
+            # the stored value, leaving a CLIP floor on a SigLIP album, where
+            # it matches nothing.
             min_search_score=(
                 None
-                if score_band_changed and "min_search_score" not in album_data
+                if score_band_changed and album_data.get("min_search_score") is None
                 else kept("min_search_score")
             ),
             max_search_results=kept("max_search_results"),
@@ -533,16 +551,23 @@ async def update_album(album_data: dict) -> JSONResponse:
         # change when credentials do — so a password that was just cleared (or
         # replaced) would otherwise keep working from cache until the token
         # expired, up to a day later.
-        if existing is not None and (
+        credentials_changed = (
             album.invokeai_password != existing.invokeai_password
             or album.invokeai_username != existing.invokeai_username
             or album.invokeai_url != existing.invokeai_url
-        ):
-            invokeai_client._invalidate_token_cache()
+        )
 
         logger.info(f"Updating album: {album.key} with index {album.index}")
 
         if config_manager.update_album(album):
+            # After the write, not before it. The cache is keyed on
+            # (url, username) alone, so a request that reads the album in
+            # between — an index scan, a board delete — logs in with the
+            # *old* password and re-caches a token that then outlives the
+            # change by up to a day, which is the thing this invalidation
+            # exists to stop.
+            if credentials_changed:
+                invokeai_client._invalidate_token_cache()
             return JSONResponse(
                 content={
                     "success": True,

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -512,16 +512,16 @@ async def update_album(album_data: dict) -> JSONResponse:
             and requested_paths is not None
         ):
 
-            def _normalized(paths: list[str]) -> list[str]:
+            def _normalized(paths: list[str]) -> set[str]:
                 # Normalized the way ``create_album`` stores them, so a
                 # symlinked root echoed back does not read as a change. A path
                 # that cannot be resolved at all (symlink loop, embedded NUL)
                 # is left as-is: it will not match either list, which is the
                 # 400 this guard exists to raise, not a 500.
-                normalized = []
+                normalized = set()
                 for path in paths:
                     try:
-                        normalized.append(str(Path(path).expanduser().resolve()))
+                        normalized.add(str(Path(path).expanduser().resolve()))
                     except Exception:
                         # Deliberately broad: what ``resolve()`` raises for an
                         # unresolvable path is interpreter-dependent (a symlink
@@ -530,12 +530,24 @@ async def update_album(album_data: dict) -> JSONResponse:
                         # supports 3.10–3.13. Whatever it is, the path is not
                         # one of the album's own — leave it unnormalized so it
                         # falls through to the 400 rather than a 500.
-                        normalized.append(str(path))
+                        normalized.add(str(path))
                 return normalized
 
-            unchanged = _normalized(requested_paths) in (
-                _normalized(existing.image_paths),
-                _normalized(album.image_paths),
+            # Sets, and subsets: this asks "is the caller requesting a
+            # change", and a caller echoing back part of what the album has
+            # is not. Order carries no meaning — nothing downstream depends
+            # on it — and comparing lists made a reordered echo a 400.
+            #
+            # A subset counts because the derived list has grown: board
+            # albums gained an ``outputs/videos`` directory alongside
+            # ``outputs/images``, so a client still holding a snapshot from
+            # before that sends one path where the album now has two. It is
+            # asking for nothing, exactly like the caller mid-root-edit that
+            # the second accepted list below exists for.
+            requested = _normalized(requested_paths)
+            unchanged = bool(requested) and (
+                requested <= _normalized(existing.image_paths)
+                or requested <= _normalized(album.image_paths)
             )
             if not unchanged:
                 raise HTTPException(

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from .. import invokeai_client
 from ..cluster_eps import FALLBACK_CLUSTER_EPS, cached_adaptive_cluster_eps
 from ..config import (
     Album,
@@ -417,11 +418,17 @@ async def update_album(album_data: dict) -> JSONResponse:
             )
 
         # The edit form never sees the saved InvokeAI password, so it sends a
-        # blank one; unlike the fields above, "" here means "keep what's
-        # stored" rather than "clear it".
-        password = album_data.get("invokeai_password") or (
-            existing.invokeai_password if existing else None
-        )
+        # blank one for "I did not touch this": "" means keep, unlike every
+        # other field here. An explicit null is the form's *Forget saved
+        # password* box — the only way to say "clear it", which a backend
+        # leaving multi-user mode needs, since a stored password with no
+        # username is dead weight the config keeps offering.
+        if "invokeai_password" in album_data and album_data["invokeai_password"] is None:
+            password = None
+        else:
+            password = album_data.get("invokeai_password") or (
+                existing.invokeai_password if existing else None
+            )
         is_board = kept("source_type", "directory") == "invokeai_board"
         # Only a change of encoder *family* invalidates a stored score: the
         # floors are 0.005 for SigLIP and 0.2 for CLIP, so swapping one CLIP
@@ -521,6 +528,17 @@ async def update_album(album_data: dict) -> JSONResponse:
                         "added to."
                     ),
                 )
+
+        # The JWT cache is keyed on (url, username), neither of which has to
+        # change when credentials do — so a password that was just cleared (or
+        # replaced) would otherwise keep working from cache until the token
+        # expired, up to a day later.
+        if existing is not None and (
+            album.invokeai_password != existing.invokeai_password
+            or album.invokeai_username != existing.invokeai_username
+            or album.invokeai_url != existing.invokeai_url
+        ):
+            invokeai_client._invalidate_token_cache()
 
         logger.info(f"Updating album: {album.key} with index {album.index}")
 

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -10,7 +10,13 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from ..cluster_eps import FALLBACK_CLUSTER_EPS, cached_adaptive_cluster_eps
-from ..config import Album, create_album, default_board_index_path, get_config_manager
+from ..config import (
+    Album,
+    create_album,
+    default_board_index_path,
+    default_min_search_score,
+    get_config_manager,
+)
 from ..embeddings import Embeddings
 from ..encoders import default_encoder_spec
 from ..video_cache import VideoFrameCache
@@ -342,44 +348,179 @@ async def add_album(album: Album) -> JSONResponse:
     "/update_album/", tags=["Albums"], dependencies=[Depends(require_no_lock)]
 )
 async def update_album(album_data: dict) -> JSONResponse:
-    """Update an existing album in the configuration."""
+    """Update an existing album, keeping any field the payload leaves out.
+
+    An update is a *patch*, not a replacement. Callers send partial payloads —
+    the bookmark menu sends five keys, the search dialog sends the album plus
+    three overrides — and rebuilding the album from those alone silently reset
+    everything else to model defaults. The damage was worst for InvokeAI-board
+    albums: ``source_type`` defaulted back to ``"directory"`` and the
+    ``invokeai_*`` fields to None, quietly demoting the album, after which
+    indexing walked InvokeAI's output directories directly and deletions
+    stopped routing through its API (issue #371).
+
+    So every field falls back to what is stored: a key the payload does not
+    carry keeps its current value. Presence is what decides — a key that *is*
+    present wins even when its value is falsy or null, because
+    ``min_image_bytes: 0``, ``use_query_optimization: false``, an emptied
+    description and ``invokeai_username: null`` are all real edits the UI
+    sends.
+    """
     try:
         existing = config_manager.get_album(album_data["key"])
-        # Edits never relocate an index: when the payload omits it, keep the
-        # stored path. Likewise the edit form never sees the saved InvokeAI
-        # password, so a blank/omitted one means "keep what's stored".
-        index = album_data.get("index") or (existing.index if existing else None)
+
+        def kept(field: str, default: Any = None) -> Any:
+            """The payload's value for ``field``, else the stored one.
+
+            Falsy is not absent: ``0``, ``false`` and ``""`` are real settings
+            here and are honored. Null *is* treated as absent, because
+            ``create_album`` turns a None into the model default rather than
+            into a cleared field — so honoring it would reset an album's
+            encoder or scan gates to factory values instead of clearing them.
+            The one field that genuinely needs clearing is handled by
+            :func:`cleared_or_kept`.
+            """
+            value = album_data.get(field)
+            if value is not None:
+                return value
+            if existing is not None:
+                return getattr(existing, field, default)
+            return default
+
+        def cleared_or_kept(field: str) -> Any:
+            """Like :func:`kept`, but an explicit null clears the field.
+
+            The edit form sends ``invokeai_username: null`` when the user
+            empties the username box — InvokeAI dropped out of multi-user
+            mode — and that has to stop the stored credentials being sent.
+            """
+            if field in album_data:
+                return album_data[field]
+            return getattr(existing, field, None) if existing else None
+
+        # An album's kind is fixed at creation: the edit form branches on the
+        # stored value and never offers to switch, so a payload that disagrees
+        # is a partial payload being read as a replacement — the bug this
+        # patch semantics exists to prevent (issue #371).
+        requested_type = album_data.get("source_type")
+        if (
+            existing is not None
+            and requested_type is not None
+            and requested_type != existing.source_type
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Album '{existing.key}' is a {existing.source_type} album; "
+                    f"its source type cannot be changed by an update."
+                ),
+            )
+
+        # The edit form never sees the saved InvokeAI password, so it sends a
+        # blank one; unlike the fields above, "" here means "keep what's
+        # stored" rather than "clear it".
         password = album_data.get("invokeai_password") or (
             existing.invokeai_password if existing else None
         )
+        is_board = kept("source_type", "directory") == "invokeai_board"
+        # Only a change of encoder *family* invalidates a stored score: the
+        # floors are 0.005 for SigLIP and 0.2 for CLIP, so swapping one CLIP
+        # model for another must leave a hand-tuned value alone.
+        score_band_changed = existing is not None and default_min_search_score(
+            kept("encoder_spec", existing.encoder_spec)
+        ) != default_min_search_score(existing.encoder_spec)
         album = create_album(
             key=album_data["key"],
             name=album_data["name"],
-            image_paths=album_data.get("image_paths"),
-            index=index,
-            # Omitted means "keep whatever the album already has", the same
-            # rule as index and the InvokeAI password above: the edit form
-            # has no Cluster Strength control and never sends this key, so
-            # anything else here loses the user's tuning the moment they
-            # rename the album. An explicit null is still a clear — that is
-            # how /set_umap_eps hands an album back to the derived value.
-            umap_eps=album_data.get(
-                "umap_eps", existing.umap_eps if existing else None
+            # Board albums derive their directories from the InvokeAI root,
+            # so theirs are never carried over: a non-empty list suppresses
+            # that derivation, which would pin the album to its old root the
+            # moment the user edits the root.
+            image_paths=None if is_board else kept("image_paths"),
+            # Falsy, not just absent: the edit form sends "" when an album has
+            # no paths left to derive an index from, and an edit never
+            # relocates an index anyway.
+            index=album_data.get("index") or (existing.index if existing else None),
+            # cleared_or_kept, not kept: absent means "keep the tuning",
+            # but an explicit null is how an album is handed back to a
+            # strength derived from its own coordinates. 0.07 is gone as a
+            # fallback — "no value" now means "derive one".
+            umap_eps=cleared_or_kept("umap_eps"),
+            description=kept("description", ""),
+            encoder_spec=kept("encoder_spec"),
+            # Left to the model to re-resolve when the encoder family changed
+            # and the payload said nothing: carrying the other family's floor
+            # over makes the new encoder look like it returns nothing.
+            min_search_score=(
+                None
+                if score_band_changed and "min_search_score" not in album_data
+                else kept("min_search_score")
             ),
-            description=album_data.get("description", ""),
-            encoder_spec=album_data.get("encoder_spec"),
-            min_search_score=album_data.get("min_search_score"),
-            max_search_results=album_data.get("max_search_results"),
-            use_query_optimization=album_data.get("use_query_optimization"),
-            min_image_dimension=album_data.get("min_image_dimension"),
-            min_image_bytes=album_data.get("min_image_bytes"),
-            source_type=album_data.get("source_type", "directory"),
-            invokeai_url=album_data.get("invokeai_url"),
-            invokeai_username=album_data.get("invokeai_username"),
+            max_search_results=kept("max_search_results"),
+            use_query_optimization=kept("use_query_optimization"),
+            min_image_dimension=kept("min_image_dimension"),
+            min_image_bytes=kept("min_image_bytes"),
+            source_type=kept("source_type", "directory"),
+            invokeai_url=kept("invokeai_url"),
+            invokeai_username=cleared_or_kept("invokeai_username"),
             invokeai_password=password,
-            invokeai_root=album_data.get("invokeai_root"),
-            invokeai_board_ids=album_data.get("invokeai_board_ids"),
+            invokeai_root=kept("invokeai_root"),
+            invokeai_board_ids=kept("invokeai_board_ids"),
         )
+
+        # A board album's directories are derived from the InvokeAI root, not
+        # chosen: an added folder would widen the album's file-access gate to
+        # a directory InvokeAI knows nothing about, and the next index run
+        # would ignore it anyway. Refusing out loud beats accepting the
+        # request and quietly doing something else with it.
+        #
+        # Echoing back what the album already has is not a change, and there
+        # are two such lists while a root edit is in flight: the stored one
+        # and the one this request derives. Callers that GET an album and POST
+        # it back — the search-settings persister does exactly that — send one
+        # or the other depending on how the two raced, and neither is asking
+        # for anything.
+        requested_paths = album_data.get("image_paths")
+        if (
+            existing is not None
+            and existing.source_type == "invokeai_board"
+            and requested_paths is not None
+        ):
+
+            def _normalized(paths: list[str]) -> list[str]:
+                # Normalized the way ``create_album`` stores them, so a
+                # symlinked root echoed back does not read as a change. A path
+                # that cannot be resolved at all (symlink loop, embedded NUL)
+                # is left as-is: it will not match either list, which is the
+                # 400 this guard exists to raise, not a 500.
+                normalized = []
+                for path in paths:
+                    try:
+                        normalized.append(str(Path(path).expanduser().resolve()))
+                    except Exception:
+                        # Deliberately broad: what ``resolve()`` raises for an
+                        # unresolvable path is interpreter-dependent (a symlink
+                        # loop is a RuntimeError up to 3.12 and an OSError from
+                        # 3.13, an embedded NUL a ValueError), and this project
+                        # supports 3.10–3.13. Whatever it is, the path is not
+                        # one of the album's own — leave it unnormalized so it
+                        # falls through to the 400 rather than a 500.
+                        normalized.append(str(path))
+                return normalized
+
+            unchanged = _normalized(requested_paths) in (
+                _normalized(existing.image_paths),
+                _normalized(album.image_paths),
+            )
+            if not unchanged:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "InvokeAI-board albums take their image directories "
+                        "from the InvokeAI root; they cannot be changed or "
+                        "added to."
+                    ),
+                )
 
         logger.info(f"Updating album: {album.key} with index {album.index}")
 
@@ -396,6 +537,10 @@ async def update_album(album_data: dict) -> JSONResponse:
                 status_code=404, detail=f"Album '{album.key}' not found"
             )
 
+    except HTTPException:
+        # A 400/404 raised above is the answer; wrapping it in a 500 would
+        # bury the reason the update was refused.
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update album: {str(e)}") from e
 

--- a/photomap/frontend/static/css/album-manager.css
+++ b/photomap/frontend/static/css/album-manager.css
@@ -100,6 +100,19 @@
   margin-bottom: 0.5em;
 }
 
+/* The rule above is an author rule, so it beats the UA stylesheet's
+   [hidden] { display: none } — a label carrying the hidden attribute would
+   stay on screen. Same shape as the .video-player-* rules. */
+.edit-album-invoke-forget-password-row[hidden] {
+  display: none;
+}
+
+/* .form-group input is 100% wide, which is not what a checkbox wants. */
+.edit-album-invoke-forget-password-row input[type="checkbox"] {
+  width: auto;
+  margin-right: 0.4em;
+}
+
 .form-group input,
 .form-group textarea,
 .form-group select {

--- a/photomap/frontend/static/javascript/album-manager.js
+++ b/photomap/frontend/static/javascript/album-manager.js
@@ -1431,6 +1431,16 @@ export class AlbumManager {
         ? "(password saved — leave blank to keep)"
         : "(optional, multi-user mode)";
     }
+    // Offering "forget" with nothing stored would be a checkbox that does
+    // nothing, so the row only appears when there is a password to forget.
+    const forgetRow = editForm.querySelector(".edit-album-invoke-forget-password-row");
+    const forgetBox = editForm.querySelector(".edit-album-invoke-forget-password");
+    if (forgetRow) {
+      forgetRow.hidden = !album.has_invokeai_password;
+    }
+    if (forgetBox) {
+      forgetBox.checked = false;
+    }
     this._createInvokeRootRow(editForm.querySelector(".edit-album-invoke-root-row"), album.invokeai_root || "");
 
     // preferredIds wins when given; otherwise fall back to the album's saved
@@ -1546,10 +1556,15 @@ export class AlbumManager {
       updatedAlbum.invokeai_url = url;
       updatedAlbum.invokeai_root = root;
       updatedAlbum.invokeai_username = editForm.querySelector(".edit-album-invoke-username")?.value.trim() || null;
-      // Blank password means "keep the stored one" — omit it entirely.
+      // Blank password means "keep the stored one" — omit it entirely. An
+      // explicit null is the one way to clear it, and a freshly typed
+      // password wins over the checkbox: the user typed it last.
       const password = editForm.querySelector(".edit-album-invoke-password")?.value;
+      const forgetPassword = editForm.querySelector(".edit-album-invoke-forget-password")?.checked;
       if (password) {
         updatedAlbum.invokeai_password = password;
+      } else if (forgetPassword) {
+        updatedAlbum.invokeai_password = null;
       }
       updatedAlbum.invokeai_board_ids = boardIds;
       // index and image_paths are omitted: the backend keeps the stored

--- a/photomap/frontend/static/javascript/album-manager.js
+++ b/photomap/frontend/static/javascript/album-manager.js
@@ -9,7 +9,7 @@ import {
 } from "./invokeai-album-source.js";
 import { exitSearchMode } from "./search-ui.js";
 import { closeSettingsModal, loadAvailableAlbums, openSettingsModal } from "./settings.js";
-import { setAlbum, state } from "./state.js";
+import { refreshActiveAlbumSearchSettings, setAlbum, state } from "./state.js";
 import { fetchJson, hideSpinner, showSpinner } from "./utils.js";
 
 // Encoder backends offered in the album manager dropdown. Values must match
@@ -1593,6 +1593,11 @@ export class AlbumManager {
 
     try {
       await fetchJson("update_album/", { json: updatedAlbum });
+      // Before anything can persist the stale ones back: an encoder-family
+      // change re-resolves min_search_score server-side, and the search
+      // dialog would otherwise write the old album's floor over it on the
+      // next nudge of any setting.
+      await refreshActiveAlbumSearchSettings(updatedAlbum.key);
       await this.refreshAlbumsAndDropdown();
       if (sourceChanged) {
         this.send_update_index_event(updatedAlbum.key);

--- a/photomap/frontend/static/javascript/bookmarks.js
+++ b/photomap/frontend/static/javascript/bookmarks.js
@@ -686,8 +686,13 @@ class BookmarkManager {
         return cleanPath === targetPath;
       });
 
+      // A board album's directories come from the InvokeAI root and cannot
+      // be added to, so offering would promise something the backend has to
+      // refuse. (The move itself is rejected below with its own message.)
+      const isBoardAlbum = albumConfig.source_type === "invokeai_board";
+
       // If target folder is not in album, ask user to confirm adding it
-      if (!targetInAlbum) {
+      if (!targetInAlbum && !isBoardAlbum) {
         hideSpinner();
         const shouldAddFolder = await showConfirmModal(
           `The destination folder is not in the current album.\n\nWould you like to add "${targetDirectory}" to the "${state.album}" album?`,
@@ -863,17 +868,13 @@ class BookmarkManager {
     const updatedPaths = [...albumConfig.image_paths, folderPath];
 
     try {
+      // Deliberately partial: /update_album/ keeps every field this payload
+      // leaves out, so the album's encoder, gates and source type survive.
       await fetchJson("update_album/", {
         json: {
           key: albumConfig.key,
           name: albumConfig.name,
           image_paths: updatedPaths,
-          index: albumConfig.index,
-          // `?? null` rather than `|| 0.07`: an album whose Cluster Strength
-          // has never been set carries null, and adding a folder to it must
-          // not quietly pin it to a number.
-          umap_eps: albumConfig.umap_eps ?? null,
-          description: albumConfig.description || "",
         },
       });
     } catch {

--- a/photomap/frontend/static/javascript/state.js
+++ b/photomap/frontend/static/javascript/state.js
@@ -491,7 +491,8 @@ export async function setAlbum(newAlbumKey, force = false) {
 
 // Pulls per-album search settings from the backend and copies them into
 // state. Called on every album switch so the search dialog always reflects
-// the active album.
+// the active album, and after an album edit that can have changed them
+// server-side (see refreshActiveAlbumSearchSettings).
 async function applyAlbumSearchSettings(albumKey) {
   const album = await fetchJson(`album/${encodeURIComponent(albumKey)}/`).catch(() => null);
   if (!album) {
@@ -520,6 +521,22 @@ async function applyAlbumSearchSettings(albumKey) {
       },
     })
   );
+}
+
+// Reload the active album's search settings from the backend.
+//
+// Needed after an album edit, because the backend can change these without
+// being asked to: changing an album's encoder *family* re-resolves
+// min_search_score, since the CLIP floor (0.2) matches almost nothing on
+// SigLIP (0.005). Without this, state keeps the old album's floor, and the
+// next search-dialog edit persists it straight back over the re-resolved one
+// — where it now survives, because an update keeps every field its payload
+// carries.
+export async function refreshActiveAlbumSearchSettings(albumKey) {
+  if (!albumKey || albumKey !== state.album) {
+    return;
+  }
+  await applyAlbumSearchSettings(albumKey).catch((err) => console.warn("Failed to reload album search settings:", err));
 }
 
 // Persist the current state's per-album search settings back to the active

--- a/photomap/frontend/templates/modules/album-manager.html
+++ b/photomap/frontend/templates/modules/album-manager.html
@@ -207,6 +207,10 @@
           <div class="form-group">
             <label>Password</label>
             <input class="edit-album-invoke-password" type="password" autocomplete="new-password" />
+            <label class="edit-album-invoke-forget-password-row" hidden>
+              <input class="edit-album-invoke-forget-password" type="checkbox" />
+              Forget saved password
+            </label>
           </div>
         </div>
         <div class="form-group">

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -28,6 +28,24 @@ def isolate_video_frame_cache(tmp_path_factory, monkeypatch):
     return root
 
 
+@pytest.fixture(autouse=True)
+def isolate_user_data_dir(tmp_path_factory, monkeypatch):
+    """Keep derived board-album indexes out of the real user data directory.
+
+    ``default_board_index_path`` resolves against
+    ``platformdirs.user_data_dir``, and deleting a board album ``rmtree``s that
+    album's directory under it — so a test using an album key that matches a
+    real one deletes the real index. ``set_temp_config_env`` isolates only
+    ``PHOTOMAP_CONFIG``, the same gap ``isolate_video_frame_cache`` covers for
+    the cache directory.
+    """
+    from photomap.backend import config as config_module
+
+    root = tmp_path_factory.mktemp("user_data")
+    monkeypatch.setattr(config_module, "user_data_dir", lambda *a, **k: str(root))
+    return root
+
+
 @pytest.fixture(scope="session", autouse=True)
 def set_temp_config_env(tmp_path_factory):
     config_path = tmp_path_factory.mktemp("data") / "test_config.yaml"

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -512,6 +512,465 @@ def test_album_endpoints_never_leak_password(client):
         client.delete("/delete_album/board_album")
 
 
+def test_partial_update_does_not_demote_a_board_album(client):
+    """A payload that omits ``source_type`` is a patch, not a replacement: the
+    bookmark menu sends key/name/image_paths only, and rebuilding the album
+    from that used to reset it to a directory album with every ``invokeai_*``
+    field cleared — after which indexing walked InvokeAI's output directories
+    directly and deletions stopped routing through its API (issue #371)."""
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        response = client.post(
+            "/update_album/",
+            json={"key": "board_album", "name": "Board Album"},
+        )
+        assert response.status_code == 200, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        album = manager.get_album("board_album")
+        assert album.source_type == "invokeai_board"
+        assert album.invokeai_root == "/srv/invokeai"
+        assert album.invokeai_url == "http://localhost:9090"
+        assert album.invokeai_board_ids == ["b1", "none"]
+        assert album.invokeai_username == "alice"
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_adding_a_folder_to_a_board_album_is_refused(client):
+    """A board album's directories are derived from the InvokeAI root, so an
+    added folder cannot survive. Accepting the request and discarding it would
+    make "add this folder to the album" look like it worked."""
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        album = client.get("/album/board_album/").json()
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "name": "Board Album",
+                "image_paths": [*album["image_paths"], "/tmp/somewhere-else"],
+            },
+        )
+        assert response.status_code == 400, response.text
+        assert "InvokeAI root" in response.json()["detail"]
+
+        manager = get_config_manager()
+        manager.reload_config()
+        assert manager.get_album("board_album").image_paths == album["image_paths"]
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_unresolvable_path_is_refused_not_a_crash(client, tmp_path):
+    """The board guard normalizes paths to compare them, and what
+    ``Path.resolve()`` raises for an unresolvable one is interpreter-dependent
+    (a symlink loop is a RuntimeError up to 3.12, an OSError from 3.13). The
+    request is still just a refused change, not a 500."""
+    loop = tmp_path / "loop"
+    loop.symlink_to(tmp_path / "loop2")
+    (tmp_path / "loop2").symlink_to(loop)
+
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "name": "Board Album",
+                "image_paths": [str(loop)],
+            },
+        )
+        assert response.status_code == 400, response.text
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_partial_update_keeps_tuning_fields(client, tmp_path):
+    """The same patch rule for every other field: a payload that carries only
+    a rename must not reset the encoder, the scan gates or the search
+    settings to their model defaults."""
+    key = "patch_album"
+    client.post(
+        "/add_album/",
+        json={
+            "key": key,
+            "name": "Patch Album",
+            "image_paths": [str(tmp_path)],
+            "index": str(tmp_path / "photomap_index" / "embeddings.npz"),
+            "encoder_spec": "openai-clip:ViT-L/14",
+            "min_image_dimension": 512,
+            "min_image_bytes": 0,
+            "max_search_results": 42,
+            "use_query_optimization": False,
+            "description": "keep me",
+        },
+    )
+    try:
+        response = client.post(
+            "/update_album/", json={"key": key, "name": "Renamed"}
+        )
+        assert response.status_code == 200, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        album = manager.get_album(key)
+        assert album.name == "Renamed"
+        assert album.encoder_spec == "openai-clip:ViT-L/14"
+        assert album.min_image_dimension == 512
+        # 0 is a real setting (the gate off), not a missing value.
+        assert album.min_image_bytes == 0
+        assert album.max_search_results == 42
+        assert album.use_query_optimization is False
+        assert album.description == "keep me"
+        assert album.image_paths == [str(tmp_path)]
+    finally:
+        client.delete(f"/delete_album/{key}")
+
+
+def test_update_can_still_clear_and_change_values(client, tmp_path):
+    """Patching must not become "you can never change anything": explicit
+    values, including a falsy one, still win over what is stored."""
+    key = "patch_album_2"
+    client.post(
+        "/add_album/",
+        json={
+            "key": key,
+            "name": "Patch Album 2",
+            "image_paths": [str(tmp_path)],
+            "index": str(tmp_path / "photomap_index" / "embeddings.npz"),
+            "description": "original",
+            "min_image_bytes": 8192,
+        },
+    )
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": key,
+                "name": "Patch Album 2",
+                "description": "",
+                "min_image_bytes": 0,
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        album = manager.get_album(key)
+        assert album.description == ""
+        assert album.min_image_bytes == 0
+    finally:
+        client.delete(f"/delete_album/{key}")
+
+
+def test_changing_the_invokeai_root_moves_the_derived_paths(client):
+    """A board album's directories are derived from its root, so an edit that
+    moves the root has to move them: carrying the stored list over would
+    suppress the derivation and leave the access gate pointing at the old
+    root, 404ing every image the re-index just wrote."""
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        # Exactly what the album editor sends: image_paths and index omitted.
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "name": "Board Album",
+                "source_type": "invokeai_board",
+                "invokeai_url": "http://localhost:9090",
+                "invokeai_root": "/srv/invokeai2",
+                "invokeai_board_ids": ["b1", "none"],
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        album = manager.get_album("board_album")
+        assert album.invokeai_root == "/srv/invokeai2"
+        assert album.image_paths[0].startswith(str(Path("/srv/invokeai2")))
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_source_type_cannot_be_changed_by_an_update(client):
+    """The kind of an album is fixed at creation. A payload that disagrees is
+    a partial payload being read as a replacement, which is how board albums
+    used to be demoted (issue #371).
+
+    ``image_paths`` is deliberately omitted: with it, the request would be
+    refused by the board-paths guard instead, and this test would pass while
+    the source type went unchecked."""
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "name": "Board Album",
+                "source_type": "directory",
+            },
+        )
+        assert response.status_code == 400, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        assert manager.get_album("board_album").source_type == "invokeai_board"
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_invokeai_username_can_be_cleared(client):
+    """The edit form sends null for an emptied username — InvokeAI dropping
+    out of multi-user mode — and that has to clear it rather than read as
+    'field omitted'."""
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "name": "Board Album",
+                "source_type": "invokeai_board",
+                "invokeai_url": "http://localhost:9090",
+                "invokeai_root": "/srv/invokeai",
+                "invokeai_board_ids": ["b1", "none"],
+                "invokeai_username": None,
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        album = manager.get_album("board_album")
+        assert album.invokeai_username is None
+        assert album.invokeai_password == "secret"  # still kept
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_unrelated_edits_keep_a_tuned_min_search_score(client, tmp_path):
+    """The score is tuned from the search dialog and never sent by the album
+    editor, so any other edit — including swapping one CLIP model for another
+    — has to leave it alone."""
+    key = "tuned_score_album"
+    client.post(
+        "/add_album/",
+        json={
+            "key": key,
+            "name": "Tuned Score",
+            "image_paths": [str(tmp_path)],
+            "index": str(tmp_path / "photomap_index" / "embeddings.npz"),
+            "encoder_spec": "openai-clip:ViT-B/32",
+            "min_search_score": 0.35,
+        },
+    )
+    try:
+        manager = get_config_manager()
+
+        response = client.post("/update_album/", json={"key": key, "name": "Renamed"})
+        assert response.status_code == 200, response.text
+        manager.reload_config()
+        assert manager.get_album(key).min_search_score == 0.35
+
+        # Same family, different model: still no reason to touch the score.
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": key,
+                "name": "Renamed",
+                "encoder_spec": "openai-clip:ViT-L/14",
+            },
+        )
+        assert response.status_code == 200, response.text
+        manager.reload_config()
+        assert manager.get_album(key).min_search_score == 0.35
+    finally:
+        client.delete(f"/delete_album/{key}")
+
+
+def test_null_does_not_reset_a_tuning_field_to_its_default(client, tmp_path):
+    """``create_album`` turns a None into the *model default*, so honoring an
+    explicit null here would quietly re-encode an album under a different
+    encoder rather than clear anything."""
+    key = "null_field_album"
+    client.post(
+        "/add_album/",
+        json={
+            "key": key,
+            "name": "Null Field",
+            "image_paths": [str(tmp_path)],
+            "index": str(tmp_path / "photomap_index" / "embeddings.npz"),
+            "encoder_spec": "openai-clip:ViT-L/14",
+            "min_image_bytes": 0,
+        },
+    )
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": key,
+                "name": "Null Field",
+                "encoder_spec": None,
+                "min_image_bytes": None,
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        album = manager.get_album(key)
+        assert album.encoder_spec == "openai-clip:ViT-L/14"
+        assert album.min_image_bytes == 0
+    finally:
+        client.delete(f"/delete_album/{key}")
+
+
+def test_board_album_accepts_the_paths_its_own_root_change_derives(client):
+    """A caller that computes the new derived paths and sends them is not
+    asking for a change, and neither is one still echoing the stored list
+    while a root edit is in flight."""
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        base = {
+            "key": "board_album",
+            "name": "Board Album",
+            "source_type": "invokeai_board",
+            "invokeai_url": "http://localhost:9090",
+            "invokeai_root": "/srv/invokeai2",
+            "invokeai_board_ids": ["b1", "none"],
+        }
+        derived = str(Path("/srv/invokeai2") / "outputs" / "images")
+        response = client.post(
+            "/update_album/", json={**base, "image_paths": [derived]}
+        )
+        assert response.status_code == 200, response.text
+
+        # A root edit that carries the album's *stored* paths — what the
+        # album editor's own GET-then-POST produces — is likewise not a
+        # request to change them.
+        response = client.post(
+            "/update_album/",
+            json={
+                **base,
+                "invokeai_root": "/srv/invokeai3",
+                "image_paths": [str(Path("/srv/invokeai2") / "outputs" / "images")],
+            },
+        )
+        assert response.status_code == 200, response.text
+        manager = get_config_manager()
+        manager.reload_config()
+        album = manager.get_album("board_album")
+        assert album.invokeai_root == "/srv/invokeai3"
+        assert album.image_paths[0].startswith(str(Path("/srv/invokeai3")))
+
+        # A stale writer that fetched the album before the root moved posts
+        # the old root together with the old paths: consistent with itself,
+        # asking for nothing, and not the guard's business (it loses the root
+        # edit, which is the pre-existing last-write-wins race).
+        stale_root = {**base, "invokeai_root": "/srv/invokeai2"}
+        stale_paths = [str(Path("/srv/invokeai2") / "outputs" / "images")]
+        response = client.post(
+            "/update_album/", json={**stale_root, "image_paths": stale_paths}
+        )
+        assert response.status_code == 200, response.text
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_changing_the_encoder_reresolves_min_search_score(client, tmp_path):
+    """The sensible score floor differs by an order of magnitude between
+    encoder families, and the edit form never sends one. Carrying the old
+    value across an encoder change makes the new encoder look broken."""
+    key = "encoder_switch_album"
+    client.post(
+        "/add_album/",
+        json={
+            "key": key,
+            "name": "Encoder Switch",
+            "image_paths": [str(tmp_path)],
+            "index": str(tmp_path / "photomap_index" / "embeddings.npz"),
+            "encoder_spec": "siglip:google/siglip2-base-patch16-224",
+        },
+    )
+    try:
+        manager = get_config_manager()
+        manager.reload_config()
+        assert manager.get_album(key).min_search_score == 0.005
+
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": key,
+                "name": "Encoder Switch",
+                "encoder_spec": "openai-clip:ViT-B/32",
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        manager.reload_config()
+        assert manager.get_album(key).min_search_score == 0.2
+
+        # An explicit score still wins over the re-resolution.
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": key,
+                "name": "Encoder Switch",
+                "encoder_spec": "siglip:google/siglip2-base-patch16-224",
+                "min_search_score": 0.15,
+            },
+        )
+        assert response.status_code == 200, response.text
+        manager.reload_config()
+        assert manager.get_album(key).min_search_score == 0.15
+    finally:
+        client.delete(f"/delete_album/{key}")
+
+
+def test_blank_index_keeps_the_stored_one(client, tmp_path):
+    """The edit form sends "" for the index when an album has no paths left to
+    derive one from; that must not be resolved against the server's working
+    directory."""
+    key = "blank_index_album"
+    index = str(tmp_path / "photomap_index" / "embeddings.npz")
+    client.post(
+        "/add_album/",
+        json={
+            "key": key,
+            "name": "Blank Index",
+            "image_paths": [str(tmp_path)],
+            "index": index,
+        },
+    )
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": key,
+                "name": "Blank Index",
+                "image_paths": [str(tmp_path)],
+                "index": "",
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        manager = get_config_manager()
+        manager.reload_config()
+        assert manager.get_album(key).index == index
+    finally:
+        client.delete(f"/delete_album/{key}")
+
+
 def test_update_board_album_keeps_password_and_index_when_omitted(client):
     """The edit form omits the password (never echoed) and the index — both
     must survive an update untouched."""

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -1310,3 +1310,58 @@ def test_the_token_cache_is_left_alone_when_credentials_did_not_change(
         assert calls == []
     finally:
         client.delete("/delete_album/board_album")
+
+
+@pytest.mark.parametrize(
+    "paths_for",
+    [
+        lambda root: list(reversed(_derived_board_paths(root))),
+        lambda root: _derived_board_paths(root)[:1],
+        lambda root: _derived_board_paths(root)[1:],
+    ],
+    ids=["reordered", "images-only", "videos-only"],
+)
+def test_echoing_part_of_a_board_albums_paths_is_not_a_change(client, paths_for):
+    """The guard asks whether the caller is requesting a *change*.
+
+    Order carries no meaning here, and the derived list has grown — board
+    albums gained an ``outputs/videos`` directory — so a client holding a
+    snapshot from before that sends one path where the album now has two.
+    Neither is asking for anything, and both used to be refused.
+    """
+    assert client.post("/add_album/", json=_board_album_payload()).status_code == 201
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "name": "Board Album",
+                "image_paths": paths_for("/srv/invokeai"),
+            },
+        )
+        assert response.status_code == 200, response.text
+        # Still derived from the root, whatever the caller echoed.
+        assert get_config_manager().get_album("board_album").image_paths == (
+            _derived_board_paths("/srv/invokeai")
+        )
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_a_board_album_still_refuses_a_directory_it_does_not_derive(client):
+    """The tolerance above must not become "anything goes": a genuinely new
+    directory is still refused out loud rather than silently ignored."""
+    assert client.post("/add_album/", json=_board_album_payload()).status_code == 201
+    try:
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "name": "Board Album",
+                "image_paths": _derived_board_paths("/srv/invokeai") + ["/srv/elsewhere"],
+            },
+        )
+        assert response.status_code == 400
+        assert "InvokeAI root" in response.json()["detail"]
+    finally:
+        client.delete("/delete_album/board_album")

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -1019,7 +1019,11 @@ def test_blank_index_keeps_the_stored_one(client, tmp_path):
 
         manager = get_config_manager()
         manager.reload_config()
-        assert manager.get_album(key).index == index
+        # Compared as paths, not strings: Album.validate_index_path stores the
+        # posix form, so on Windows the stored value uses forward slashes
+        # while str(tmp_path / ...) uses backslashes. Both name the same file,
+        # which is what this test is about.
+        assert Path(manager.get_album(key).index) == Path(index)
     finally:
         client.delete(f"/delete_album/{key}")
 

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -834,6 +834,17 @@ def test_null_does_not_reset_a_tuning_field_to_its_default(client, tmp_path):
         client.delete(f"/delete_album/{key}")
 
 
+def _derived_board_paths(root: str) -> list[str]:
+    """The image directories a board album derives from ``root``.
+
+    Both of them — board albums have indexed videos alongside images since
+    #369, so the derived list is a pair and a caller echoing only the images
+    directory is not echoing what the album has.
+    """
+    outputs = Path(root) / "outputs"
+    return [str(outputs / "images"), str(outputs / "videos")]
+
+
 def test_board_album_accepts_the_paths_its_own_root_change_derives(client):
     """A caller that computes the new derived paths and sends them is not
     asking for a change, and neither is one still echoing the stored list
@@ -849,10 +860,11 @@ def test_board_album_accepts_the_paths_its_own_root_change_derives(client):
             "invokeai_root": "/srv/invokeai2",
             "invokeai_board_ids": ["b1", "none"],
         }
-        derived = str(Path("/srv/invokeai2") / "outputs" / "images")
-        response = client.post(
-            "/update_album/", json={**base, "image_paths": [derived]}
-        )
+        # Both of them: a board album derives an images *and* a videos
+        # directory from its root, so "the paths this root derives" is the
+        # pair, not the images one alone.
+        derived = _derived_board_paths("/srv/invokeai2")
+        response = client.post("/update_album/", json={**base, "image_paths": derived})
         assert response.status_code == 200, response.text
 
         # A root edit that carries the album's *stored* paths — what the
@@ -863,7 +875,7 @@ def test_board_album_accepts_the_paths_its_own_root_change_derives(client):
             json={
                 **base,
                 "invokeai_root": "/srv/invokeai3",
-                "image_paths": [str(Path("/srv/invokeai2") / "outputs" / "images")],
+                "image_paths": _derived_board_paths("/srv/invokeai2"),
             },
         )
         assert response.status_code == 200, response.text
@@ -878,7 +890,7 @@ def test_board_album_accepts_the_paths_its_own_root_change_derives(client):
         # asking for nothing, and not the guard's business (it loses the root
         # edit, which is the pre-existing last-write-wins race).
         stale_root = {**base, "invokeai_root": "/srv/invokeai2"}
-        stale_paths = [str(Path("/srv/invokeai2") / "outputs" / "images")]
+        stale_paths = _derived_board_paths("/srv/invokeai2")
         response = client.post(
             "/update_album/", json={**stale_root, "image_paths": stale_paths}
         )

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -887,6 +887,47 @@ def test_board_album_accepts_the_paths_its_own_root_change_derives(client):
         client.delete("/delete_album/board_album")
 
 
+def test_invokeai_password_can_be_forgotten(client):
+    """A blank password means "I did not touch this", so clearing one needs a
+    signal of its own: the edit form's *Forget saved password* box sends an
+    explicit null. Without it a backend that leaves multi-user mode keeps
+    offering a credential nobody can remove short of editing YAML."""
+    response = client.post("/add_album/", json=_board_album_payload())
+    assert response.status_code == 201, response.text
+    try:
+        base = {
+            "key": "board_album",
+            "name": "Board Album",
+            "source_type": "invokeai_board",
+            "invokeai_url": "http://localhost:9090",
+            "invokeai_root": "/srv/invokeai",
+            "invokeai_board_ids": ["b1", "none"],
+        }
+        manager = get_config_manager()
+
+        # Blank still means keep.
+        response = client.post(
+            "/update_album/", json={**base, "invokeai_password": ""}
+        )
+        assert response.status_code == 200, response.text
+        manager.reload_config()
+        assert manager.get_album("board_album").invokeai_password == "secret"
+        assert client.get("/album/board_album/").json()["has_invokeai_password"] is True
+
+        # Null clears it.
+        response = client.post(
+            "/update_album/", json={**base, "invokeai_password": None}
+        )
+        assert response.status_code == 200, response.text
+        manager.reload_config()
+        assert manager.get_album("board_album").invokeai_password is None
+        assert (
+            client.get("/album/board_album/").json()["has_invokeai_password"] is False
+        )
+    finally:
+        client.delete("/delete_album/board_album")
+
+
 def test_changing_the_encoder_reresolves_min_search_score(client, tmp_path):
     """The sensible score floor differs by an order of magnitude between
     encoder families, and the edit form never sends one. Carrying the old

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -1140,3 +1140,173 @@ def test_min_image_bytes_round_trips(client, tmp_path):
         assert response.status_code == 200
         listing = {a["key"]: a for a in client.get("/available_albums/").json()}
         assert listing["bytes_default"]["min_image_bytes"] == value
+
+
+def _directory_album(client, tmp_path, key, **overrides):
+    """A plain directory album to patch in the tests below."""
+    images = tmp_path / key
+    images.mkdir()
+    payload = {
+        "key": key,
+        "name": key.capitalize(),
+        "image_paths": [str(images)],
+        "index": str(tmp_path / f"{key}.npz"),
+        "encoder_spec": "openai-clip:ViT-B/32",
+    }
+    payload.update(overrides)
+    assert client.post("/add_album/", json=payload).status_code == 201
+    return payload
+
+
+def test_a_null_score_still_re_resolves_across_an_encoder_family_change(
+    client, tmp_path
+):
+    """Null means "not supplied" to ``kept``, so it has to mean that here too.
+
+    Testing presence instead made the two halves of this rule disagree: an
+    explicit null suppressed the re-resolve *and* then fell through ``kept``
+    to the stored number, leaving a CLIP floor of 0.35 on a SigLIP album.
+    SigLIP similarities sit around 0.05-0.15, so that floor matches nothing
+    and the album's search silently returns empty.
+    """
+    _directory_album(client, tmp_path, "nullscore", min_search_score=0.35)
+
+    response = client.post(
+        "/update_album/",
+        json={
+            "key": "nullscore",
+            "encoder_spec": "siglip:google/siglip2-large-patch16-256",
+            "min_search_score": None,
+        },
+    )
+    assert response.status_code == 200
+
+    album = get_config_manager().get_album("nullscore")
+    assert album.encoder_spec.startswith("siglip:")
+    assert album.min_search_score == pytest.approx(0.005)
+
+
+def test_a_hand_tuned_score_survives_a_change_within_one_family(client, tmp_path):
+    """The other half: swapping one CLIP model for another must not touch a
+    score the user chose."""
+    _directory_album(client, tmp_path, "tuned", min_search_score=0.35)
+
+    # `name` carried so this pins the family logic alone, not the separate
+    # fix that made an omitted name patchable.
+    response = client.post(
+        "/update_album/",
+        json={
+            "key": "tuned",
+            "name": "Tuned",
+            "encoder_spec": "open-clip:ViT-L-14/dfn2b_s39b",
+        },
+    )
+    assert response.status_code == 200
+    assert get_config_manager().get_album("tuned").min_search_score == pytest.approx(0.35)
+
+
+def test_name_is_patchable_like_every_other_field(client, tmp_path):
+    """The endpoint documents "a key the payload does not carry keeps its
+    current value"; name was read straight out of the payload, so omitting it
+    raised a KeyError that surfaced as a 500 whose detail was the word
+    "name"."""
+    _directory_album(client, tmp_path, "namekeep")
+
+    response = client.post(
+        "/update_album/", json={"key": "namekeep", "min_search_score": 0.3}
+    )
+    assert response.status_code == 200
+    album = get_config_manager().get_album("namekeep")
+    assert album.name == "Namekeep"
+    assert album.min_search_score == pytest.approx(0.3)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"key": "ghost", "name": "Ghost"},
+        {"key": "ghost"},
+        {
+            "key": "ghost",
+            "name": "Ghost",
+            "image_paths": ["/tmp/ghost"],
+            "index": "/tmp/ghost/i.npz",
+        },
+    ],
+    ids=["partial", "key-only", "complete"],
+)
+def test_updating_a_missing_album_is_always_a_404(client, payload):
+    """It used to depend on the payload: a complete one reached the failed
+    write and got a 404, a partial one died in create_album and got a 500.
+    There is nothing to patch either way."""
+    response = client.post("/update_album/", json=payload)
+    assert response.status_code == 404
+    assert get_config_manager().get_album("ghost") is None
+
+
+def test_the_token_cache_is_invalidated_only_once_the_change_is_stored(
+    client, monkeypatch
+):
+    """Order matters: the cache key is (url, username), so the password is
+    not part of it.
+
+    Invalidating before the write leaves a window in which any request that
+    reads the album — an index scan, a board delete — logs in with the *old*
+    password and re-caches a token that then outlives the change by up to a
+    day, which is exactly what this invalidation exists to prevent.
+    """
+    from photomap.backend import invokeai_client
+    from photomap.backend.routers import album as album_router
+
+    assert client.post("/add_album/", json=_board_album_payload()).status_code == 201
+    try:
+        order = []
+
+        def record_invalidate():
+            order.append("invalidate")
+
+        real_update = album_router.config_manager.update_album
+
+        def record_update(album):
+            order.append("write")
+            return real_update(album)
+
+        monkeypatch.setattr(
+            invokeai_client, "_invalidate_token_cache", record_invalidate
+        )
+        monkeypatch.setattr(album_router.config_manager, "update_album", record_update)
+
+        response = client.post(
+            "/update_album/",
+            json={
+                "key": "board_album",
+                "invokeai_password": None,
+            },
+        )
+        assert response.status_code == 200
+        assert order == ["write", "invalidate"]
+    finally:
+        client.delete("/delete_album/board_album")
+
+
+def test_the_token_cache_is_left_alone_when_credentials_did_not_change(
+    client, monkeypatch
+):
+    """Every album edit would otherwise force a fresh login on the next
+    InvokeAI call, for a rename."""
+    from photomap.backend import invokeai_client
+
+    assert client.post("/add_album/", json=_board_album_payload()).status_code == 201
+    try:
+        calls = []
+        monkeypatch.setattr(
+            invokeai_client, "_invalidate_token_cache", lambda: calls.append(1)
+        )
+
+        response = client.post(
+            "/update_album/", json={"key": "board_album", "name": "Renamed"}
+        )
+        assert response.status_code == 200
+        assert calls == []
+    finally:
+        client.delete("/delete_album/board_album")

--- a/tests/frontend/album-manager-progress.test.js
+++ b/tests/frontend/album-manager-progress.test.js
@@ -30,6 +30,7 @@ jest.unstable_mockModule(`${M}/settings.js`, () => ({
 }));
 jest.unstable_mockModule(`${M}/state.js`, () => ({
   setAlbum: jest.fn(),
+  refreshActiveAlbumSearchSettings: jest.fn(() => Promise.resolve()),
   state: {},
 }));
 jest.unstable_mockModule(`${M}/utils.js`, () => ({

--- a/tests/frontend/album-manager-update-all.test.js
+++ b/tests/frontend/album-manager-update-all.test.js
@@ -31,6 +31,7 @@ jest.unstable_mockModule(`${M}/settings.js`, () => ({
 }));
 jest.unstable_mockModule(`${M}/state.js`, () => ({
   setAlbum: jest.fn(),
+  refreshActiveAlbumSearchSettings: jest.fn(() => Promise.resolve()),
   state: {},
 }));
 jest.unstable_mockModule(`${M}/utils.js`, () => ({

--- a/tests/frontend/album-search-settings-refresh.test.js
+++ b/tests/frontend/album-search-settings-refresh.test.js
@@ -1,0 +1,93 @@
+// Reloading an album's search settings after it is edited.
+//
+// The backend changes min_search_score without being asked to: swapping an
+// album's encoder *family* re-resolves it, because the CLIP floor (0.2)
+// matches almost nothing under SigLIP (0.005). If state keeps the old value,
+// the next nudge of any search setting persists it straight back over the
+// re-resolved one -- and it now survives there, because an album update
+// keeps every field its payload carries.
+
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+
+const JS = "../../photomap/frontend/static/javascript";
+
+jest.unstable_mockModule(`${JS}/album-manager.js`, () => ({
+  albumManager: { fetchAvailableAlbums: jest.fn(() => Promise.resolve([])) },
+  checkAlbumIndex: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/cluster-utils.js`, () => ({
+  setAutotaggingEnabledInLabels: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/index.js`, () => ({
+  getIndexMetadata: jest.fn(() => Promise.resolve({ filename_count: 0 })),
+}));
+jest.unstable_mockModule(`${JS}/preferences-client.js`, () => ({
+  fetchPreferences: jest.fn(() => Promise.resolve({})),
+  flushPendingPatches: jest.fn(() => Promise.resolve()),
+  loadServerTimestamp: jest.fn(() => Promise.resolve()),
+  queuePreferencePatch: jest.fn(),
+}));
+
+const fetchJson = jest.fn();
+jest.unstable_mockModule(`${JS}/utils.js`, () => ({ fetchJson }));
+
+const SIGLIP = {
+  key: "a",
+  encoder_spec: "siglip:google/siglip2-large-patch16-256",
+  min_search_score: 0.005,
+  max_search_results: 100,
+  use_query_optimization: true,
+};
+
+let stateModule;
+
+beforeEach(async () => {
+  jest.resetModules();
+  fetchJson.mockReset();
+  stateModule = await import(`${JS}/state.js`);
+  // The album was a CLIP album when the page loaded.
+  stateModule.state.album = "a";
+  stateModule.state.minSearchScore = 0.2;
+});
+
+describe("refreshActiveAlbumSearchSettings", () => {
+  it("adopts a score the backend re-resolved during an album edit", async () => {
+    fetchJson.mockResolvedValue(SIGLIP);
+
+    await stateModule.refreshActiveAlbumSearchSettings("a");
+
+    expect(stateModule.state.minSearchScore).toBe(0.005);
+  });
+
+  it("ignores an edit to some album other than the active one", async () => {
+    fetchJson.mockResolvedValue(SIGLIP);
+
+    await stateModule.refreshActiveAlbumSearchSettings("b");
+
+    expect(fetchJson).not.toHaveBeenCalled();
+    expect(stateModule.state.minSearchScore).toBe(0.2);
+  });
+
+  it("leaves state alone when the reload fails", async () => {
+    fetchJson.mockRejectedValue(new Error("offline"));
+
+    await expect(stateModule.refreshActiveAlbumSearchSettings("a")).resolves.toBeUndefined();
+    expect(stateModule.state.minSearchScore).toBe(0.2);
+  });
+
+  it("stops the next settings write from restoring the stale score", async () => {
+    // The whole point: without the refresh, this write puts 0.2 back on a
+    // SigLIP album, where it matches nothing.
+    fetchJson.mockResolvedValue(SIGLIP);
+    await stateModule.refreshActiveAlbumSearchSettings("a");
+
+    fetchJson.mockReset();
+    fetchJson.mockResolvedValue(SIGLIP);
+    stateModule.persistCurrentAlbumSearchSettings();
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const write = fetchJson.mock.calls.find(([url]) => url === "update_album/");
+    expect(write).toBeDefined();
+    expect(write[1].json.min_search_score).toBe(0.005);
+  });
+});

--- a/tests/frontend/bookmarks-move-board-album.test.js
+++ b/tests/frontend/bookmarks-move-board-album.test.js
@@ -1,0 +1,112 @@
+// An InvokeAI-board album's directories are derived from the InvokeAI root, so
+// the "the destination is not in this album — add it?" offer cannot be honored
+// for one: the backend refuses the change, and before it did, the partial
+// update silently demoted the album to a directory album (issue #371).
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const mockFetchJson = jest.fn();
+const mockShowConfirmModal = jest.fn();
+
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/utils.js", () => ({
+  errorDetail: jest.fn(),
+  fetchJson: mockFetchJson,
+  hideSpinner: jest.fn(),
+  setCheckmarkOnIcon: jest.fn(),
+  showSpinner: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/control-panel.js", () => ({
+  showDeleteConfirmModal: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/filetree.js", () => ({
+  createSimpleDirectoryPicker: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/index.js", () => ({
+  deleteImages: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/modal-utils.js", () => ({
+  showConfirmModal: mockShowConfirmModal,
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/search.js", () => ({
+  setSearchResults: jest.fn(),
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/slide-state.js", () => ({
+  slideState: { getCurrentSlide: () => ({ globalIndex: 0 }), totalAlbumImages: 0 },
+}));
+jest.unstable_mockModule("../../photomap/frontend/static/javascript/state.js", () => ({
+  state: { album: "board", swiper: null, single_swiper: null },
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+
+const { bookmarkManager } = await import("../../photomap/frontend/static/javascript/bookmarks.js");
+
+/** Route fetchJson by URL: album config, then the move itself. */
+function routeFetch(albumConfig, moveResult) {
+  mockFetchJson.mockImplementation((url) => {
+    if (url.startsWith("album/")) {
+      return Promise.resolve(albumConfig);
+    }
+    if (url.startsWith("move_images/")) {
+      return moveResult();
+    }
+    return Promise.resolve({});
+  });
+}
+
+const BOARD_ALBUM = {
+  key: "board",
+  name: "Board",
+  source_type: "invokeai_board",
+  image_paths: ["/srv/invokeai/outputs/images"],
+  index: "/data/board/embeddings.npz",
+};
+
+const DIRECTORY_ALBUM = {
+  key: "dir",
+  name: "Dir",
+  source_type: "directory",
+  image_paths: ["/photos"],
+  index: "/photos/photomap_index/embeddings.npz",
+};
+
+beforeEach(() => {
+  mockFetchJson.mockReset();
+  mockShowConfirmModal.mockReset();
+  global.alert = jest.fn();
+});
+
+describe("performMove on an InvokeAI-board album", () => {
+  it("does not offer to add the destination folder to the album", async () => {
+    routeFetch(BOARD_ALBUM, () => Promise.reject(new Error("Moving images is not supported")));
+
+    await bookmarkManager.performMove([0], "/somewhere/else");
+
+    expect(mockShowConfirmModal).not.toHaveBeenCalled();
+    const updateCalls = mockFetchJson.mock.calls.filter(([url]) => url === "update_album/");
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it("still offers for a directory album", async () => {
+    routeFetch(DIRECTORY_ALBUM, () => Promise.resolve({ moved_count: 1, same_folder_count: 0, error_count: 0 }));
+    mockShowConfirmModal.mockResolvedValue(false);
+
+    await bookmarkManager.performMove([0], "/somewhere/else");
+
+    expect(mockShowConfirmModal).toHaveBeenCalled();
+  });
+});
+
+describe("addFolderToAlbum", () => {
+  it("sends only the fields it is changing, so the rest survive the patch", async () => {
+    mockFetchJson.mockResolvedValue({});
+
+    await bookmarkManager.addFolderToAlbum("/extra", DIRECTORY_ALBUM);
+
+    const [url, options] = mockFetchJson.mock.calls[0];
+    expect(url).toBe("update_album/");
+    expect(options.json).toEqual({
+      key: "dir",
+      name: "Dir",
+      image_paths: ["/photos", "/extra"],
+    });
+  });
+});

--- a/tests/frontend/invokeai-album-source.test.js
+++ b/tests/frontend/invokeai-album-source.test.js
@@ -445,7 +445,7 @@ describe("AlbumManager source-section toggle", () => {
 });
 
 describe("AlbumManager edit-save payloads for board albums", () => {
-  function buildEditDom({ loaded = true, boardIds = ["b1"] } = {}) {
+  function buildEditDom({ loaded = true, boardIds = ["b1"], password = "", forget = false } = {}) {
     document.body.innerHTML = `
       <div class="album-card">
         <div class="edit-form">
@@ -456,7 +456,10 @@ describe("AlbumManager edit-save payloads for board albums", () => {
           <input class="edit-album-invoke-url" value="http://localhost:9090" />
           <div class="edit-album-invoke-root-row"><input class="invoke-root-input" value="/srv/invokeai" /></div>
           <input class="edit-album-invoke-username" value="alice" />
-          <input class="edit-album-invoke-password" value="" />
+          <input class="edit-album-invoke-password" value="${password}" />
+          <label class="edit-album-invoke-forget-password-row" ${forget ? "" : "hidden"}>
+            <input class="edit-album-invoke-forget-password" type="checkbox" ${forget ? "checked" : ""} />
+          </label>
           <div class="edit-album-invoke-boards" ${loaded ? 'data-loaded="true"' : ""}>
             ${boardIds
               .map((id) => `<label><input type="checkbox" class="board-checkbox" value="${id}" checked /></label>`)
@@ -501,6 +504,34 @@ describe("AlbumManager edit-save payloads for board albums", () => {
     expect(manager.send_update_index_event).toHaveBeenCalledWith("board_album");
   });
 
+  test.each([
+    // typed password, forget box, what the payload should carry
+    ["", false, "absent"],
+    ["", true, "null"],
+    ["typed", false, "typed"],
+    // A password typed in the same edit is the later intent of the two.
+    ["typed", true, "typed"],
+  ])("password %p with forget=%p sends %s", async (password, forget, expected) => {
+    const card = buildEditDom({ password, forget });
+    const manager = makeEditStub();
+    fetchJson.mockResolvedValue({ success: true });
+
+    await AlbumManager.prototype.saveAlbumChanges.call(manager, card, album);
+
+    const payload = fetchJson.mock.calls[0][1].json;
+    if (expected === "absent") {
+      // Absent and null are the same after JSON.stringify but opposite in
+      // meaning to the backend: absent keeps the stored password, null
+      // clears it.
+      expect(Object.hasOwn(payload, "invokeai_password")).toBe(false);
+    } else if (expected === "null") {
+      expect(Object.hasOwn(payload, "invokeai_password")).toBe(true);
+      expect(payload.invokeai_password).toBeNull();
+    } else {
+      expect(payload.invokeai_password).toBe(expected);
+    }
+  });
+
   test("unloaded board checklist falls back to the saved selection", async () => {
     const card = buildEditDom({ loaded: false, boardIds: [] });
     const manager = makeEditStub();
@@ -517,10 +548,22 @@ describe("AlbumManager edit-save payloads for board albums", () => {
 describe("AlbumManager board-album edit form population", () => {
   function buildBoardEditForm() {
     document.body.innerHTML = `
+      <style>
+        /* The real stylesheet's .form-group label rule is what made the
+           hidden attribute a no-op on this row; keep both here so the test
+           fails if the override is dropped. */
+        .form-group label { display: block; }
+        .edit-album-invoke-forget-password-row[hidden] { display: none; }
+      </style>
       <div class="edit-form">
         <input class="edit-album-invoke-url" />
         <input class="edit-album-invoke-username" />
-        <input class="edit-album-invoke-password" />
+        <div class="form-group">
+          <input class="edit-album-invoke-password" />
+          <label class="edit-album-invoke-forget-password-row" hidden>
+            <input class="edit-album-invoke-forget-password" type="checkbox" />
+          </label>
+        </div>
         <small class="edit-album-invoke-status-hint"></small>
         <div class="edit-album-invoke-root-row"></div>
         <button class="edit-album-invoke-connect-btn"></button>
@@ -555,6 +598,47 @@ describe("AlbumManager board-album edit form population", () => {
   // Flush the async connectAndLoadBoards() chain populateBoardAlbumEditForm
   // kicks off but doesn't await.
   const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  test("the forget-password row is only offered when a password is stored", async () => {
+    const editForm = buildBoardEditForm();
+    const manager = makeStub();
+    fetchJson.mockResolvedValue({ reachable: false, detail: "not reachable" });
+    const row = editForm.querySelector(".edit-album-invoke-forget-password-row");
+
+    manager.populateBoardAlbumEditForm(editForm, {
+      ...album,
+      has_invokeai_password: false,
+    });
+    // Computed style, not just the attribute: `.form-group label` sets
+    // display:block, which beats the UA stylesheet's [hidden] rule — the
+    // attribute alone would report hidden while the box stayed on screen.
+    expect(getComputedStyle(row).display).toBe("none");
+
+    manager.populateBoardAlbumEditForm(editForm, {
+      ...album,
+      has_invokeai_password: true,
+    });
+    expect(getComputedStyle(row).display).not.toBe("none");
+
+    // populateBoardAlbumEditForm kicks off connectAndLoadBoards without
+    // awaiting it; drain it here so it cannot land inside the next test.
+    await flush();
+  });
+
+  test("re-opening the form clears a previously checked forget box", async () => {
+    const editForm = buildBoardEditForm();
+    const manager = makeStub();
+    fetchJson.mockResolvedValue({ reachable: false, detail: "not reachable" });
+    const box = editForm.querySelector(".edit-album-invoke-forget-password");
+
+    manager.populateBoardAlbumEditForm(editForm, album);
+    box.checked = true;
+    manager.populateBoardAlbumEditForm(editForm, album);
+
+    expect(box.checked).toBe(false);
+
+    await flush();
+  });
 
   test("checks every saved board on reopen, even when Uncategorized is among them", async () => {
     // Regression: the placeholder render only paints the (checked)

--- a/tests/frontend/invokeai-album-source.test.js
+++ b/tests/frontend/invokeai-album-source.test.js
@@ -30,6 +30,7 @@ jest.unstable_mockModule(`${M}/settings.js`, () => ({
 }));
 jest.unstable_mockModule(`${M}/state.js`, () => ({
   setAlbum: jest.fn(),
+  refreshActiveAlbumSearchSettings: jest.fn(() => Promise.resolve()),
   state: {},
 }));
 jest.unstable_mockModule(`${M}/utils.js`, () => ({


### PR DESCRIPTION
Fixes #371.

`POST /update_album/` rebuilt the album from the request payload alone, so every field the payload left out was reset to its model default. Real callers send partial payloads — the bookmark menu sends five keys, the search dialog sends the album plus three overrides — and the worst thing that reset was `source_type`: an InvokeAI-board album came back as a *directory* album with every `invokeai_*` field cleared. After that its indexing walked InvokeAI's output directories as ordinary folders, and deletions stopped routing through InvokeAI's API, leaving dangling rows in its database.

Reproducing it took one bookmark: bookmark menu → **Move to folder** → pick a folder outside the album → **"Yes, Add Folder"**.

## What changed

**An update is a patch.** A key the payload does not carry keeps its stored value. Falsy values that real edits send — `min_image_bytes: 0`, `use_query_optimization: false`, an emptied description — still win. Null is treated as absent, because `create_album` turns a None into the model *default* rather than into a cleared field; honoring it would swap an album's encoder for the host default and silently invalidate its index. `invokeai_username` is the one field that genuinely needs clearing (InvokeAI leaving multi-user mode), so it goes through a helper that keys on presence instead.

**Three things that needed handling beyond the plain rule:**

- **Board albums pass `image_paths=None`** so the model re-derives them. Carrying the stored list over would suppress that derivation and pin the album to its old root the moment the user edits the root — the re-index would write under the new root while the access gate still pointed at the old one, 404ing every image in the album.
- **`min_search_score` is left to the model to re-resolve when the encoder *family* changes.** The floors differ by an order of magnitude (0.005 for SigLIP, 0.2 for CLIP), so carrying one across makes the new encoder look like it returns nothing — but swapping one CLIP model for another must not discard a score the user tuned by hand. The model and the router now read that rule from one `default_min_search_score`.
- **A `source_type` that disagrees with the stored album is refused.** The edit form branches on the stored kind and never offers to switch, so a disagreement is a partial payload being read as a replacement.

**A board album's directories cannot be changed or added to**, and saying so beats accepting the request and quietly deriving something else: a payload that changes them gets a 400, unless it merely echoes the album's paths — either the stored list or the one that same request derives, both of which callers legitimately send while a root edit is in flight. An `HTTPException` raised inside the handler is now re-raised rather than wrapped in a 500, so that 400 (and the 404 for an unknown key) survives as itself.

**Frontend:** the bookmark menu no longer offers to add a destination folder to a board album, since the backend has to refuse it, and its update payload carries only the keys it is changing.

## Clearing the InvokeAI password

The same "blank means I did not touch this" rule left the password unclearable: the edit form never sees the stored one, so there was no way to say *forget it*. An InvokeAI that leaves multi-user mode kept a credential in `config.yaml` that only a text editor could remove, and `has_invokeai_password` kept reporting it to the form.

`invokeai_password: null` now clears it, while `""` and an omitted key still keep what is stored. No existing caller can send that null by accident — `_album_public_dict` carries `has_invokeai_password` and never the password itself, so the search-settings persister's round trip cannot reach it, and the bookmark menu sends three keys. The only source is a new **Forget saved password** checkbox in the edit form, offered only when there is one to forget and reset every time the form opens; a password typed in the same edit wins over it.

That checkbox needed its own `[hidden]` rule. It lives in a `<label>` inside a `.form-group`, and that selector's `display: block` is an author rule, so it beats the UA stylesheet's `[hidden] { display: none }` — the box stayed on screen for albums with no stored password while the attribute reported otherwise. Same shape as the existing `.video-player-*[hidden]` rules.

Clearing or changing a credential now also invalidates the cached JWT. The token is keyed on `(base_url, username)`, neither of which has to change when a password does, so a forgotten password would have kept working from cache until the token expired — up to a day later.

## Tests

Eleven new backend cases: the demotion itself, the refused folder and source-type changes, a root change moving the derived paths, an explicit null neither clearing a tuning field nor surviving as one, the username clear, the encoder-family re-resolve and the same-family preservation, a blank index, and an unresolvable path being refused rather than crashing. Plus the password work: the three-way backend distinction (absent / blank / null), and on the frontend the payload matrix including "typed wins over the box", the row's visibility under the real CSS rule — asserting computed style, since the attribute alone reported hidden while the box was visible — and the reset on re-open. Each was checked by reverting its production hunk and confirming it fails.

Board-album tests also stopped deleting from the developer's **real** user data directory: `default_board_index_path` resolves against `platformdirs.user_data_dir`, which no fixture isolated, so a test album keyed like a real one removed the real index on cleanup — the same gap `isolate_video_frame_cache` already covers for the cache directory.

Backend 681 passed, frontend 587 passed, ruff and prettier clean.

## Notes

Found during the adversarial review of #369; the bug predates it and reproduces on `master`. This branch is based on `master` and does not depend on #369.

Three adversarial review rounds ran against this change and turned up fourteen defects in it, all fixed here — the board root-change breakage, the username that could no longer be cleared, the encoder-swap score reset, and the symlink-loop 500 among them.

A fourth round reviewed the password commit on top and found two more, both fixed: the *Forget saved password* checkbox was always visible (the CSS specificity problem above), and a cleared password kept working from the JWT cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
