### PR TITLE
Refuse a Cluster Strength that DBSCAN cannot run with

### DIFF
--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -5,6 +5,7 @@ This module handles loading, saving, and managing photo album configurations.
 It uses a YAML file to store album details and provides methods to manipulate albums.
 """
 import logging
+import math
 import os
 import threading
 from functools import lru_cache
@@ -24,6 +25,7 @@ from .encoders import (
 from .util import atomic_write_text
 
 logger = logging.getLogger(__name__)
+
 
 
 def default_board_index_path(album_key: str) -> Path:
@@ -98,10 +100,38 @@ class Album(BaseModel):
             "coordinates (see backend/cluster_eps.py), which is what keeps "
             "small albums from clustering into nothing. Adjusting Cluster "
             "Strength in the UI stores a number here and the derived value "
-            "is no longer consulted."
+            "is no longer consulted. A number stored here must be positive "
+            "and finite; anything else is treated as 'not chosen'."
         ),
     )
     description: str = Field(default="", description="Album description")
+
+    @field_validator("umap_eps")
+    @classmethod
+    def discard_unusable_umap_eps(cls, v: float | None) -> float | None:
+        """Treat a stored Cluster Strength DBSCAN cannot use as "not chosen".
+
+        Validation refuses these at the API boundary now, but a config
+        written before that can already hold one, and it does real damage: a
+        stored NaN cannot be serialized, so ``/get_umap_eps`` fails outright,
+        and a non-positive value is silently replaced at clustering time, so
+        the map is drawn at a strength the field never showed.
+
+        ``None`` rather than a fixed fallback, because ``None`` is what asks
+        for a value derived from the album's own coordinates — the same
+        treatment an album that never had one gets, and a better answer than
+        any constant.
+        """
+        if v is None:
+            return None
+        if not math.isfinite(v) or v <= 0:
+            logger.warning(
+                f"Ignoring unusable stored Cluster Strength {v!r}; "
+                "deriving one from the album's coordinates instead."
+            )
+            return None
+        return v
+
     encoder_spec: str = Field(
         # Resolved per-host: OpenCLIP ViT-L-14 on CUDA/macOS, lighter OpenAI CLIP
         # ViT-B/32 on CPU-only Linux/Windows. See encoders.default_encoder_spec.

--- a/photomap/backend/config.py
+++ b/photomap/backend/config.py
@@ -16,6 +16,7 @@ import yaml
 from platformdirs import user_config_dir, user_data_dir
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from .cluster_eps import MIN_CLUSTER_EPS
 from .encoders import (
     LEGACY_CLIP_MIN_SEARCH_SCORE,
     LEGACY_ENCODER_SPEC,
@@ -25,7 +26,6 @@ from .encoders import (
 from .util import atomic_write_text
 
 logger = logging.getLogger(__name__)
-
 
 
 def default_board_index_path(album_key: str) -> Path:
@@ -47,6 +47,56 @@ def default_board_index_path(album_key: str) -> Path:
         raise ValueError(f"Album key not usable as a directory name: {album_key!r}")
     data_dir = Path(user_data_dir("photomap", "photomap"))
     return data_dir / "indexes" / album_key / "embeddings.npz"
+
+
+def repaired_umap_eps(raw: Any) -> float | None:
+    """A Cluster Strength read off disk, brought inside the bounds the model
+    now enforces.
+
+    The API refuses an unusable value before it can be written, but a config
+    file written before that bound existed can hold anything, and the model
+    would now refuse to load it — which would take the whole config down over
+    one album's number. The two ways a stored value can be out of bounds want
+    different answers:
+
+    * Non-finite, zero or negative is not a strength anyone chose; it is
+      damage. ``None`` — "nobody chose one" — hands the album back to a value
+      derived from its own coordinates, the same treatment an album that never
+      had one gets, and a better answer than any constant.
+    * Positive but under the floor *is* an intent: the tightest clustering the
+      control can ask for. ``resolve_cluster_eps`` already floors it at
+      :data:`MIN_CLUSTER_EPS` before clustering, so raising it here changes
+      nothing about the map — it only stops the field from reporting a number
+      the map is not using.
+
+    Anything that is not a number at all is left alone for the model to
+    reject in its own words; this repairs values, it does not launder types.
+    Being liberal about *what counts as* a number matters, though: the model
+    refuses out-of-bounds values now, so any number this hands back unrepaired
+    takes the whole config file down, not just one album's Cluster Strength.
+    That is why ``bool`` is not special-cased — pydantic accepts one as a
+    float, so ``umap_eps: false`` reaches the model as ``0.0``, and a config
+    holding one has to load.
+    """
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return raw
+    if not math.isfinite(value) or value <= 0:
+        logger.warning(
+            f"Ignoring unusable stored Cluster Strength {raw!r}; "
+            "deriving one from the album's coordinates instead."
+        )
+        return None
+    if value < MIN_CLUSTER_EPS:
+        logger.warning(
+            f"Raising stored Cluster Strength {raw!r} to the {MIN_CLUSTER_EPS} "
+            "the semantic map clusters with anyway."
+        )
+        return MIN_CLUSTER_EPS
+    return value
 
 
 class Album(BaseModel):
@@ -94,44 +144,22 @@ class Album(BaseModel):
     )
     umap_eps: float | None = Field(
         default=None,
+        ge=MIN_CLUSTER_EPS,
+        allow_inf_nan=False,
         description=(
             "DBSCAN epsilon for the semantic map's clustering. None means "
             "'not chosen': the value is derived from the album's own UMAP "
             "coordinates (see backend/cluster_eps.py), which is what keeps "
             "small albums from clustering into nothing. Adjusting Cluster "
             "Strength in the UI stores a number here and the derived value "
-            "is no longer consulted. A number stored here must be positive "
-            "and finite; anything else is treated as 'not chosen'."
+            "is no longer consulted. A number stored here is bounded below "
+            "by MIN_CLUSTER_EPS — the floor resolve_cluster_eps applies "
+            "anyway — so the stored number and the number the map clusters "
+            "with cannot disagree. A config written before that bound can "
+            "still hold anything; see repaired_umap_eps."
         ),
     )
     description: str = Field(default="", description="Album description")
-
-    @field_validator("umap_eps")
-    @classmethod
-    def discard_unusable_umap_eps(cls, v: float | None) -> float | None:
-        """Treat a stored Cluster Strength DBSCAN cannot use as "not chosen".
-
-        Validation refuses these at the API boundary now, but a config
-        written before that can already hold one, and it does real damage: a
-        stored NaN cannot be serialized, so ``/get_umap_eps`` fails outright,
-        and a non-positive value is silently replaced at clustering time, so
-        the map is drawn at a strength the field never showed.
-
-        ``None`` rather than a fixed fallback, because ``None`` is what asks
-        for a value derived from the album's own coordinates — the same
-        treatment an album that never had one gets, and a better answer than
-        any constant.
-        """
-        if v is None:
-            return None
-        if not math.isfinite(v) or v <= 0:
-            logger.warning(
-                f"Ignoring unusable stored Cluster Strength {v!r}; "
-                "deriving one from the album's coordinates instead."
-            )
-            return None
-        return v
-
     encoder_spec: str = Field(
         # Resolved per-host: OpenCLIP ViT-L-14 on CUDA/macOS, lighter OpenAI CLIP
         # ViT-B/32 on CPU-only Linux/Windows. See encoders.default_encoder_spec.
@@ -316,7 +344,11 @@ class Album(BaseModel):
             # what None asks the map to derive. The old 0.07 fallback here
             # was a number for *every* album regardless of size, which is
             # what left small albums with no clusters at all.
-            umap_eps=data.get("umap_eps"),
+            #
+            # This is the one door untrusted numbers come through — the API
+            # refuses them now, but a file written before it did cannot be
+            # allowed to make the whole config unloadable.
+            umap_eps=repaired_umap_eps(data.get("umap_eps")),
             description=data.get("description", ""),
             # Legacy YAML albums predate the encoder_spec field; their indexes
             # were built with the original CLIP, so fall back to that to stay

--- a/photomap/backend/photomap_server.py
+++ b/photomap/backend/photomap_server.py
@@ -4,6 +4,7 @@ Main entry point for the PhotoMapAI backend server.
 Initializes the FastAPI app, mounts routers, and handles server startup.
 """
 import logging
