### PR TITLE
Resolve InvokeAI board media through their recorded subfolder

### DIFF
--- a/photomap/backend/invokeai_client.py
+++ b/photomap/backend/invokeai_client.py
@@ -4,11 +4,16 @@ This module owns everything needed to make authenticated calls against a
 running InvokeAI instance: URL validation, the JWT token cache with its
 single-user/multi-user fallback logic, and thin wrappers around the
 InvokeAI REST endpoints PhotoMap consumes (version probe, board listing,
-board image and video names, image and video deletion).
+board image and video paths, image and video deletion).
 
 Images and videos are distinct resources on the InvokeAI side — separate
-routers, separate listing shapes, separate output directories — so each has
-its own wrapper here rather than one parameterized by media type.
+routers, separate output directories — so each has its own wrapper here
+over the shared paging helper.
+
+Board contents are reported as paths *relative to the media type's outputs
+directory*, never as bare names: InvokeAI's subfolder strategy is a
+server-side setting, and the subfolder each file was actually written to is
+recorded per row, so only the row itself says where the file lives.
 
 It deliberately lives outside ``routers/`` so that non-router code (the
 indexing pipeline, curation) can use it without importing a FastAPI router
@@ -27,6 +32,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Awaitable, Callable
+from pathlib import PurePosixPath
 from typing import NamedTuple
 from urllib.parse import urlsplit
 
@@ -39,9 +45,17 @@ logger = logging.getLogger(__name__)
 # certainly means the backend is unreachable rather than genuinely busy.
 _HTTP_TIMEOUT = 5.0
 
-# Listing the image names of a very large board can legitimately take
-# longer than the snappy 5s used for control-plane calls.
+# Listing the contents of a very large board can legitimately take longer
+# than the snappy 5s used for control-plane calls.
 _BOARD_FETCH_TIMEOUT = 30.0
+
+# InvokeAI clamps its listing endpoints at MAX_PAGE_SIZE (1000) and answers
+# 422 for anything larger, so this is the biggest page we may ask for.
+_DTO_PAGE_SIZE = 1000
+
+# Backstop against a backend that keeps answering full pages forever (a
+# board of a million items is not a real library, it is a paging bug).
+_MAX_DTO_PAGES = 10_000
 
 # ── InvokeAI JWT token cache ──────────────────────────────────────────
 _cached_token: str | None = None
@@ -278,192 +292,245 @@ async def list_boards(
     ]
 
 
-async def fetch_board_image_names(
+def _media_relpath(name: object, subfolder: object, resource: str) -> str | None:
+    """Join InvokeAI's stored subfolder onto a media name, or ``None``.
+
+    InvokeAI does not necessarily store a board's media flat under
+    ``outputs/images`` / ``outputs/videos``: the subfolder strategy is a
+    server-side setting (``flat``, ``type``, ``date``, ``hash``) and the
+    subfolder actually used is recorded per row at save time, which is why
+    it has to be read off each DTO rather than derived here.  An empty or
+    absent subfolder is the flat layout, and is what every InvokeAI
+    predating the setting reports.
+
+    The result is turned into a local filesystem path by the caller, so the
+    server's string is treated as untrusted: a name that is not a bare
+    basename, or a subfolder that is absolute or walks upwards, is dropped
+    with a warning rather than allowed to escape the outputs directory.
+    """
+    if not isinstance(name, str) or not name or PurePosixPath(name).name != name:
+        logger.warning("Ignoring InvokeAI %s with a suspicious name: %r", resource, name)
+        return None
+    if not subfolder:
+        return name
+    if not isinstance(subfolder, str):
+        logger.warning(
+            "Ignoring InvokeAI %s %r: non-string subfolder %r", resource, name, subfolder
+        )
+        return None
+    # A Windows-hosted InvokeAI can report a backslash-separated subfolder;
+    # PhotoMap always builds the path with pathlib, so normalize to "/".
+    parts = PurePosixPath(subfolder.replace("\\", "/")).parts
+    if PurePosixPath(subfolder).is_absolute() or any(part in {"", ".", ".."} for part in parts):
+        logger.warning(
+            "Ignoring InvokeAI %s %r: unsafe subfolder %r", resource, name, subfolder
+        )
+        return None
+    return PurePosixPath(*parts, name).as_posix()
+
+
+class BoardMediaPaths(NamedTuple):
+    """What a board listing learned about one media type on a board.
+
+    ``relpaths`` are paths *relative to that media type's outputs directory*
+    (``general/x.mp4`` under a type-organized InvokeAI, plain ``x.mp4``
+    under a flat one), so the caller only has to join them to
+    ``<invokeai_root>/outputs/<images|videos>``.
+
+    ``api_available`` is False when the backend answered 404 for the
+    listing router.  ``relpaths`` may still be non-empty in that case
+    (earlier boards in the same call succeeded); what the flag says is that
+    the listing is incomplete, so an empty or short list must not be read as
+    "these files were removed from the board".
+    """
+
+    relpaths: list[str]
+    api_available: bool
+
+
+async def _fetch_board_media_relpaths(
+    base_url: str,
+    board_ids: list[str],
+    username: str | None,
+    password: str | None,
+    *,
+    resource: str,
+    name_key: str,
+    subfolder_key: str,
+    tolerate_absent_router: bool,
+) -> BoardMediaPaths:
+    """Page a board listing endpoint and return relative on-disk paths.
+
+    ``GET /api/v1/{resource}/`` is used rather than the cheaper
+    ``.../names`` endpoints because only the DTO carries the row's
+    subfolder, and without it there is no way to locate the file on disk on
+    any InvokeAI not configured for the flat layout.  (The name endpoints
+    are deprecated upstream in favour of the polymorphic gallery listing
+    anyway.)  The listing is paginated and clamped server-side, so each
+    board is walked a page at a time until a short page arrives.
+
+    Canvas intermediates (region masks, staging composites) and
+    control/mask-category assets are excluded, matching what InvokeAI's own
+    gallery shows — a Wan pipeline writes its intermediate clips to the
+    board just as canvas writes its staging images.  Servers that predate
+    these query params ignore them and return the unfiltered list.
+
+    ``tolerate_absent_router`` reports a 404 as ``api_available=False``
+    instead of raising.  That matters only for videos: an InvokeAI predating
+    video support has no ``/api/v1/videos`` router at all, and a board album
+    on such a backend still has to index its images.  The 404 is *not*
+    unambiguous — InvokeAI answers 404 "Board not found" for a caller whose
+    board id no longer resolves, and a reverse proxy can route
+    ``/api/v1/images`` while 404ing ``/api/v1/videos`` — so an absent
+    listing is reported as a distinct fact from an empty one, and only the
+    caller can decide whether dropping previously indexed rows is warranted.
+
+    Paths already collected from earlier boards are kept when a later board
+    404s, for the same reason: they were fetched successfully and are not
+    made wrong by a subsequent failure.
+    """
+    filter_params: dict[str, object] = {
+        "is_intermediate": "false",
+        "categories": ["general", "user"],
+        "limit": _DTO_PAGE_SIZE,
+    }
+    list_url = f"{base_url.rstrip('/')}/api/v1/{resource}/"
+    all_relpaths: list[str] = []
+    try:
+        async with httpx.AsyncClient(timeout=_BOARD_FETCH_TIMEOUT) as client:
+            for board_id in board_ids:
+                offset = 0
+                for _ in range(_MAX_DTO_PAGES):
+                    params = {**filter_params, "board_id": board_id, "offset": offset}
+
+                    async def _do(
+                        headers: dict[str, str], params: dict = params
+                    ) -> httpx.Response:
+                        return await client.get(list_url, params=params, headers=headers)
+
+                    response = await _request_with_auth_fallback(
+                        base_url, username, password, _do
+                    )
+                    if response.status_code == 404 and tolerate_absent_router:
+                        logger.info(
+                            "InvokeAI backend at %s did not answer the %s listing "
+                            "for board %r (no such API, or the board is not "
+                            "readable); board %s were not listed.",
+                            base_url,
+                            resource,
+                            board_id,
+                            resource,
+                        )
+                        return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), False)
+                    if response.status_code >= 400:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"InvokeAI backend returned {response.status_code} for "
+                                f"{resource} on board {board_id!r}: {response.text[:200]}"
+                            ),
+                        )
+                    try:
+                        payload = response.json()
+                    except ValueError as exc:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=f"The {resource} listing for board {board_id!r} did not return JSON",
+                        ) from exc
+                    items = payload.get("items") if isinstance(payload, dict) else None
+                    if not isinstance(items, list):
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"The {resource} listing for board {board_id!r} "
+                                "returned an unexpected shape"
+                            ),
+                        )
+                    for item in items:
+                        if not isinstance(item, dict):
+                            continue
+                        relpath = _media_relpath(
+                            item.get(name_key), item.get(subfolder_key, ""), resource
+                        )
+                        if relpath is not None:
+                            all_relpaths.append(relpath)
+                    # A short page is the last page.  Trusting ``total``
+                    # instead would loop forever against a backend that
+                    # reports a total it will not serve.
+                    if len(items) < _DTO_PAGE_SIZE:
+                        break
+                    offset += len(items)
+                else:
+                    logger.warning(
+                        "Stopped paging %s on board %r after %d pages.",
+                        resource,
+                        board_id,
+                        _MAX_DTO_PAGES,
+                    )
+    except httpx.RequestError as exc:
+        logger.warning("InvokeAI %s listing request failed: %s", resource, exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Could not reach InvokeAI backend at {base_url}: {exc}",
+        ) from exc
+
+    # A file belongs to one board, but overlapping selections (a board plus
+    # "none") must not index the same file twice — dedupe preserving order.
+    return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), True)
+
+
+async def fetch_board_image_relpaths(
     base_url: str,
     board_ids: list[str],
     username: str | None,
     password: str | None,
 ) -> list[str]:
-    """Return the image names belonging to ``board_ids``, deduplicated.
+    """Return the board images' paths relative to ``outputs/images``.
 
-    Calls ``GET /api/v1/boards/{board_id}/image_names`` for each board.
     The special board id ``"none"`` is InvokeAI's Uncategorized bucket.
-    Returned names include their file extension (``{uuid}.png`` style).
-    Raises 502 on any network error or non-200 response.
-
-    Canvas intermediates (region masks, staging composites) and
-    control/mask-category assets are excluded, matching what InvokeAI's own
-    gallery shows.  Servers that predate these query params ignore them and
-    return the unfiltered list.
+    Names include their file extension (``{uuid}.png`` style) and are
+    prefixed by the subfolder InvokeAI filed them under, if any.  Raises 502
+    on any network error or non-200 response — unlike videos, there is no
+    InvokeAI old enough to lack an image listing, so a failure here is a
+    real failure.
     """
-    # httpx repeats list values (categories=general&categories=user), which
-    # is the encoding FastAPI expects for list[ImageCategory].
-    filter_params = {
-        "is_intermediate": "false",
-        "categories": ["general", "user"],
-    }
-    all_names: list[str] = []
-    try:
-        async with httpx.AsyncClient(timeout=_BOARD_FETCH_TIMEOUT) as client:
-            for board_id in board_ids:
-                names_url = (
-                    f"{base_url.rstrip('/')}/api/v1/boards/{board_id}/image_names"
-                )
-
-                async def _do(
-                    headers: dict[str, str], url: str = names_url
-                ) -> httpx.Response:
-                    return await client.get(url, params=filter_params, headers=headers)
-
-                response = await _request_with_auth_fallback(
-                    base_url, username, password, _do
-                )
-                if response.status_code >= 400:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=(
-                            f"InvokeAI backend returned {response.status_code} for "
-                            f"board {board_id!r}: {response.text[:200]}"
-                        ),
-                    )
-                try:
-                    names = response.json()
-                except ValueError as exc:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Image-names endpoint for board {board_id!r} did not return JSON",
-                    ) from exc
-                if not isinstance(names, list):
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Image-names endpoint for board {board_id!r} returned an unexpected shape",
-                    )
-                all_names.extend(str(name) for name in names)
-    except httpx.RequestError as exc:
-        logger.warning("InvokeAI image-names request failed: %s", exc)
-        raise HTTPException(
-            status_code=502,
-            detail=f"Could not reach InvokeAI backend at {base_url}: {exc}",
-        ) from exc
-
-    # An image can belong to only one board, but guard against overlapping
-    # selections (e.g. "none" plus a board) — dedupe preserving order.
-    return list(dict.fromkeys(all_names))
+    media = await _fetch_board_media_relpaths(
+        base_url,
+        board_ids,
+        username,
+        password,
+        resource="images",
+        name_key="image_name",
+        subfolder_key="image_subfolder",
+        tolerate_absent_router=False,
+    )
+    return media.relpaths
 
 
-class BoardVideoNames(NamedTuple):
-    """What :func:`fetch_board_video_names` learned about a board's videos.
-
-    ``api_available`` is False when the backend answered 404 for the video
-    router.  ``names`` may still be non-empty in that case (earlier boards in
-    the same call succeeded); what the flag says is that the listing is
-    incomplete, so an empty or short list must not be read as "these videos
-    were removed from the board".
-    """
-
-    names: list[str]
-    api_available: bool
-
-
-async def fetch_board_video_names(
+async def fetch_board_video_relpaths(
     base_url: str,
     board_ids: list[str],
     username: str | None,
     password: str | None,
-) -> BoardVideoNames:
-    """Return the video names belonging to ``board_ids``, deduplicated.
+) -> BoardMediaPaths:
+    """Return the board videos' paths relative to ``outputs/videos``.
 
     Videos are a separate resource from images in InvokeAI, with their own
-    router: this calls ``GET /api/v1/videos/names?board_id=...`` once per
-    board (the board is a *query* parameter here, unlike the images
-    endpoint's path parameter) and reads the ``video_names`` array out of the
-    returned ``VideoNamesResult`` object.  Returned names include their
-    extension (``{uuid}.mp4``) and resolve under
-    ``<invokeai_root>/outputs/videos``.
-
-    The same ``is_intermediate``/``categories`` filters as
-    :func:`fetch_board_image_names` are applied, and they matter just as much
-    here: a Wan pipeline writes its intermediate clips to the board too, so
-    an unfiltered listing returns videos the InvokeAI gallery itself hides.
-
-    A backend predating video support has no ``/api/v1/videos`` router at
-    all and answers **404**, which must not fail the whole index run — board
-    albums have to keep indexing their images against an older InvokeAI.
-    That case is reported as ``api_available=False`` rather than as a bare
-    empty list, because a 404 is *not* unambiguous: InvokeAI's own
-    ``get_video_names`` calls ``assert_board_read_access``, which answers 404
-    "Board not found" for a non-admin caller whose board id no longer
-    resolves, and a reverse proxy in front of InvokeAI can route
-    ``/api/v1/images`` while 404ing ``/api/v1/videos``.  An empty listing and
-    an absent listing are different facts to the caller: the first means the
-    board has no videos, the second means we do not know what it has, and
-    only the caller can decide whether dropping previously indexed videos is
-    warranted.
-
-    Names already collected from earlier boards are kept when a later board
-    404s, for the same reason: they were fetched successfully and are not
-    made wrong by a subsequent failure.
+    router and their own outputs directory, so they are listed separately.
+    A backend predating video support answers 404 and is reported as
+    ``api_available=False`` rather than as an empty board — see
+    :func:`_fetch_board_media_relpaths`.
     """