+import math
 import os
 import signal
 import subprocess
@@ -12,7 +13,9 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -72,6 +75,30 @@ for router in [
     app.include_router(router)
 
 app.include_router(curation_router, prefix="/api/curation", tags=["curation"])
+
+
+@app.exception_handler(RequestValidationError)
+async def json_safe_validation_error(request: Request, exc: RequestValidationError):
+    """Return a 422 whose body can actually be serialized.
+
+    FastAPI's default handler echoes the rejected input back in the error
+    detail. Python's ``json`` module parses the bare ``NaN``/``Infinity``
+    literals on the way in but refuses to emit them, so rejecting a
+    non-finite number produced an unserializable 422 — which surfaces to the
+    client as a 500, i.e. the validation looked like a server bug. Replace
+    any value that cannot survive the round trip with its repr.
+    """
+
+    def sanitized(error: dict) -> dict:
+        value = error.get("input")
+        if isinstance(value, float) and not math.isfinite(value):
+            return {**error, "input": repr(value)}
+        return error
+
+    return JSONResponse(
+        status_code=422,
+        content=jsonable_encoder({"detail": [sanitized(e) for e in exc.errors()]}),
+    )
 
 
 class IECompatibilityMiddleware(BaseHTTPMiddleware):

--- a/photomap/backend/photomap_server.py
+++ b/photomap/backend/photomap_server.py
@@ -4,7 +4,6 @@ Main entry point for the PhotoMapAI backend server.
 Initializes the FastAPI app, mounts routers, and handles server startup.
 """
 import logging
-import math
 import os
 import signal
 import subprocess
@@ -35,7 +34,7 @@ from photomap.backend.routers.search import search_router
 from photomap.backend.routers.umap import umap_router
 from photomap.backend.routers.upgrade import upgrade_router
 from photomap.backend.static_assets import VersionedStaticFiles, compute_asset_version
-from photomap.backend.util import get_app_url
+from photomap.backend.util import get_app_url, json_safe
 
 # Initialize logging
 logger = logging.getLogger(__name__)
@@ -85,19 +84,15 @@ async def json_safe_validation_error(request: Request, exc: RequestValidationErr
     detail. Python's ``json`` module parses the bare ``NaN``/``Infinity``
     literals on the way in but refuses to emit them, so rejecting a
     non-finite number produced an unserializable 422 — which surfaces to the
-    client as a 500, i.e. the validation looked like a server bug. Replace
-    any value that cannot survive the round trip with its repr.
+    client as a 500, i.e. the validation looked like a server bug.
+
+    Sanitizing runs *after* ``jsonable_encoder`` rather than before: the
+    encoder is what turns an error's ``ctx`` objects into plain containers,
+    and a NaN sitting inside one of those is only reachable once it has.
     """
-
-    def sanitized(error: dict) -> dict:
-        value = error.get("input")
-        if isinstance(value, float) and not math.isfinite(value):
-            return {**error, "input": repr(value)}
-        return error
-
     return JSONResponse(
         status_code=422,
-        content=jsonable_encoder({"detail": [sanitized(e) for e in exc.errors()]}),
+        content=json_safe(jsonable_encoder({"detail": exc.errors()})),
     )
 
 

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from .. import invokeai_client
-from ..cluster_eps import FALLBACK_CLUSTER_EPS, cached_adaptive_cluster_eps
+from ..cluster_eps import FALLBACK_CLUSTER_EPS, MIN_CLUSTER_EPS, cached_adaptive_cluster_eps
 from ..config import (
     Album,
     create_album,
@@ -19,6 +20,7 @@ from ..config import (
 )
 from ..embeddings import Embeddings
 from ..encoders import default_encoder_spec, default_min_search_score
+from ..util import json_safe
 from ..video_cache import VideoFrameCache
 
 
@@ -29,12 +31,14 @@ class UmapEpsSetRequest(BaseModel):
     # would be a one-way door: once a number is typed there is no way back
     # to the derived value short of editing the config file.
     #
-    # A number, though, is constrained: DBSCAN rejects a non-positive epsilon,
-    # and a non-finite one cannot be serialized back out at all, so storing
-    # either left the album's Cluster Strength lying about what the map is
-    # doing — or, for NaN, made /get_umap_eps fail outright. A 422 says no
-    # before anything is written.
-    eps: float | None = Field(default=None, gt=0, allow_inf_nan=False)
+    # A number, though, is constrained. The bound is MIN_CLUSTER_EPS rather
+    # than a bare "positive" because that is the floor resolve_cluster_eps
+    # applies before clustering: anything under it is stored and displayed as
+    # one number while the map is drawn with another, which is the whole
+    # failure this constraint exists to prevent. A non-finite one is worse
+    # still — it cannot be serialized back out, so /get_umap_eps fails on its
+    # own response. A 422 says no before anything is written.
+    eps: float | None = Field(default=None, ge=MIN_CLUSTER_EPS, allow_inf_nan=False)
 
 
 class UmapEpsGetRequest(BaseModel):
@@ -605,6 +609,15 @@ async def update_album(album_data: dict) -> JSONResponse:
         # A 400/404 raised above is the answer; wrapping it in a 500 would
         # bury the reason the update was refused.
         raise
+    except ValidationError as e:
+        # This endpoint takes a free-form dict rather than a request model, so
+        # a field the Album model refuses — a Cluster Strength the map cannot
+        # cluster with, say — surfaces here rather than as FastAPI's own 422.
+        # It is still the caller's mistake, and it must not be reported as
+        # success: /update_album silently dropping an unusable umap_eps is how
+        # a client would end up believing it had stored one.
+        detail = json_safe(jsonable_encoder(e.errors(include_url=False)))
+        raise HTTPException(status_code=422, detail=detail) from e
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update album: {str(e)}") from e
 

--- a/photomap/backend/routers/album.py
+++ b/photomap/backend/routers/album.py
@@ -7,7 +7,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .. import invokeai_client
 from ..cluster_eps import FALLBACK_CLUSTER_EPS, cached_adaptive_cluster_eps
@@ -28,7 +28,13 @@ class UmapEpsSetRequest(BaseModel):
     # value derived from the album's own coordinates. Without this the UI
     # would be a one-way door: once a number is typed there is no way back
     # to the derived value short of editing the config file.
-    eps: float | None = None
+    #
+    # A number, though, is constrained: DBSCAN rejects a non-positive epsilon,
+    # and a non-finite one cannot be serialized back out at all, so storing
+    # either left the album's Cluster Strength lying about what the map is
+    # doing — or, for NaN, made /get_umap_eps fail outright. A 422 says no
+    # before anything is written.
+    eps: float | None = Field(default=None, gt=0, allow_inf_nan=False)
 
 
 class UmapEpsGetRequest(BaseModel):

--- a/photomap/backend/routers/cluster_labels.py
+++ b/photomap/backend/routers/cluster_labels.py
@@ -16,7 +16,7 @@ from typing import Annotated
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
-from ..cluster_eps import resolve_album_cluster_eps
+from ..cluster_eps import MIN_CLUSTER_EPS, resolve_album_cluster_eps
 from ..cluster_labels import compute_image_label, get_or_build_cluster_labels
 from .album import AlbumDep, EmbeddingsDep, album_umap_coords_async
 
@@ -28,10 +28,13 @@ async def get_cluster_labels(
     album_key: str,
     album_config: AlbumDep,
     embeddings: EmbeddingsDep,
-    # Same bound as the stored value: a query parameter DBSCAN cannot run
-    # with should be a 422 from the caller, not a 500 from sklearn.
-    cluster_eps: Annotated[float | None, Query(gt=0, allow_inf_nan=False)] = None,
-    cluster_min_samples: int = 10,
+    # Same bounds as the stored value: a query parameter the map cannot be
+    # clustered with should be a 422 naming the field, not a 500 out of
+    # sklearn. MIN_CLUSTER_EPS rather than "positive" because that is the
+    # floor resolve_cluster_eps applies anyway — accepting anything under it
+    # would cluster at one number while the caller was told another.
+    cluster_eps: Annotated[float | None, Query(ge=MIN_CLUSTER_EPS, allow_inf_nan=False)] = None,
+    cluster_min_samples: Annotated[int, Query(ge=1)] = 10,
     top_k: int = 3,
 ) -> JSONResponse:
     """Return one short text label per DBSCAN cluster for an album's UMAP.

--- a/photomap/backend/routers/cluster_labels.py
+++ b/photomap/backend/routers/cluster_labels.py
@@ -11,8 +11,9 @@ exactly so cluster IDs returned here match cluster IDs returned by
 
 import asyncio
 from pathlib import Path
+from typing import Annotated
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
 from ..cluster_eps import resolve_album_cluster_eps
@@ -27,7 +28,9 @@ async def get_cluster_labels(
     album_key: str,
     album_config: AlbumDep,
     embeddings: EmbeddingsDep,
-    cluster_eps: float | None = None,
+    # Same bound as the stored value: a query parameter DBSCAN cannot run
+    # with should be a 422 from the caller, not a 500 from sklearn.
+    cluster_eps: Annotated[float | None, Query(gt=0, allow_inf_nan=False)] = None,
     cluster_min_samples: int = 10,
     top_k: int = 3,
 ) -> JSONResponse:

--- a/photomap/backend/routers/umap.py
+++ b/photomap/backend/routers/umap.py
@@ -2,9 +2,10 @@
 
 import asyncio
 from pathlib import Path
+from typing import Annotated
 
 import numpy as np
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 from sklearn.cluster import DBSCAN
 
@@ -22,7 +23,9 @@ async def get_umap_data(
     album_key: str,
     album_config: AlbumDep,
     embeddings: EmbeddingsDep,
-    cluster_eps: float | None = None,
+    # Same bound as the stored value: a query parameter DBSCAN cannot run
+    # with should be a 422 from the caller, not a 500 from sklearn.
+    cluster_eps: Annotated[float | None, Query(gt=0, allow_inf_nan=False)] = None,
     cluster_min_samples: int = 10,
 ) -> JSONResponse:
     """

--- a/photomap/backend/routers/umap.py
+++ b/photomap/backend/routers/umap.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 from sklearn.cluster import DBSCAN
 
-from ..cluster_eps import resolve_album_cluster_eps
+from ..cluster_eps import MIN_CLUSTER_EPS, resolve_album_cluster_eps
 from ..config import get_config_manager
 from ..media_types import media_type_for
 from .album import AlbumDep, EmbeddingsDep
@@ -23,10 +23,13 @@ async def get_umap_data(
     album_key: str,
     album_config: AlbumDep,
     embeddings: EmbeddingsDep,
-    # Same bound as the stored value: a query parameter DBSCAN cannot run
-    # with should be a 422 from the caller, not a 500 from sklearn.
-    cluster_eps: Annotated[float | None, Query(gt=0, allow_inf_nan=False)] = None,
-    cluster_min_samples: int = 10,
+    # Same bounds as the stored value: a query parameter the map cannot be
+    # clustered with should be a 422 naming the field, not a 500 out of
+    # sklearn. MIN_CLUSTER_EPS rather than "positive" because that is the
+    # floor resolve_cluster_eps applies anyway — accepting anything under it
+    # would cluster at one number while the caller was told another.
+    cluster_eps: Annotated[float | None, Query(ge=MIN_CLUSTER_EPS, allow_inf_nan=False)] = None,
+    cluster_min_samples: Annotated[int, Query(ge=1)] = 10,
 ) -> JSONResponse:
     """
     Get UMAP coordinates for all images in an album.

--- a/photomap/backend/util.py
+++ b/photomap/backend/util.py
@@ -1,6 +1,7 @@
 """
 This module provides utility functions for the PhotoMap application."""
 
+import math
 import os
 import socket
 import stat
@@ -14,6 +15,29 @@ import numpy as np
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
+
+
+def json_safe(value: Any) -> Any:
+    """``value`` with every non-finite float replaced by its repr.
+
+    ``json`` parses the bare ``NaN``/``Infinity`` literals on the way in but
+    refuses to emit them, and the JSON responses this app returns are
+    rendered with ``allow_nan=False``. So any error body that echoes a
+    rejected request back to the client has to come through here first, or
+    refusing a NaN becomes a 500 — the validation reads as a server bug.
+
+    Recursive, because the float is rarely at the top: pydantic reports the
+    *containing* object as an error's ``input`` whenever the field that
+    failed is not the float itself, so a NaN travels inside a dict or a list
+    far more often than it arrives alone.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return repr(value)
+    if isinstance(value, dict):
+        return {k: json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe(v) for v in value]
+    return value
 
 
 def is_cuda_oom(err: BaseException) -> bool:

--- a/tests/backend/test_albums.py
+++ b/tests/backend/test_albums.py
@@ -375,7 +375,12 @@ def test_min_image_dimension_round_trips(client, tmp_path):
             "min_image_dimension": 0,
         },
     )
-    assert response.status_code == 500
+    # 422, not 500: /update_album takes a free-form dict, so a field the Album
+    # model refuses arrives as a ValidationError rather than as FastAPI's own
+    # body validation. It used to fall through to the endpoint's catch-all and
+    # be reported as a server error, which reads as "PhotoMap broke" for what
+    # is squarely the caller's mistake.
+    assert response.status_code == 422
     # Previous valid value must remain — failed update must not corrupt state.
     listing = {a["key"]: a for a in client.get("/available_albums/").json()}
     assert listing["dim_default"]["min_image_dimension"] == 512

--- a/tests/backend/test_umap_eps_validation.py
+++ b/tests/backend/test_umap_eps_validation.py
@@ -1,25 +1,36 @@
-"""A Cluster Strength DBSCAN cannot run with must never reach the config.
+"""A Cluster Strength the semantic map cannot use must never reach the config.
 
-Both halves are reachable only through the API — the spinner cannot produce
-them — but both persisted to YAML and left the album's semantic map broken
-until someone edited the file by hand:
+All of it is reachable only through the API — the spinner cannot produce
+these — but every kind persisted to YAML and left the album's map either
+broken or lying about itself until someone edited the file by hand:
 
 * a non-positive eps makes ``DBSCAN`` raise, so every ``/umap_data`` and
   ``/cluster_labels`` request 500s;
 * a non-finite eps cannot be serialized back out at all, so ``/get_umap_eps``
-  500s on its own response.
+  500s on its own response;
+* a positive eps below ``MIN_CLUSTER_EPS`` is quieter and just as wrong:
+  ``resolve_cluster_eps`` floors it, so the map is clustered at one number
+  while the spinner and ``/get_umap_eps`` report another.
+
+The refusal has to hold at every door into the field — ``/set_umap_eps``,
+``/add_album`` and ``/update_album`` — and the 422 it produces has to be
+serializable, which for a rejected NaN is not free.
 """
 
-import math
+
+import json
 
 import pytest
 import yaml
 from fixtures import build_index
 
+from photomap.backend.cluster_eps import MIN_CLUSTER_EPS
 from photomap.backend.config import get_config_manager
 
 BAD_JSON_LITERALS = ["NaN", "Infinity", "-Infinity"]
-BAD_NUMBERS = [0, -5.0, -0.001]
+# Zero and negative are what DBSCAN itself refuses; the last two are the
+# quiet half — positive, but under the floor the clustering applies anyway.
+BAD_NUMBERS = [0, -5.0, -0.001, MIN_CLUSTER_EPS / 2, MIN_CLUSTER_EPS - 1e-9]
 
 
 def _post_raw_eps(client, album_key, literal):
@@ -44,7 +55,7 @@ def test_a_non_finite_eps_is_refused(client, new_album, literal):
 
 
 @pytest.mark.parametrize("eps", BAD_NUMBERS)
-def test_a_non_positive_eps_is_refused(client, new_album, eps):
+def test_an_unusable_eps_is_refused(client, new_album, eps):
     key = new_album["key"]
     before = get_config_manager().get_album(key).umap_eps
 
@@ -53,15 +64,20 @@ def test_a_non_positive_eps_is_refused(client, new_album, eps):
     assert get_config_manager().get_album(key).umap_eps == pytest.approx(before)
 
 
-def test_a_usable_eps_is_still_stored(client, new_album):
+@pytest.mark.parametrize("eps", [0.42, MIN_CLUSTER_EPS])
+def test_a_usable_eps_is_still_stored(client, new_album, eps):
+    """The floor itself is usable: the bound is ``ge``, and it is the number
+    the spinner's own ``min`` lets a user ask for."""
     key = new_album["key"]
-    assert client.post("/set_umap_eps/", json={"album": key, "eps": 0.42}).status_code == 200
-    assert get_config_manager().get_album(key).umap_eps == pytest.approx(0.42)
+    assert client.post("/set_umap_eps/", json={"album": key, "eps": eps}).status_code == 200
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(eps)
 
 
-@pytest.mark.parametrize("eps", [0, -1])
-def test_a_non_positive_query_parameter_is_refused(client, new_album, eps):
-    """A 422 from the caller rather than a 500 out of sklearn."""
+@pytest.mark.parametrize("eps", [0, -1, 0.005])
+def test_an_unusable_query_parameter_is_refused(client, new_album, eps):
+    """A 422 from the caller rather than a 500 out of sklearn — or, for the
+    value under the floor, rather than a map clustered at something the
+    caller was never told about."""
     build_index(client, new_album)
     key = new_album["key"]
 
@@ -103,14 +119,217 @@ def test_the_map_survives_a_config_that_already_holds_a_nan(client, new_album):
     config_path = manager.config_path
     # `.nan` is what yaml.safe_dump writes for a stored NaN, so this is the
     # file such an album really ends up with.
-    config_path.write_text(config_path.read_text().replace(
-        f"umap_eps: {new_album['umap_eps']}", "umap_eps: .nan"
-    ))
+    original = config_path.read_text()
+    patched = original.replace(f"umap_eps: {new_album['umap_eps']}", "umap_eps: .nan")
+    assert patched != original, "the fixture's stored eps was not where this test expects it"
+    config_path.write_text(patched)
+    manager.reload_config()
+
+    # Nobody chose a NaN, so the album is handed back to a derived strength
+    # rather than left holding a number that cannot even be serialized.
+    assert manager.get_album(key).umap_eps is None
+    resolved = client.post("/get_umap_eps/", json={"album": key})
+    assert resolved.status_code == 200
+    assert resolved.json()["auto"] is True
+    assert client.get(f"/umap_data/{key}").status_code == 200
+
+
+def test_a_stored_value_under_the_floor_is_raised_to_it(client, new_album):
+    """Not discarded: it is a real intent, and the map already clusters there.
+
+    Dropping it back to derived would answer "the tightest clustering you can
+    ask for" with whatever the album's coordinates suggest, which can be an
+    order of magnitude looser.
+    """
+    key = new_album["key"]
+    manager = get_config_manager()
+    config_path = manager.config_path
+    config_path.write_text(
+        config_path.read_text().replace(f"umap_eps: {new_album['umap_eps']}", "umap_eps: 0.004")
+    )
+    manager.reload_config()
+
+    assert manager.get_album(key).umap_eps == pytest.approx(MIN_CLUSTER_EPS)
+    resolved = client.post("/get_umap_eps/", json={"album": key})
+    assert resolved.json()["eps"] == pytest.approx(MIN_CLUSTER_EPS)
+    assert resolved.json()["auto"] is False
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        # The rejected float is not always the error's `input`: pydantic
+        # reports the *containing* object whenever some other field is what
+        # failed, so the NaN arrives one or two levels down. Sanitizing only
+        # a top-level float leaves those 500ing on the way out — the very
+        # failure the handler exists to prevent.
+        '{"eps": NaN}',
+        '{"album": "test_album", "eps": [NaN]}',
+        '{"album": {"nested": NaN}, "eps": 0.5}',
+        '{"album": "test_album", "eps": {"value": -Infinity}}',
+    ],
+)
+def test_a_nan_the_error_only_contains_is_still_serializable(client, new_album, body):
+    response = client.post(
+        "/set_umap_eps/", content=body, headers={"Content-Type": "application/json"}
+    )
+    assert response.status_code == 422
+    # The body has to survive being read, which is where it used to fail.
+    assert "detail" in response.json()
+
+
+@pytest.mark.parametrize("eps", BAD_NUMBERS)
+def test_add_album_refuses_a_bad_eps(client, tmp_path, eps):
+    """Every door into the field, not just /set_umap_eps."""
+    images = tmp_path / "images"
+    images.mkdir()
+    response = client.post(
+        "/add_album/",
+        json={
+            "key": "eps_probe",
+            "name": "Eps Probe",
+            "image_paths": [images.as_posix()],
+            "index": (images / "embeddings.npz").as_posix(),
+            "umap_eps": eps,
+        },
+    )
+    try:
+        assert response.status_code == 422
+        assert get_config_manager().get_album("eps_probe") is None
+    finally:
+        client.delete("/delete_album/eps_probe")
+
+
+@pytest.mark.parametrize("eps", BAD_NUMBERS)
+def test_update_album_refuses_a_bad_eps(client, new_album, eps):
+    """A 422, not a 200 that quietly drops the number the caller sent."""
+    key = new_album["key"]
+    before = get_config_manager().get_album(key).umap_eps
+
+    response = client.post(
+        "/update_album/",
+        json={
+            "key": key,
+            "name": new_album["name"],
+            "image_paths": new_album["image_paths"],
+            "index": new_album["index"],
+            "umap_eps": eps,
+        },
+    )
+    assert response.status_code == 422
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(before)
+
+
+def _album_body_with_nan_eps(album: dict) -> str:
+    """An album payload carrying a bare ``NaN`` literal.
+
+    ``json.dumps`` will not emit one, so the sentinel is swapped out after
+    encoding — which is also exactly how a client that *can* emit it (any
+    ``json.dumps(..., allow_nan=True)``, i.e. the default) reaches this API.
+    """
+    encoded = json.dumps(
+        {
+            "key": album["key"],
+            "name": album["name"],
+            "image_paths": album["image_paths"],
+            "index": album["index"],
+            "umap_eps": "__NAN__",
+        }
+    )
+    return encoded.replace('"__NAN__"', "NaN")
+
+
+def test_update_album_refuses_a_non_finite_eps_serializably(client, new_album):
+    """The NaN reaches the client's error body through a different route here.
+
+    /update_album takes a free-form dict, so the refusal is a ValidationError
+    turned into an HTTPException rather than FastAPI's own 422 — and an
+    HTTPException detail is rendered without the encoder the validation
+    handler applies, so it has to be made safe on its own.
+    """
+    key = new_album["key"]
+    response = client.post(
+        "/update_album/",
+        content=_album_body_with_nan_eps(new_album),
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 422
+    assert "detail" in response.json()
+    assert get_config_manager().get_album(key).umap_eps is not None
+
+
+def test_add_album_refuses_a_non_finite_eps_serializably(client, tmp_path):
+    """Same value, third door: here it is FastAPI's own body validation, and
+    the NaN sits inside the album object rather than being the input itself."""
+    images = tmp_path / "images"
+    images.mkdir()
+    payload = {
+        "key": "eps_probe",
+        "name": "Eps Probe",
+        "image_paths": [images.as_posix()],
+        "index": (images / "embeddings.npz").as_posix(),
+    }
+    response = client.post(
+        "/add_album/",
+        content=_album_body_with_nan_eps(payload),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        assert response.status_code == 422
+        assert "detail" in response.json()
+        assert get_config_manager().get_album("eps_probe") is None
+    finally:
+        client.delete("/delete_album/eps_probe")
+
+
+@pytest.mark.parametrize("written", ['"0.004"', "false", "0"])
+def test_a_config_the_model_would_now_refuse_still_loads(client, new_album, written):
+    """The bound is new; the files it applies to are not.
+
+    Every one of these reaches the Album model as a float it refuses — a
+    quoted number, a bool pydantic reads as 0.0, a plain zero — so if the
+    repair does not catch it the album does not merely lose its Cluster
+    Strength, the whole config fails to load.
+    """
+    key = new_album["key"]
+    manager = get_config_manager()
+    config_path = manager.config_path
+    config_path.write_text(
+        config_path.read_text().replace(f"umap_eps: {new_album['umap_eps']}", f"umap_eps: {written}")
+    )
     manager.reload_config()
 
     stored = manager.get_album(key).umap_eps
-    assert stored is None or not math.isnan(stored)
+    assert stored is None or stored >= MIN_CLUSTER_EPS
     assert client.post("/get_umap_eps/", json={"album": key}).status_code == 200
+
+
+def test_a_string_eps_under_the_floor_still_loads(client, new_album):
+    """A hand-written config can quote its numbers.
+
+    The model refuses out-of-bounds values now, so anything the repair does
+    not recognize as a number takes the *whole config* down rather than one
+    album's Cluster Strength.
+    """
+    key = new_album["key"]
+    manager = get_config_manager()
+    config_path = manager.config_path
+    config_path.write_text(
+        config_path.read_text().replace(f"umap_eps: {new_album['umap_eps']}", 'umap_eps: "0.004"')
+    )
+    manager.reload_config()
+
+    assert manager.get_album(key).umap_eps == pytest.approx(MIN_CLUSTER_EPS)
+
+
+@pytest.mark.parametrize("min_samples", [0, -1])
+def test_a_non_positive_min_samples_is_refused(client, new_album, min_samples):
+    """The other DBSCAN parameter these endpoints hand to sklearn unchecked."""
+    build_index(client, new_album)
+    key = new_album["key"]
+
+    assert client.get(f"/umap_data/{key}?cluster_min_samples={min_samples}").status_code == 422
+    assert client.get(f"/cluster_labels/{key}?cluster_min_samples={min_samples}").status_code == 422
 
 
 def test_null_still_clears_the_stored_value(client, new_album):

--- a/tests/backend/test_umap_eps_validation.py
+++ b/tests/backend/test_umap_eps_validation.py
@@ -1,0 +1,123 @@
+"""A Cluster Strength DBSCAN cannot run with must never reach the config.
+
+Both halves are reachable only through the API — the spinner cannot produce
+them — but both persisted to YAML and left the album's semantic map broken
+until someone edited the file by hand:
+
+* a non-positive eps makes ``DBSCAN`` raise, so every ``/umap_data`` and
+  ``/cluster_labels`` request 500s;
+* a non-finite eps cannot be serialized back out at all, so ``/get_umap_eps``
+  500s on its own response.
+"""
+
+import math
+
+import pytest
+import yaml
+from fixtures import build_index
+
+from photomap.backend.config import get_config_manager
+
+BAD_JSON_LITERALS = ["NaN", "Infinity", "-Infinity"]
+BAD_NUMBERS = [0, -5.0, -0.001]
+
+
+def _post_raw_eps(client, album_key, literal):
+    """POST a body containing a bare JSON literal ``json.loads`` accepts."""
+    return client.post(
+        "/set_umap_eps/",
+        content=f'{{"album": "{album_key}", "eps": {literal}}}',
+        headers={"Content-Type": "application/json"},
+    )
+
+
+@pytest.mark.parametrize("literal", BAD_JSON_LITERALS)
+def test_a_non_finite_eps_is_refused(client, new_album, literal):
+    key = new_album["key"]
+    before = get_config_manager().get_album(key).umap_eps
+
+    assert _post_raw_eps(client, key, literal).status_code == 422
+    # Refused means not written, not "written and then rejected".
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(before)
+    # And the endpoint that has to serialize it still works.
+    assert client.post("/get_umap_eps/", json={"album": key}).status_code == 200
+
+
+@pytest.mark.parametrize("eps", BAD_NUMBERS)
+def test_a_non_positive_eps_is_refused(client, new_album, eps):
+    key = new_album["key"]
+    before = get_config_manager().get_album(key).umap_eps
+
+    response = client.post("/set_umap_eps/", json={"album": key, "eps": eps})
+    assert response.status_code == 422
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(before)
+
+
+def test_a_usable_eps_is_still_stored(client, new_album):
+    key = new_album["key"]
+    assert client.post("/set_umap_eps/", json={"album": key, "eps": 0.42}).status_code == 200
+    assert get_config_manager().get_album(key).umap_eps == pytest.approx(0.42)
+
+
+@pytest.mark.parametrize("eps", [0, -1])
+def test_a_non_positive_query_parameter_is_refused(client, new_album, eps):
+    """A 422 from the caller rather than a 500 out of sklearn."""
+    build_index(client, new_album)
+    key = new_album["key"]
+
+    assert client.get(f"/umap_data/{key}?cluster_eps={eps}").status_code == 422
+    assert client.get(f"/cluster_labels/{key}?cluster_eps={eps}").status_code == 422
+
+
+def test_the_map_survives_a_config_that_already_holds_a_bad_value(client, new_album):
+    """Validation stops new ones; a config written before it still has to load.
+
+    A stored 0 used to 500 both map endpoints on every request, with no way
+    back except editing the YAML.
+    """
+    build_index(client, new_album)
+    key = new_album["key"]
+
+    manager = get_config_manager()
+    config_path = manager.config_path
+    raw = yaml.safe_load(config_path.read_text())
+    raw["albums"][key]["umap_eps"] = 0
+    config_path.write_text(yaml.safe_dump(raw))
+    manager.reload_config()
+
+    # None is "nobody chose one", so the album gets a derived strength --
+    # the same treatment as one that never had a value, and better than any
+    # constant this code could pick.
+    assert manager.get_album(key).umap_eps is None
+    assert client.get(f"/umap_data/{key}").status_code == 200
+    resolved = client.post("/get_umap_eps/", json={"album": key})
+    assert resolved.status_code == 200
+    assert resolved.json()["auto"] is True
+
+
+def test_the_map_survives_a_config_that_already_holds_a_nan(client, new_album):
+    build_index(client, new_album)
+    key = new_album["key"]
+
+    manager = get_config_manager()
+    config_path = manager.config_path
+    # `.nan` is what yaml.safe_dump writes for a stored NaN, so this is the
+    # file such an album really ends up with.
+    config_path.write_text(config_path.read_text().replace(
+        f"umap_eps: {new_album['umap_eps']}", "umap_eps: .nan"
+    ))
+    manager.reload_config()
+
+    stored = manager.get_album(key).umap_eps
+    assert stored is None or not math.isnan(stored)
+    assert client.post("/get_umap_eps/", json={"album": key}).status_code == 200
+
+
+def test_null_still_clears_the_stored_value(client, new_album):
+    """The constraint applies to a number, not to the deliberate clear that
+    hands the album back to a derived Cluster Strength."""
+    key = new_album["key"]
+    assert client.post("/set_umap_eps/", json={"album": key, "eps": 0.42}).status_code == 200
+
+    assert client.post("/set_umap_eps/", json={"album": key, "eps": None}).status_code == 200
+    assert get_config_manager().get_album(key).umap_eps is None


### PR DESCRIPTION
Rebased onto master through #373; everything below is measured against master as it stands, #372's patch semantics for `/update_album/` included.

Nothing constrains the Cluster Strength a client can store. The API accepts four kinds of value the semantic map cannot honour, writes them to the config file, and — at three of the four doors into the field — reports success.

## Measured on master

```
POST /set_umap_eps/ {"album": A, "eps": NaN}
  -> stored=nan
     POST /get_umap_eps/  raises ValueError: Out of range float values are not JSON compliant
     GET  /umap_data/A    raises InvalidParameterError:
            The 'eps' parameter of DBSCAN must be a float in the range (0.0, inf)

POST /set_umap_eps/ {"album": A, "eps": 0}      -> 200, stored=0.0
POST /set_umap_eps/ {"album": A, "eps": -5}     -> 200, stored=-5.0
POST /set_umap_eps/ {"album": A, "eps": 0.005}  -> 200, stored=0.005
     POST /get_umap_eps/  -> 200 {"eps": 0.005, "auto": false}
     GET  /umap_data/A    -> 200          # clustered at 0.01

POST /add_album/    {..., "umap_eps": -3}  -> 201, stored=-3.0
POST /update_album/ {..., "umap_eps": 0}   -> 200, stored=0.0

GET  /umap_data/A?cluster_min_samples=0
     raises InvalidParameterError:
       The 'min_samples' parameter of DBSCAN must be an int in the range [1, inf)

POST /set_umap_eps/ {"eps": NaN}                  # album key omitted
     raises ValueError: Out of range float values are not JSON compliant
```

**NaN or infinity is fatal and permanent.** `json` parses the bare `NaN`/`Infinity` literals on the way in but refuses to emit them, so `/get_umap_eps/` 500s serializing its own response; DBSCAN rejects a NaN epsilon, so `/umap_data/` 500s too. `yaml.safe_dump` writes `.nan` and it reloads faithfully, so restarting does not help. The album's semantic map is dead until someone edits the YAML.

**Zero, negative, or merely small is quieter but still wrong.** `resolve_cluster_eps` floors everything at `MIN_CLUSTER_EPS`, so the map draws — at a strength that is *not* the one `/get_umap_eps/` reports and the spinner shows. The control ends up lying about what the map is doing, which is exactly what the derived-eps work went out of its way to avoid ("the spinner must not silently display something other than what the map clustered with"). `0.005` is the same defect as `0`; the floor is what makes both of them a lie, so the floor is the bound.

**And `min_samples` is the same story one parameter over.** Nothing checks it either, and DBSCAN says so.

## What changed

**Refuse them at the boundary.** The bound is `ge=MIN_CLUSTER_EPS, allow_inf_nan=False` — not a bare "positive", because `MIN_CLUSTER_EPS` is the floor the clustering applies anyway, and it is also the spinner's own `min`, so a number the control cannot produce can no longer round-trip through the API. It applies to `UmapEpsSetRequest.eps`, to `Album.umap_eps` itself, and to the `cluster_eps` query parameter on `/umap_data/` and `/cluster_labels/`. `None` is left alone: clearing the field is a deliberate signal meaning "derive one", not a value. `cluster_min_samples` on both endpoints gets `ge=1` for the same reason — a 422 naming the field rather than a 500 out of sklearn.

**Every door, not just `/set_umap_eps/`.** `/add_album/` and `/update_album/` also write this field, and on master they persist whatever they are handed. Because the constraint now lives on the Album model, `/add_album/` refuses one through FastAPI's own body validation. `/update_album/` takes a free-form dict, so its `ValidationError` is caught and returned as a 422 — a caller must not be told it stored a number that was never stored, and an edit carrying a bad one must not silently clear the album's tuning.

**Treat an already-stored bad value as the config file's problem, not the album's.** The model refuses out-of-bounds numbers now, so a config written before it did could otherwise fail to load *in its entirety* over one album's field. `Album.from_dict` — the one door untrusted numbers come through — repairs instead:

* non-finite, zero or negative becomes `None`, so the album gets a *derived* strength: the same treatment an album that never had one gets, and a better answer than any constant this code could pick;
* positive but under the floor is raised *to* the floor rather than discarded. It is a real intent — the tightest clustering the control can ask for — and the map already clusters there, whereas handing the album back to a derived value could answer "as tight as possible" with something an order of magnitude looser.

Anything convertible to a float is repaired rather than passed through, `bool` included: pydantic reads `false` as `0.0`, so `umap_eps: false` in a YAML file has to load.

**Keep the 422 serializable.** This is the half that is easy to miss: FastAPI's validation-error handler echoes the rejected input back in the body, so refusing a NaN produced a response that could not be encoded — the refusal surfaced to the client as a 500. And the rejected float is usually *not* the error's `input`: pydantic reports the containing object whenever some other field is what failed, so in `{"eps": NaN}` with the album key omitted the NaN is one level down. `util.json_safe` walks the structure, replacing any non-finite float with its `repr`, and runs after `jsonable_encoder` so it can see inside an error's `ctx`. Both the validation handler and `/update_album/`'s 422 go through it. Without this, the rest looks like it does nothing.

## Tests

39 tests in `tests/backend/test_umap_eps_validation.py`: every bad literal refused *and not persisted*, at all three doors; a NaN that only appears *inside* the error input still producing a readable 422; `/get_umap_eps/` still serving afterwards; usable values still stored, `MIN_CLUSTER_EPS` itself included, since the bound is `ge`; `eps: null` still clearing to derived; both query parameters plus `cluster_min_samples` refused; and a config hand-written with `umap_eps: 0` / `.nan` / `"0.004"` / `false` loading and serving rather than 500ing or taking the whole file down.

809 backend tests pass, 605 frontend; ruff, eslint and prettier clean.

`test_min_image_dimension_round_trips` asserted that `/update_album/` returns **500** for a field the Album model refuses. That was the endpoint's catch-all swallowing a `ValidationError`; the test's own comment calls it an API-level rejection. It now expects the 422 it describes — worth noting that this is a behaviour change for *any* invalid field on that endpoint, not just this one.

## Interaction with #376

Complementary, and worth landing #376 first.

An earlier draft of this description claimed a bad value was unreachable from the UI. That is true of NaN, and wrong about the rest: `min="0.01"` on `<input type="number">` is constraint validation, not value sanitization, so typing `0` leaves `.value === "0"` and the debounce sends it. On master that stored a zero; with this branch alone it is a 422 that `fetchUmapData` does not check, so `points` is overwritten with the error body and the redraw dies on `points.map is not a function` — no map, no message. #376's guard on the spinner is what stops it being sent at all.

Two notes for that branch: its guard is `Number.isFinite(eps) && eps > 0`, which wants to be `>= 0.01` to agree with the bound here, and a `response.ok` check before `points = await response.json()` would keep any future 422 from arriving as an uncaught `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