-    filter_params = {
-        "is_intermediate": "false",
-        "categories": ["general", "user"],
-    }
-    names_url = f"{base_url.rstrip('/')}/api/v1/videos/names"
-    all_names: list[str] = []
-    try:
-        async with httpx.AsyncClient(timeout=_BOARD_FETCH_TIMEOUT) as client:
-            for board_id in board_ids:
-                params = {**filter_params, "board_id": board_id}
-
-                async def _do(
-                    headers: dict[str, str], params: dict = params
-                ) -> httpx.Response:
-                    return await client.get(names_url, params=params, headers=headers)
-
-                response = await _request_with_auth_fallback(
-                    base_url, username, password, _do
-                )
-                if response.status_code == 404:
-                    logger.info(
-                        "InvokeAI backend at %s did not answer the video-names "
-                        "endpoint for board %r (no video API, or the board is "
-                        "not readable); board videos were not listed.",
-                        base_url,
-                        board_id,
-                    )
-                    return BoardVideoNames(list(dict.fromkeys(all_names)), False)
-                if response.status_code >= 400:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=(
-                            f"InvokeAI backend returned {response.status_code} for "
-                            f"videos on board {board_id!r}: {response.text[:200]}"
-                        ),
-                    )
-                try:
-                    payload = response.json()
-                except ValueError as exc:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Video-names endpoint for board {board_id!r} did not return JSON",
-                    ) from exc
-                names = payload.get("video_names") if isinstance(payload, dict) else None
-                if not isinstance(names, list):
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Video-names endpoint for board {board_id!r} returned an unexpected shape",
-                    )
-                all_names.extend(str(name) for name in names)
-    except httpx.RequestError as exc:
-        logger.warning("InvokeAI video-names request failed: %s", exc)
-        raise HTTPException(
-            status_code=502,
-            detail=f"Could not reach InvokeAI backend at {base_url}: {exc}",
-        ) from exc
-
-    # A video belongs to one board, but overlapping selections (a board plus
-    # "none") must not index the same file twice — dedupe preserving order.
-    return BoardVideoNames(list(dict.fromkeys(all_names)), True)
+    return await _fetch_board_media_relpaths(
+        base_url,
+        board_ids,
+        username,
+        password,
+        resource="videos",
+        name_key="video_name",
+        subfolder_key="video_subfolder",
+        tolerate_absent_router=True,
+    )
 
 
 async def delete_image(

--- a/photomap/backend/invokeai_client.py
+++ b/photomap/backend/invokeai_client.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from pathlib import PurePosixPath
 from typing import NamedTuple
 from urllib.parse import urlsplit
 
@@ -49,13 +48,14 @@ _HTTP_TIMEOUT = 5.0
 # than the snappy 5s used for control-plane calls.
 _BOARD_FETCH_TIMEOUT = 30.0
 
-# InvokeAI clamps its listing endpoints at MAX_PAGE_SIZE (1000) and answers
-# 422 for anything larger, so this is the biggest page we may ask for.
+# The videos listing declares ``limit: le=MAX_PAGE_SIZE`` and answers 422
+# above it; the images listing has no such clamp.  MAX_PAGE_SIZE has been
+# 1000 since it was introduced, so this is the largest page both will serve.
 _DTO_PAGE_SIZE = 1000
 
-# Backstop against a backend that keeps answering full pages forever (a
-# board of a million items is not a real library, it is a paging bug).
-_MAX_DTO_PAGES = 10_000
+# Last-resort backstop.  A server that ignores ``offset`` is normally caught
+# far sooner, by the "paged past the declared total" break in the walk.
+_MAX_DTO_PAGES = 1_000
 
 # ── InvokeAI JWT token cache ──────────────────────────────────────────
 _cached_token: str | None = None
@@ -292,6 +292,17 @@ async def list_boards(
     ]
 
 
+def _has_path_syntax(part: str) -> bool:
+    """True if ``part`` is anything other than one plain path component.
+
+    An empty string, a dot segment, or a component carrying a separator of
+    either flavour all mean the server handed back structure where a bare
+    name was expected — which is the only way a joined path can leave the
+    outputs directory.
+    """
+    return not part or part in {".", ".."} or "/" in part or "\\" in part
+
+
 def _media_relpath(name: object, subfolder: object, resource: str) -> str | None:
     """Join InvokeAI's stored subfolder onto a media name, or ``None``.
 
@@ -307,8 +318,24 @@ def _media_relpath(name: object, subfolder: object, resource: str) -> str | None
     server's string is treated as untrusted: a name that is not a bare
     basename, or a subfolder that is absolute or walks upwards, is dropped
     with a warning rather than allowed to escape the outputs directory.
+
+    The accepted grammar is deliberately the one InvokeAI itself enforces
+    when it *writes* a subfolder (``DiskImageFileStorage._validate_subfolder``):
+    forward-slash separated, relative, no empty or dot segments, and no
+    backslashes at all.  Every strategy emits ``/`` even when InvokeAI runs
+    on Windows, so a backslash is not a separator to be normalized but a
+    value InvokeAI would have refused to store.  Rewriting them to ``/``
+    instead is actively unsafe: a lone backslash followed by ``etc`` is not
+    absolute as written, so an is-absolute check on it passes, and it then
+    *becomes* ``/etc`` — and joining an absolute path discards the outputs
+    directory entirely.
+
+    Names are held to the same rule.  Testing only for ``/`` leaves a
+    backslash-separated ``..`` chain looking like an ordinary filename,
+    which it is on Linux but is not on a Windows PhotoMap host, where those
+    segments would be walked.
     """
-    if not isinstance(name, str) or not name or PurePosixPath(name).name != name:
+    if not isinstance(name, str) or _has_path_syntax(name):
         logger.warning("Ignoring InvokeAI %s with a suspicious name: %r", resource, name)
         return None
     if not subfolder:
@@ -318,15 +345,13 @@ def _media_relpath(name: object, subfolder: object, resource: str) -> str | None
             "Ignoring InvokeAI %s %r: non-string subfolder %r", resource, name, subfolder
         )
         return None
-    # A Windows-hosted InvokeAI can report a backslash-separated subfolder;
-    # PhotoMap always builds the path with pathlib, so normalize to "/".
-    parts = PurePosixPath(subfolder.replace("\\", "/")).parts
-    if PurePosixPath(subfolder).is_absolute() or any(part in {"", ".", ".."} for part in parts):
+    parts = subfolder.split("/")
+    if any(_has_path_syntax(part) for part in parts):
         logger.warning(
             "Ignoring InvokeAI %s %r: unsafe subfolder %r", resource, name, subfolder
         )
         return None
-    return PurePosixPath(*parts, name).as_posix()
+    return "/".join([*parts, name])
 
 
 class BoardMediaPaths(NamedTuple):
@@ -348,6 +373,23 @@ class BoardMediaPaths(NamedTuple):
     api_available: bool
 
 
+class _BoardWalk(NamedTuple):
+    """One pass over a single board's listing.
+
+    ``relpaths`` is in listing order and may repeat an entry: rows added
+    while the walk is in progress shift later rows to a higher offset, so a
+    page can re-show something an earlier page already returned.
+
+    ``seen_names`` holds the raw names, deduped, *before* sanitizing — it is
+    what gets compared against ``declared_total``, so a row dropped for an
+    unsafe path does not read as a page the server failed to serve.
+    """
+
+    relpaths: list[str]
+    seen_names: set[str]
+    declared_total: int | None
+
+
 async def _fetch_board_media_relpaths(
     base_url: str,
     board_ids: list[str],
@@ -366,14 +408,28 @@ async def _fetch_board_media_relpaths(
     subfolder, and without it there is no way to locate the file on disk on
     any InvokeAI not configured for the flat layout.  (The name endpoints
     are deprecated upstream in favour of the polymorphic gallery listing
-    anyway.)  The listing is paginated and clamped server-side, so each
-    board is walked a page at a time until a short page arrives.
+    anyway.)  It costs roughly one request per 1000 rows and a fatter
+    payload, since a whole DTO is fetched to read one field.
 
     Canvas intermediates (region masks, staging composites) and
     control/mask-category assets are excluded, matching what InvokeAI's own
     gallery shows — a Wan pipeline writes its intermediate clips to the
     board just as canvas writes its staging images.  Servers that predate
     these query params ignore them and return the unfiltered list.
+
+    **Completeness matters more than freshness here.**  The caller feeds
+    this list to an index *update*, which prunes every indexed row the list
+    does not mention, so a listing that is quietly short deletes rows for
+    files that are still on the board.  Offset pagination is not a snapshot:
+    InvokeAI orders by ``starred DESC, created_at DESC`` and serves each page
+    from a separate query, so deleting, unstarring or un-boarding one row
+    between pages shifts every later row down an offset and skips exactly one
+    of them.  Each board is therefore checked against the ``total`` its own
+    listing reported, re-walked once if it came up short, and only then
+    failed — an aborted update leaves the previous index intact, which is the
+    recoverable outcome; silently pruning live rows is not.  (Rows *added*
+    mid-walk are harmless: they push entries to a higher offset, so they can
+    only produce a repeat, which the dedupe absorbs.)
 
     ``tolerate_absent_router`` reports a 404 as ``api_available=False``
     instead of raising.  That matters only for videos: an InvokeAI predating
@@ -396,9 +452,20 @@ async def _fetch_board_media_relpaths(
     }
     list_url = f"{base_url.rstrip('/')}/api/v1/{resource}/"
     all_relpaths: list[str] = []
+
+    def _incomplete(walk: _BoardWalk) -> bool:
+        """Did the walk return fewer distinct rows than the server claimed?"""
+        return walk.declared_total is not None and len(walk.seen_names) < walk.declared_total
+
     try:
         async with httpx.AsyncClient(timeout=_BOARD_FETCH_TIMEOUT) as client:
-            for board_id in board_ids:
+
+            async def _walk(board_id: str) -> _BoardWalk | None:
+                """One full pass over ``board_id``; ``None`` if it 404'd and
+                a 404 is tolerated for this resource."""
+                relpaths: list[str] = []
+                seen_names: set[str] = set()
+                declared_total: int | None = None
                 offset = 0
                 for _ in range(_MAX_DTO_PAGES):
                     params = {**filter_params, "board_id": board_id, "offset": offset}
@@ -421,7 +488,7 @@ async def _fetch_board_media_relpaths(
                             board_id,
                             resource,
                         )
-                        return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), False)
+                        return None
                     if response.status_code >= 400:
                         raise HTTPException(
                             status_code=502,
@@ -446,20 +513,31 @@ async def _fetch_board_media_relpaths(
                                 "returned an unexpected shape"
                             ),
                         )
+                    total = payload.get("total")
+                    if declared_total is None and isinstance(total, int) and total >= 0:
+                        declared_total = total
                     for item in items:
                         if not isinstance(item, dict):
                             continue
+                        name = item.get(name_key)
+                        if isinstance(name, str):
+                            seen_names.add(name)
                         relpath = _media_relpath(
-                            item.get(name_key), item.get(subfolder_key, ""), resource
+                            name, item.get(subfolder_key, ""), resource
                         )
                         if relpath is not None:
-                            all_relpaths.append(relpath)
-                    # A short page is the last page.  Trusting ``total``
-                    # instead would loop forever against a backend that
-                    # reports a total it will not serve.
+                            relpaths.append(relpath)
+                    # A short page is the last page.
                     if len(items) < _DTO_PAGE_SIZE:
                         break
                     offset += len(items)
+                    # Paging past what the server said it holds means it is
+                    # not honouring ``offset`` (a caching or query-stripping
+                    # proxy will re-serve page one forever).  Stop and let the
+                    # completeness check below report it, rather than grinding
+                    # through the whole page budget.
+                    if declared_total is not None and offset >= declared_total + _DTO_PAGE_SIZE:
+                        break
                 else:
                     logger.warning(
                         "Stopped paging %s on board %r after %d pages.",
@@ -467,6 +545,37 @@ async def _fetch_board_media_relpaths(
                         board_id,
                         _MAX_DTO_PAGES,
                     )
+                return _BoardWalk(relpaths, seen_names, declared_total)
+
+            for board_id in board_ids:
+                walk = await _walk(board_id)
+                if walk is None:
+                    return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), False)
+                if _incomplete(walk):
+                    logger.warning(
+                        "InvokeAI listed %d of %d %s for board %r; the board "
+                        "changed mid-listing. Re-reading it.",
+                        len(walk.seen_names),
+                        walk.declared_total,
+                        resource,
+                        board_id,
+                    )
+                    retry = await _walk(board_id)
+                    if retry is None:
+                        return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), False)
+                    if _incomplete(retry):
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"InvokeAI listed only {len(retry.seen_names)} of "
+                                f"{retry.declared_total} {resource} on board "
+                                f"{board_id!r}, twice in a row. Indexing was "
+                                f"stopped rather than treat the missing entries "
+                                f"as deleted; try again once the board is idle."
+                            ),
+                        )
+                    walk = retry
+                all_relpaths.extend(walk.relpaths)
     except httpx.RequestError as exc:
         logger.warning("InvokeAI %s listing request failed: %s", resource, exc)
         raise HTTPException(

--- a/photomap/backend/routers/index.py
+++ b/photomap/backend/routers/index.py
@@ -722,12 +722,20 @@ class BoardAlbumFiles(NamedTuple):
 async def _resolve_board_album_files(album_config) -> BoardAlbumFiles:
     """Resolve an InvokeAI-board album's images and videos to local paths.
 
-    Fetches the selected boards' image names *and* video names from the
-    InvokeAI API and maps them to ``<invokeai_root>/outputs/images/<name>``
-    and ``<invokeai_root>/outputs/videos/<name>`` respectively — the two are
-    separate resources on the InvokeAI side, listed by separate endpoints and
-    stored in separate directories, so both have to be asked for by name.
-    Names the API lists but that don't exist locally are skipped with a
+    Fetches the selected boards' images *and* videos from the InvokeAI API
+    and joins the returned paths to ``<invokeai_root>/outputs/images`` and
+    ``<invokeai_root>/outputs/videos`` respectively — the two are separate
+    resources on the InvokeAI side, listed by separate endpoints and stored
+    in separate directories, so both have to be asked for.
+
+    Those paths are *relative*, not bare filenames: InvokeAI files each
+    image and video into a subfolder chosen by a server-side strategy
+    (``flat``, ``type``, ``date``, ``hash``), recorded per row, so a board's
+    videos routinely live at ``outputs/videos/general/<name>`` rather than
+    ``outputs/videos/<name>``. The client hands back whatever prefix the
+    server reported (empty for a flat backend), and this only joins it.
+
+    Files the API lists but that don't exist locally are skipped with a
     warning; if *none* of them exist the InvokeAI root is almost certainly
     wrong, which deserves a pointed error instead of a generic "no images
     found". The error names the directory that actually came up empty, since
@@ -742,7 +750,7 @@ async def _resolve_board_album_files(album_config) -> BoardAlbumFiles:
     still on the board.
     """
     outputs = Path(album_config.invokeai_root).expanduser() / "outputs"
-    image_names = await invokeai_client.fetch_board_image_names(
+    image_relpaths = await invokeai_client.fetch_board_image_relpaths(
         album_config.invokeai_url,
         album_config.invokeai_board_ids,
         album_config.invokeai_username,
@@ -751,15 +759,18 @@ async def _resolve_board_album_files(album_config) -> BoardAlbumFiles:
     # ``api_available`` is False against an InvokeAI with no video API, so a
     # board album on an older backend keeps indexing exactly as it did before
     # — the caller only has to say so when it costs the album something.
-    video_names, video_api_available = await invokeai_client.fetch_board_video_names(
+    (
+        video_relpaths,
+        video_api_available,
+    ) = await invokeai_client.fetch_board_video_relpaths(
         album_config.invokeai_url,
         album_config.invokeai_board_ids,
         album_config.invokeai_username,
         album_config.invokeai_password,
     )
 
-    image_paths = [outputs / "images" / name for name in image_names]
-    video_paths = [outputs / "videos" / name for name in video_names]
+    image_paths = [outputs / "images" / rel for rel in image_relpaths]
+    video_paths = [outputs / "videos" / rel for rel in video_relpaths]
     paths = image_paths + video_paths
     existing = [p for p in paths if p.is_file()]
     missing = len(paths) - len(existing)

--- a/tests/backend/test_invokeai_board_index.py
+++ b/tests/backend/test_invokeai_board_index.py
@@ -45,6 +45,12 @@ def _index_filenames(index_path: Path) -> set[str]:
     return {Path(str(f)).name for f in data["filenames"]}
 
 
+def _index_paths(index_path: Path) -> set[str]:
+    """The full paths in the index, for assertions a basename cannot make."""
+    data = np.load(index_path, allow_pickle=True)
+    return {str(f) for f in data["filenames"]}
+
+
 def _poll_until(client, album_key, statuses, timeout=60):
     start = time.time()
     while True:
@@ -68,9 +74,8 @@ def board_album(client, tmp_path, monkeypatch):
     images_dir.mkdir(parents=True)
     videos_dir = tmp_path / "invokeai" / "outputs" / "videos"
     videos_dir.mkdir(parents=True)
-    # The subfolders a ``type``-organized InvokeAI files media into; the
-    # flat-layout tests simply never put anything in them.
-    (images_dir / "general").mkdir()
+    # A subfolder of the kind a ``type``-organized InvokeAI files media
+    # into; the flat-layout tests simply never put anything in it.
     (videos_dir / "user").mkdir()
     src_images = sorted(
         p for p in (Path(__file__).parent / "test_images").iterdir() if p.is_file()
@@ -201,17 +206,17 @@ def test_board_media_in_subfolders_are_found(client, board_album):
     visibly for videos, which are written entirely under those subfolders.
     The client now returns the subfolder-qualified path, and indexing has to
     honour it."""
-    image_name = f"{uuid.uuid4()}.png"
-    shutil.copy(
-        board_album["src_images"][0], board_album["images_dir"] / "general" / image_name
-    )
-    board_album["boards"]["b1"].append(f"general/{image_name}")
+    # A ``date``-organized image (three segments) and a ``type``-organized
+    # video (one), so the join is exercised at both depths.
+    image_rel = f"2026/08/19/{uuid.uuid4()}.png"
+    image_path = board_album["images_dir"] / image_rel
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(board_album["src_images"][0], image_path)
+    board_album["boards"]["b1"].append(image_rel)
 
-    video_name = f"{uuid.uuid4()}.mp4"
-    shutil.copy(
-        media_fixture_path("clip.mp4"), board_album["videos_dir"] / "user" / video_name
-    )
-    board_album["video_boards"].setdefault("b1", []).append(f"user/{video_name}")
+    video_rel = f"user/{uuid.uuid4()}.mp4"
+    shutil.copy(media_fixture_path("clip.mp4"), board_album["videos_dir"] / video_rel)
+    board_album["video_boards"].setdefault("b1", []).append(video_rel)
 
     _build_index(client)
 
@@ -219,7 +224,11 @@ def test_board_media_in_subfolders_are_found(client, board_album):
     assert metadata["filename_count"] == 6
     assert metadata["image_count"] == 5
     assert metadata["video_count"] == 1
-    assert {image_name, video_name} <= _index_filenames(board_album["index_path"])
+    # Assert the *stored* paths, not the basenames: a basename check would
+    # pass even if the file had been found somewhere else entirely.
+    indexed = _index_paths(board_album["index_path"])
+    assert str(board_album["images_dir"] / image_rel) in indexed
+    assert str(board_album["videos_dir"] / video_rel) in indexed
 
 
 @requires_ffmpeg

--- a/tests/backend/test_invokeai_board_index.py
+++ b/tests/backend/test_invokeai_board_index.py
@@ -1,10 +1,16 @@
 """Tests for indexing and curating InvokeAI board-backed albums.
 
 The InvokeAI HTTP API is stubbed at the ``invokeai_client`` layer: fake
-``fetch_board_image_names`` / ``fetch_board_video_names`` serve mutable
-board → name mappings, and the files themselves are UUID-named copies of the
+``fetch_board_image_relpaths`` / ``fetch_board_video_relpaths`` serve mutable
+board → path mappings, and the files themselves are UUID-named copies of the
 bundled fixtures laid out under fake ``<root>/outputs/images`` and
 ``<root>/outputs/videos`` directories.
+
+Those mappings hold paths *relative to* those two directories, which is what
+the real client returns: InvokeAI files each image and video into a subfolder
+chosen by a server-side strategy.  Most of the fixture is flat (every relative
+path is a bare name), matching a ``flat`` backend;
+``test_board_media_in_subfolders_are_found`` covers the organized layout.
 
 The video mapping starts out empty, so the image-only tests below run the
 same path as a board that simply has no videos. An InvokeAI too old to have
@@ -23,7 +29,7 @@ from fastapi import HTTPException
 from fixtures import media_fixture_path
 
 from photomap.backend import invokeai_client
-from photomap.backend.invokeai_client import BoardVideoNames
+from photomap.backend.invokeai_client import BoardMediaPaths
 from photomap.backend.video import VIDEO_METADATA_KEY, ffmpeg_exe
 from photomap.backend.video_cache import VideoFrameCache
 
@@ -62,6 +68,10 @@ def board_album(client, tmp_path, monkeypatch):
     images_dir.mkdir(parents=True)
     videos_dir = tmp_path / "invokeai" / "outputs" / "videos"
     videos_dir.mkdir(parents=True)
+    # The subfolders a ``type``-organized InvokeAI files media into; the
+    # flat-layout tests simply never put anything in them.
+    (images_dir / "general").mkdir()
+    (videos_dir / "user").mkdir()
     src_images = sorted(
         p for p in (Path(__file__).parent / "test_images").iterdir() if p.is_file()
     )[:4]
@@ -91,11 +101,11 @@ def board_album(client, tmp_path, monkeypatch):
 
     async def fake_fetch_videos(base_url, board_ids, username, password):
         if not video_api["available"]:
-            return BoardVideoNames(list(video_api["names_on_outage"]), False)
-        return BoardVideoNames(_merged(video_boards, board_ids), True)
+            return BoardMediaPaths(list(video_api["names_on_outage"]), False)
+        return BoardMediaPaths(_merged(video_boards, board_ids), True)
 
-    monkeypatch.setattr(invokeai_client, "fetch_board_image_names", fake_fetch)
-    monkeypatch.setattr(invokeai_client, "fetch_board_video_names", fake_fetch_videos)
+    monkeypatch.setattr(invokeai_client, "fetch_board_image_relpaths", fake_fetch)
+    monkeypatch.setattr(invokeai_client, "fetch_board_video_relpaths", fake_fetch_videos)
 
     index_path = tmp_path / "index" / "embeddings.npz"
     album = {
@@ -179,6 +189,37 @@ def test_board_videos_are_indexed_alongside_images(client, board_album):
     assert metadata["image_count"] == 4
     assert metadata["video_count"] == 1
     assert video_name in _index_filenames(board_album["index_path"])
+
+
+@requires_ffmpeg
+def test_board_media_in_subfolders_are_found(client, board_album):
+    """InvokeAI does not necessarily store a board's media flat under
+    ``outputs/images`` / ``outputs/videos``: with the ``type`` subfolder
+    strategy every non-intermediate file lands in ``general/``, and with
+    ``date`` in ``YYYY/MM/DD/``.  PhotoMap used to join the bare filename to
+    the outputs directory, so on such a backend *nothing* resolved — most
+    visibly for videos, which are written entirely under those subfolders.
+    The client now returns the subfolder-qualified path, and indexing has to
+    honour it."""
+    image_name = f"{uuid.uuid4()}.png"
+    shutil.copy(
+        board_album["src_images"][0], board_album["images_dir"] / "general" / image_name
+    )
+    board_album["boards"]["b1"].append(f"general/{image_name}")
+
+    video_name = f"{uuid.uuid4()}.mp4"
+    shutil.copy(
+        media_fixture_path("clip.mp4"), board_album["videos_dir"] / "user" / video_name
+    )
+    board_album["video_boards"].setdefault("b1", []).append(f"user/{video_name}")
+
+    _build_index(client)
+
+    metadata = client.get(f"/index_metadata/{ALBUM_KEY}").json()
+    assert metadata["filename_count"] == 6
+    assert metadata["image_count"] == 5
+    assert metadata["video_count"] == 1
+    assert {image_name, video_name} <= _index_filenames(board_album["index_path"])
 
 
 @requires_ffmpeg
@@ -465,7 +506,7 @@ def test_unreachable_invokeai_fails_indexing_and_keeps_old_index(
     async def broken_fetch(base_url, board_ids, username, password):
         raise HTTPException(status_code=502, detail="connection refused")
 
-    monkeypatch.setattr(invokeai_client, "fetch_board_image_names", broken_fetch)
+    monkeypatch.setattr(invokeai_client, "fetch_board_image_relpaths", broken_fetch)
 
     response = client.post("/update_index_async", json={"album_key": ALBUM_KEY})
     assert response.status_code == 202
@@ -642,7 +683,7 @@ def test_first_update_failure_surfaces_error_without_prior_run(
     async def broken_fetch(base_url, board_ids, username, password):
         raise HTTPException(status_code=502, detail="connection refused")
 
-    monkeypatch.setattr(invokeai_client, "fetch_board_image_names", broken_fetch)
+    monkeypatch.setattr(invokeai_client, "fetch_board_image_relpaths", broken_fetch)
 
     response = client.post("/update_index_async", json={"album_key": ALBUM_KEY})
     assert response.status_code == 202

--- a/tests/backend/test_invokeai_board_index.py
+++ b/tests/backend/test_invokeai_board_index.py
@@ -46,9 +46,19 @@ def _index_filenames(index_path: Path) -> set[str]:
 
 
 def _index_paths(index_path: Path) -> set[str]:
-    """The full paths in the index, for assertions a basename cannot make."""
+    """The full paths in the index, for assertions a basename cannot make.
+
+    Compare against :func:`_indexed_form`, not ``str(path)``: the index
+    stores ``path.resolve().as_posix()``, so on Windows every stored path is
+    forward-slash separated while ``str(Path(...))`` is not.
+    """
     data = np.load(index_path, allow_pickle=True)
     return {str(f) for f in data["filenames"]}
+
+
+def _indexed_form(path: Path) -> str:
+    """``path`` written the way the index writes it (see embeddings.py)."""
+    return path.resolve().as_posix()
 
 
 def _poll_until(client, album_key, statuses, timeout=60):
@@ -227,8 +237,8 @@ def test_board_media_in_subfolders_are_found(client, board_album):
     # Assert the *stored* paths, not the basenames: a basename check would
     # pass even if the file had been found somewhere else entirely.
     indexed = _index_paths(board_album["index_path"])
-    assert str(board_album["images_dir"] / image_rel) in indexed
-    assert str(board_album["videos_dir"] / video_rel) in indexed
+    assert _indexed_form(board_album["images_dir"] / image_rel) in indexed
+    assert _indexed_form(board_album["videos_dir"] / video_rel) in indexed
 
 
 @requires_ffmpeg

--- a/tests/backend/test_invokeai_client.py
+++ b/tests/backend/test_invokeai_client.py
@@ -1,10 +1,12 @@
 """Tests for the raw HTTP behaviour of ``photomap.backend.invokeai_client``.
 
 The board-index tests (``test_invokeai_board_index.py``) monkeypatch
-``fetch_board_image_names`` / ``fetch_board_video_names`` wholesale, so the
-request-building details are covered here instead — most importantly that
-board fetches ask InvokeAI to exclude canvas intermediates and mask/control
-assets, mirroring what the InvokeAI gallery itself displays.
+``fetch_board_image_relpaths`` / ``fetch_board_video_relpaths`` wholesale,
+so the request-building details are covered here instead — most importantly
+that board fetches ask InvokeAI to exclude canvas intermediates and
+mask/control assets (mirroring what the InvokeAI gallery itself displays),
+and that each file's on-disk subfolder is read off its DTO rather than
+assumed flat.
 """
 
 import pytest
@@ -55,55 +57,39 @@ def _clear_token_cache():
     invokeai_client._invalidate_token_cache()
 
 
+def _page(items, name_key="image_name", subfolder_key="image_subfolder"):
+    """One page of a listing endpoint, in the DTO shape InvokeAI returns."""
+    return _Resp(
+        json_body={
+            "items": [
+                {name_key: name, subfolder_key: subfolder} for name, subfolder in items
+            ],
+            "total": len(items),
+            "offset": 0,
+            "limit": invokeai_client._DTO_PAGE_SIZE,
+        }
+    )
+
+
 @pytest.mark.asyncio
-async def test_fetch_board_image_names_filters_out_intermediates(monkeypatch):
+async def test_fetch_board_image_relpaths_filters_out_intermediates(monkeypatch):
     """Board fetches must request only non-intermediate general/user images."""
     stub = _RecordingClient(
         [
-            _Resp(json_body=["aaa.png", "bbb.png"]),
-            _Resp(json_body=["bbb.png", "ccc.png"]),
+            _page([("aaa.png", ""), ("bbb.png", "")]),
+            _page([("bbb.png", ""), ("ccc.png", "")]),
         ]
     )
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
-    names = await invokeai_client.fetch_board_image_names(
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
         "http://localhost:9090", ["board-1", "none"], None, None
     )
 
-    assert names == ["aaa.png", "bbb.png", "ccc.png"]
+    assert relpaths == ["aaa.png", "bbb.png", "ccc.png"]
     assert [call["url"] for call in stub.calls] == [
-        "http://localhost:9090/api/v1/boards/board-1/image_names",
-        "http://localhost:9090/api/v1/boards/none/image_names",
-    ]
-    for call in stub.calls:
-        assert call["params"] == {
-            "is_intermediate": "false",
-            "categories": ["general", "user"],
-        }
-
-
-@pytest.mark.asyncio
-async def test_fetch_board_video_names_queries_each_board_with_filters(monkeypatch):
-    """Videos are listed by a query parameter, not a path segment, and get the
-    same intermediate/category filtering as images (a Wan pipeline writes its
-    intermediate clips to the board too)."""
-    stub = _RecordingClient(
-        [
-            _Resp(json_body={"video_names": ["a.mp4", "b.mp4"], "total_count": 2}),
-            _Resp(json_body={"video_names": ["b.mp4", "c.mp4"], "total_count": 2}),
-        ]
-    )
-    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
-
-    result = await invokeai_client.fetch_board_video_names(
-        "http://localhost:9090", ["board-1", "none"], None, None
-    )
-
-    assert result.names == ["a.mp4", "b.mp4", "c.mp4"]
-    assert result.api_available is True
-    assert [call["url"] for call in stub.calls] == [
-        "http://localhost:9090/api/v1/videos/names",
-        "http://localhost:9090/api/v1/videos/names",
+        "http://localhost:9090/api/v1/images/",
+        "http://localhost:9090/api/v1/images/",
     ]
     assert [call["params"]["board_id"] for call in stub.calls] == ["board-1", "none"]
     for call in stub.calls:
@@ -112,7 +98,109 @@ async def test_fetch_board_video_names_queries_each_board_with_filters(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_fetch_board_video_names_tolerates_backend_without_videos(monkeypatch):
+async def test_fetch_board_relpaths_prefix_the_reported_subfolder(monkeypatch):
+    """InvokeAI files media into a subfolder chosen by a server-side strategy
+    and records it per row.  Ignoring it (the old flat assumption) means every
+    file on a ``type``-organized backend resolves to a path that is not there,
+    which is exactly how a board full of videos indexes as empty."""
+    stub = _RecordingClient(
+        [
+            _page([("aaa.png", "general"), ("bbb.png", "2026/08/19"), ("ccc.png", "")]),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/aaa.png", "2026/08/19/bbb.png", "ccc.png"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_reject_paths_that_escape_outputs(monkeypatch):
+    """The subfolder is a server-supplied string that PhotoMap turns into a
+    local filesystem path, so a traversal or an absolute path is dropped
+    rather than followed out of the outputs directory."""
+    stub = _RecordingClient(
+        [
+            _page(
+                [
+                    ("ok.png", "general"),
+                    ("escape.png", "../../../etc"),
+                    ("absolute.png", "/etc"),
+                    ("../traversal.png", "general"),
+                ]
+            ),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/ok.png"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_page_until_a_short_page(monkeypatch):
+    """The listing endpoint is paginated and clamped server-side, so a board
+    bigger than one page must be walked — stopping at the first page would
+    silently index only the newest 1000 files."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    stub = _RecordingClient(
+        [
+            _page([("a.png", "general"), ("b.png", "general")]),
+            _page([("c.png", "general"), ("d.png", "general")]),
+            _page([("e.png", "general")]),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == [f"general/{n}.png" for n in "abcde"]
+    assert [call["params"]["offset"] for call in stub.calls] == [0, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_video_relpaths_queries_the_video_router(monkeypatch):
+    """Videos are a separate resource with their own outputs directory, and
+    get the same intermediate/category filtering as images (a Wan pipeline
+    writes its intermediate clips to the board too)."""
+    stub = _RecordingClient(
+        [
+            _page([("a.mp4", "general")], "video_name", "video_subfolder"),
+            _page(
+                [("a.mp4", "general"), ("c.mp4", "user")],
+                "video_name",
+                "video_subfolder",
+            ),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    result = await invokeai_client.fetch_board_video_relpaths(
+        "http://localhost:9090", ["board-1", "none"], None, None
+    )
+
+    assert result.relpaths == ["general/a.mp4", "user/c.mp4"]
+    assert result.api_available is True
+    assert [call["url"] for call in stub.calls] == [
+        "http://localhost:9090/api/v1/videos/",
+        "http://localhost:9090/api/v1/videos/",
+    ]
+    assert [call["params"]["board_id"] for call in stub.calls] == ["board-1", "none"]
+    for call in stub.calls:
+        assert call["params"]["is_intermediate"] == "false"
+        assert call["params"]["categories"] == ["general", "user"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_video_relpaths_tolerates_backend_without_videos(monkeypatch):
     """An InvokeAI predating the video API 404s the whole router; that must
     not fail the index run, and it must be distinguishable from a board that
     genuinely holds no videos — the caller prunes rows for anything absent
@@ -120,45 +208,60 @@ async def test_fetch_board_video_names_tolerates_backend_without_videos(monkeypa
     stub = _RecordingClient([_Resp(status_code=404, text="Not Found")])
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
-    result = await invokeai_client.fetch_board_video_names(
+    result = await invokeai_client.fetch_board_video_relpaths(
         "http://localhost:9090", ["board-1"], None, None
     )
 
-    assert result.names == []
+    assert result.relpaths == []
     assert result.api_available is False
 
 
 @pytest.mark.asyncio
-async def test_fetch_board_video_names_keeps_names_from_earlier_boards(monkeypatch):
+async def test_fetch_board_image_relpaths_raise_on_a_404(monkeypatch):
+    """There is no InvokeAI old enough to lack an image listing, so unlike
+    videos a 404 here is a real failure and must not be swallowed into an
+    empty — and therefore index-pruning — result."""
+    stub = _RecordingClient([_Resp(status_code=404, text="Not Found")])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await invokeai_client.fetch_board_image_relpaths(
+            "http://localhost:9090", ["board-1"], None, None
+        )
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_video_relpaths_keeps_paths_from_earlier_boards(monkeypatch):
     """A 404 on a later board must not discard what earlier boards returned.
     InvokeAI answers 404 for a board a non-admin cannot read, not only for a
     missing video router, so the successful listings are still good data."""
     stub = _RecordingClient(
         [
-            _Resp(json_body={"video_names": ["a.mp4"], "total_count": 1}),
+            _page([("a.mp4", "general")], "video_name", "video_subfolder"),
             _Resp(status_code=404, text="Board not found"),
         ]
     )
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
-    result = await invokeai_client.fetch_board_video_names(
+    result = await invokeai_client.fetch_board_video_relpaths(
         "http://localhost:9090", ["board-1", "board-gone"], None, None
     )
 
-    assert result.names == ["a.mp4"]
+    assert result.relpaths == ["general/a.mp4"]
     assert result.api_available is False
 
 
 @pytest.mark.asyncio
-async def test_fetch_board_video_names_rejects_unexpected_shape(monkeypatch):
-    """A bare list (the *images* endpoint's shape) is not silently accepted —
-    reading no names off a successful response would quietly drop every video
-    from the album."""
+async def test_fetch_board_video_relpaths_rejects_unexpected_shape(monkeypatch):
+    """A bare list (the shape the retired ``/names`` endpoints returned) is not
+    silently accepted — reading no items off a successful response would
+    quietly drop every video from the album."""
     stub = _RecordingClient([_Resp(json_body=["a.mp4"])])
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
     with pytest.raises(HTTPException) as excinfo:
-        await invokeai_client.fetch_board_video_names(
+        await invokeai_client.fetch_board_video_relpaths(
             "http://localhost:9090", ["board-1"], None, None
         )
     assert excinfo.value.status_code == 502

--- a/tests/backend/test_invokeai_client.py
+++ b/tests/backend/test_invokeai_client.py
@@ -9,6 +9,8 @@ and that each file's on-disk subfolder is read off its DTO rather than
 assumed flat.
 """
 
+from pathlib import Path
+
 import pytest
 from fastapi import HTTPException
 
@@ -57,18 +59,29 @@ def _clear_token_cache():
     invokeai_client._invalidate_token_cache()
 
 
-def _page(items, name_key="image_name", subfolder_key="image_subfolder"):
-    """One page of a listing endpoint, in the DTO shape InvokeAI returns."""
-    return _Resp(
-        json_body={
-            "items": [
-                {name_key: name, subfolder_key: subfolder} for name, subfolder in items
-            ],
-            "total": len(items),
-            "offset": 0,
-            "limit": invokeai_client._DTO_PAGE_SIZE,
-        }
-    )
+_UNSET = object()
+
+
+def _page(
+    items, name_key="image_name", subfolder_key="image_subfolder", total=_UNSET
+):
+    """One page of a listing endpoint, in the DTO shape InvokeAI returns.
+
+    ``total`` is the count of *all* rows matching the query, not the page's
+    own length; it defaults to the page length so single-page tests read as
+    a complete listing.  Pass ``None`` for a server that omits it.
+    """
+    body = {
+        "items": [
+            {name_key: name, subfolder_key: subfolder} for name, subfolder in items
+        ],
+        "offset": 0,
+        "limit": invokeai_client._DTO_PAGE_SIZE,
+    }
+    resolved = len(items) if total is _UNSET else total
+    if resolved is not None:
+        body["total"] = resolved
+    return _Resp(json_body=body)
 
 
 @pytest.mark.asyncio
@@ -118,20 +131,84 @@ async def test_fetch_board_relpaths_prefix_the_reported_subfolder(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_board_relpaths_reject_paths_that_escape_outputs(monkeypatch):
+@pytest.mark.parametrize(
+    "name, subfolder",
+    [
+        ("escape.png", "../../../etc"),
+        ("absolute.png", "/etc"),
+        ("../traversal.png", "general"),
+        # Backslash spellings.  These are the dangerous ones: none of them
+        # look absolute as written, but rewriting the separators — which an
+        # earlier version of this code did, to "support" a Windows-hosted
+        # InvokeAI — turns them into absolute paths, and joining an absolute
+        # path throws the outputs directory away entirely.  InvokeAI refuses
+        # to store a backslash in a subfolder at all, so no real server
+        # reports one.
+        ("bs.png", "\\etc"),
+        ("bs-unc.png", "\\\\server\\share"),
+        ("bs-root.png", "\\"),
+        ("..\\..\\win.png", "general"),
+        # Empty and dot segments, rejected by InvokeAI's own validator too.
+        ("dot.png", "."),
+        ("empty-seg.png", "a//b"),
+        ("blank.png", " /../.."),
+    ],
+)
+async def test_fetch_board_relpaths_reject_paths_that_escape_outputs(
+    monkeypatch, name, subfolder
+):
     """The subfolder is a server-supplied string that PhotoMap turns into a
-    local filesystem path, so a traversal or an absolute path is dropped
-    rather than followed out of the outputs directory."""
+    local filesystem path, so anything that is not a plain relative path is
+    dropped rather than followed out of the outputs directory.
+
+    Asserted through the joined path, not just the returned string: what
+    matters is where ``outputs/images / relpath`` lands, and an absolute
+    relpath silently discards the left-hand side of that join."""
+    stub = _RecordingClient([_page([("ok.png", "general"), (name, subfolder)])])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/ok.png"]
+    outputs = Path("/invokeai/outputs/images")
+    for rel in relpaths:
+        assert (outputs / rel).is_relative_to(outputs)
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_keep_legitimate_nested_subfolders(monkeypatch):
+    """The rejection rule must not swallow the layouts InvokeAI really
+    produces — ``type`` yields one segment, ``date`` yields three."""
+    stub = _RecordingClient(
+        [_page([("a.png", "general"), ("b.png", "2026/08/19"), ("c.png", "ab")])]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/a.png", "2026/08/19/b.png", "ab/c.png"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_retry_a_listing_that_came_up_short(monkeypatch):
+    """Offset pagination is not a snapshot: deleting one row between pages
+    shifts every later row down an offset, so exactly one live row is skipped.
+    The caller prunes indexed rows this list does not mention, so a short
+    listing silently deletes a file that is still on the board — it has to be
+    caught against the server's own ``total`` and re-read."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
     stub = _RecordingClient(
         [
-            _page(
-                [
-                    ("ok.png", "general"),
-                    ("escape.png", "../../../etc"),
-                    ("absolute.png", "/etc"),
-                    ("../traversal.png", "general"),
-                ]
-            ),
+            # First walk: server says 4, a deletion mid-walk means we see 3.
+            _page([("a.png", ""), ("b.png", "")], total=4),
+            _page([("d.png", "")], total=4),
+            # Re-read: quiet server, all 3 remaining rows, total agrees.
+            _page([("a.png", ""), ("b.png", "")], total=3),
+            _page([("d.png", "")], total=3),
         ]
     )
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
@@ -140,7 +217,97 @@ async def test_fetch_board_relpaths_reject_paths_that_escape_outputs(monkeypatch
         "http://localhost:9090", ["board-1"], None, None
     )
 
-    assert relpaths == ["general/ok.png"]
+    assert relpaths == ["a.png", "b.png", "d.png"]
+    assert len(stub.calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_fail_rather_than_prune_a_short_listing(monkeypatch):
+    """A listing that stays short across two reads is not churn — it is a
+    backend (or an intermediary) that will not serve what it says it holds.
+    Failing leaves the previous index intact; returning the short list would
+    delete an indexed row for every entry the server withheld."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    stub = _RecordingClient(
+        [
+            _page([("a.png", ""), ("b.png", "")], total=99),
+            _page([("c.png", "")], total=99),
+            _page([("a.png", ""), ("b.png", "")], total=99),
+            _page([("c.png", "")], total=99),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await invokeai_client.fetch_board_image_relpaths(
+            "http://localhost:9090", ["board-1"], None, None
+        )
+
+    assert excinfo.value.status_code == 502
+    assert "3 of 99" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_stop_paging_a_server_that_ignores_offset(
+    monkeypatch,
+):
+    """A caching or query-stripping proxy can re-serve page one forever.  The
+    short-page rule alone never fires there, so the walk has to give up once
+    it has paged past the total the server declared — and then report the
+    listing as unusable rather than return the fragment it did get."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    same_page = [("a.png", ""), ("b.png", "")]
+    stub = _RecordingClient([_page(same_page, total=10) for _ in range(50)])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await invokeai_client.fetch_board_image_relpaths(
+            "http://localhost:9090", ["board-1"], None, None
+        )
+
+    assert excinfo.value.status_code == 502
+    # 6 pages per walk (offset runs 0..10, then passes total + one page),
+    # twice — bounded, and nowhere near the 1000-page budget.
+    assert len(stub.calls) == 12
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_tolerate_a_listing_with_no_total(monkeypatch):
+    """The completeness check is best-effort: a payload without a usable
+    ``total`` must still index, not fail."""
+    stub = _RecordingClient([_page([("a.png", "general")], total=None)])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/a.png"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_tolerate_rows_added_mid_walk(monkeypatch):
+    """Rows added while the walk is in flight push existing rows to a higher
+    offset, so a page can repeat what an earlier one returned.  That is a
+    duplicate, not a gap: it must dedupe, not trigger a re-read."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    stub = _RecordingClient(
+        [
+            _page([("b.png", ""), ("c.png", "")], total=3),
+            # "a.png" was created mid-walk and sorts first, so page two
+            # re-shows c.png before reaching d.png.
+            _page([("c.png", ""), ("d.png", "")], total=4),
+            _page([], total=4),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["b.png", "c.png", "d.png"]
+    assert len(stub.calls) == 3
 
 
 @pytest.mark.asyncio
@@ -151,9 +318,11 @@ async def test_fetch_board_relpaths_page_until_a_short_page(monkeypatch):
     monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
     stub = _RecordingClient(
         [
-            _page([("a.png", "general"), ("b.png", "general")]),
-            _page([("c.png", "general"), ("d.png", "general")]),
-            _page([("e.png", "general")]),
+            # ``total`` is the whole board, not the page — every page repeats
+            # the same figure, which is what the real endpoint does.
+            _page([("a.png", "general"), ("b.png", "general")], total=5),
+            _page([("c.png", "general"), ("d.png", "general")], total=5),
+            _page([("e.png", "general")], total=5),
         ]
     )
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)


### PR DESCRIPTION
## The bug

Indexing an InvokeAI board containing videos found none of them on disk.

InvokeAI does not store board media flat under `outputs/images` / `outputs/videos`. The subfolder strategy is a server-side setting (`flat`, `type`, `date`, `hash`), and the subfolder each file was actually written into is recorded per row at save time. On a `type`-organized backend every non-intermediate video lives at `outputs/videos/general/<name>.mp4`.

PhotoMap asked the `/boards/{id}/image_names` and `/videos/names` endpoints, which return **only names**, and joined them straight onto `<invokeai_root>/outputs/videos/<name>` — so `is_file()` was false for every video on the board. Depending on the mix, the album either indexed as empty or failed with *"None of the N board video(s) listed by InvokeAI were found under …/outputs/videos — check the InvokeAI root directory"*, which pointed at the wrong culprit.

Images had the same bug and it was simply less visible: a long-lived `outputs/images` still holds a pile of legacy flat files, so old images resolved while newer ones (`image_subfolder: "general"`) silently vanished.

## The fix

The client now pages the DTO listings `GET /api/v1/{images,videos}/` instead of the two name endpoints (deprecated upstream anyway, in favour of the polymorphic gallery listing) and reads `image_subfolder` / `video_subfolder` off each row, returning paths **relative to that media type's outputs directory**. `routers/index.py` joins them.

A backend predating the setting reports no subfolder, which yields exactly the old flat path — verified against real legacy rows, which report `''`. Existing indexes see no churn, and nothing is re-keyed or re-embedded.

Cost: roughly one request per 1000 rows and a fatter payload, since a whole DTO is fetched to read one field. Measured on the largest local board — 14,103 images in 2.7 s.

## Hardening (second commit, from an adversarial review)

- **The subfolder sanitizer could be walked out of the outputs directory.** It normalized backslashes to `/` *before* validating, but tested is-absolute on the raw string, so `\etc` passed the check and then became `/etc` — and joining an absolute path discards the left-hand side entirely. The normalization was never needed: InvokeAI's own `_validate_subfolder` rejects backslashes outright and every strategy emits `/`. Names were checked with `PurePosixPath`, which treats `..\..\secret` as an ordinary filename (true on Linux, false on a Windows PhotoMap host). Both now go through one rule matching InvokeAI's own grammar: relative, `/`-separated, no empty or dot segments, no backslashes anywhere.
- **Offset pagination is not a snapshot.** InvokeAI orders by `(starred, created_at)` and serves each page from its own query, so deleting or unstarring one row between pages shifts every later row down an offset and skips exactly one. Since an index *update* prunes every indexed row the listing does not mention, that silently deleted a file still on the board. Each board is now checked against the `total` its own listing reported, re-walked once if short, and only then failed — an aborted update leaves the previous index intact, which is recoverable; pruning live rows is not. Rows *added* mid-walk only produce duplicates, which the dedupe absorbs.
- The same check catches an intermediary that truncates pages, and the walk stops once it has paged past the declared total, so a proxy that ignores `offset` costs a handful of requests rather than the whole page budget.

## Verification

- Live against InvokeAI 6.14.0-alpha: **14103/14103** images on the largest board (15 pages, 2.7 s, no spurious re-read), **30/30** and **20/20** videos on the video boards, **250/250** on the uncategorized bucket across a mix of flat and subfoldered rows. Paging re-checked live at a forced page size of 100.
- New `test_board_media_in_subfolders_are_found` covers both depths (`type`'s one segment, `date`'s three) end-to-end through indexing and asserts the **stored** paths, not basenames. It fails against the old flat join, so it is a genuine regression test.
- Escape cases are parameterized over every backslash, absolute, traversal, and empty-segment spelling, asserted through the joined path.
- New tests for the short-listing re-read, the fail-rather-than-prune path, the offset-ignoring server, a payload with no `total`, and rows added mid-walk.
- `773 passed`, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLPwCcYrkpzwaTbk4FwjuB