### PR TITLE
Restore the board-subfolder and Cluster Strength fixes #382 reverted

### DIFF
--- a/photomap/backend/invokeai_client.py
+++ b/photomap/backend/invokeai_client.py
@@ -4,11 +4,16 @@ This module owns everything needed to make authenticated calls against a
 running InvokeAI instance: URL validation, the JWT token cache with its
 single-user/multi-user fallback logic, and thin wrappers around the
 InvokeAI REST endpoints PhotoMap consumes (version probe, board listing,
-board image and video names, image and video deletion).
+board image and video paths, image and video deletion).
 
 Images and videos are distinct resources on the InvokeAI side — separate
-routers, separate listing shapes, separate output directories — so each has
-its own wrapper here rather than one parameterized by media type.
+routers, separate output directories — so each has its own wrapper here
+over the shared paging helper.
+
+Board contents are reported as paths *relative to the media type's outputs
+directory*, never as bare names: InvokeAI's subfolder strategy is a
+server-side setting, and the subfolder each file was actually written to is
+recorded per row, so only the row itself says where the file lives.
 
 It deliberately lives outside ``routers/`` so that non-router code (the
 indexing pipeline, curation) can use it without importing a FastAPI router
@@ -39,9 +44,18 @@ logger = logging.getLogger(__name__)
 # certainly means the backend is unreachable rather than genuinely busy.
 _HTTP_TIMEOUT = 5.0
 
-# Listing the image names of a very large board can legitimately take
-# longer than the snappy 5s used for control-plane calls.
+# Listing the contents of a very large board can legitimately take longer
+# than the snappy 5s used for control-plane calls.
 _BOARD_FETCH_TIMEOUT = 30.0
+
+# The videos listing declares ``limit: le=MAX_PAGE_SIZE`` and answers 422
+# above it; the images listing has no such clamp.  MAX_PAGE_SIZE has been
+# 1000 since it was introduced, so this is the largest page both will serve.
+_DTO_PAGE_SIZE = 1000
+
+# Last-resort backstop.  A server that ignores ``offset`` is normally caught
+# far sooner, by the "paged past the declared total" break in the walk.
+_MAX_DTO_PAGES = 1_000
 
 # ── InvokeAI JWT token cache ──────────────────────────────────────────
 _cached_token: str | None = None
@@ -278,192 +292,354 @@ async def list_boards(
     ]
 
 
-async def fetch_board_image_names(
+def _has_path_syntax(part: str) -> bool:
+    """True if ``part`` is anything other than one plain path component.
+
+    An empty string, a dot segment, or a component carrying a separator of
+    either flavour all mean the server handed back structure where a bare
+    name was expected — which is the only way a joined path can leave the
+    outputs directory.
+    """
+    return not part or part in {".", ".."} or "/" in part or "\\" in part
+
+
+def _media_relpath(name: object, subfolder: object, resource: str) -> str | None:
+    """Join InvokeAI's stored subfolder onto a media name, or ``None``.
+
+    InvokeAI does not necessarily store a board's media flat under
+    ``outputs/images`` / ``outputs/videos``: the subfolder strategy is a
+    server-side setting (``flat``, ``type``, ``date``, ``hash``) and the
+    subfolder actually used is recorded per row at save time, which is why
+    it has to be read off each DTO rather than derived here.  An empty or
+    absent subfolder is the flat layout, and is what every InvokeAI
+    predating the setting reports.
+
+    The result is turned into a local filesystem path by the caller, so the
+    server's string is treated as untrusted: a name that is not a bare
+    basename, or a subfolder that is absolute or walks upwards, is dropped
+    with a warning rather than allowed to escape the outputs directory.
+
+    The accepted grammar is deliberately the one InvokeAI itself enforces
+    when it *writes* a subfolder (``DiskImageFileStorage._validate_subfolder``):
+    forward-slash separated, relative, no empty or dot segments, and no
+    backslashes at all.  Every strategy emits ``/`` even when InvokeAI runs
+    on Windows, so a backslash is not a separator to be normalized but a
+    value InvokeAI would have refused to store.  Rewriting them to ``/``
+    instead is actively unsafe: a lone backslash followed by ``etc`` is not
+    absolute as written, so an is-absolute check on it passes, and it then
+    *becomes* ``/etc`` — and joining an absolute path discards the outputs
+    directory entirely.
+
+    Names are held to the same rule.  Testing only for ``/`` leaves a
+    backslash-separated ``..`` chain looking like an ordinary filename,
+    which it is on Linux but is not on a Windows PhotoMap host, where those
+    segments would be walked.
+    """
+    if not isinstance(name, str) or _has_path_syntax(name):
+        logger.warning("Ignoring InvokeAI %s with a suspicious name: %r", resource, name)
+        return None
+    if not subfolder:
+        return name
+    if not isinstance(subfolder, str):
+        logger.warning(
+            "Ignoring InvokeAI %s %r: non-string subfolder %r", resource, name, subfolder
+        )
+        return None
+    parts = subfolder.split("/")
+    if any(_has_path_syntax(part) for part in parts):
+        logger.warning(
+            "Ignoring InvokeAI %s %r: unsafe subfolder %r", resource, name, subfolder
+        )
+        return None
+    return "/".join([*parts, name])
+
+
+class BoardMediaPaths(NamedTuple):
+    """What a board listing learned about one media type on a board.
+
+    ``relpaths`` are paths *relative to that media type's outputs directory*
+    (``general/x.mp4`` under a type-organized InvokeAI, plain ``x.mp4``
+    under a flat one), so the caller only has to join them to
+    ``<invokeai_root>/outputs/<images|videos>``.
+
+    ``api_available`` is False when the backend answered 404 for the
+    listing router.  ``relpaths`` may still be non-empty in that case
+    (earlier boards in the same call succeeded); what the flag says is that
+    the listing is incomplete, so an empty or short list must not be read as
+    "these files were removed from the board".
+    """
+
+    relpaths: list[str]
+    api_available: bool
+
+
+class _BoardWalk(NamedTuple):
+    """One pass over a single board's listing.
+
+    ``relpaths`` is in listing order and may repeat an entry: rows added
+    while the walk is in progress shift later rows to a higher offset, so a
+    page can re-show something an earlier page already returned.
+
+    ``seen_names`` holds the raw names, deduped, *before* sanitizing — it is
+    what gets compared against ``declared_total``, so a row dropped for an
+    unsafe path does not read as a page the server failed to serve.
+    """
+
+    relpaths: list[str]
+    seen_names: set[str]
+    declared_total: int | None
+
+
+async def _fetch_board_media_relpaths(
+    base_url: str,
+    board_ids: list[str],
+    username: str | None,
+    password: str | None,
+    *,
+    resource: str,
+    name_key: str,
+    subfolder_key: str,
+    tolerate_absent_router: bool,
+) -> BoardMediaPaths:
+    """Page a board listing endpoint and return relative on-disk paths.
+
+    ``GET /api/v1/{resource}/`` is used rather than the cheaper
+    ``.../names`` endpoints because only the DTO carries the row's
+    subfolder, and without it there is no way to locate the file on disk on
+    any InvokeAI not configured for the flat layout.  (The name endpoints
+    are deprecated upstream in favour of the polymorphic gallery listing
+    anyway.)  It costs roughly one request per 1000 rows and a fatter
+    payload, since a whole DTO is fetched to read one field.
+
+    Canvas intermediates (region masks, staging composites) and
+    control/mask-category assets are excluded, matching what InvokeAI's own
+    gallery shows — a Wan pipeline writes its intermediate clips to the
+    board just as canvas writes its staging images.  Servers that predate
+    these query params ignore them and return the unfiltered list.
+
+    **Completeness matters more than freshness here.**  The caller feeds
+    this list to an index *update*, which prunes every indexed row the list
+    does not mention, so a listing that is quietly short deletes rows for
+    files that are still on the board.  Offset pagination is not a snapshot:
+    InvokeAI orders by ``starred DESC, created_at DESC`` and serves each page
+    from a separate query, so deleting, unstarring or un-boarding one row
+    between pages shifts every later row down an offset and skips exactly one
+    of them.  Each board is therefore checked against the ``total`` its own
+    listing reported, re-walked once if it came up short, and only then
+    failed — an aborted update leaves the previous index intact, which is the
+    recoverable outcome; silently pruning live rows is not.  (Rows *added*
+    mid-walk are harmless: they push entries to a higher offset, so they can
+    only produce a repeat, which the dedupe absorbs.)
+
+    ``tolerate_absent_router`` reports a 404 as ``api_available=False``
+    instead of raising.  That matters only for videos: an InvokeAI predating
+    video support has no ``/api/v1/videos`` router at all, and a board album
+    on such a backend still has to index its images.  The 404 is *not*
+    unambiguous — InvokeAI answers 404 "Board not found" for a caller whose
+    board id no longer resolves, and a reverse proxy can route
+    ``/api/v1/images`` while 404ing ``/api/v1/videos`` — so an absent
+    listing is reported as a distinct fact from an empty one, and only the
+    caller can decide whether dropping previously indexed rows is warranted.
+
+    Paths already collected from earlier boards are kept when a later board
+    404s, for the same reason: they were fetched successfully and are not
+    made wrong by a subsequent failure.
+    """
+    filter_params: dict[str, object] = {
+        "is_intermediate": "false",
+        "categories": ["general", "user"],
+        "limit": _DTO_PAGE_SIZE,
+    }
+    list_url = f"{base_url.rstrip('/')}/api/v1/{resource}/"
+    all_relpaths: list[str] = []
+
+    def _incomplete(walk: _BoardWalk) -> bool:
+        """Did the walk return fewer distinct rows than the server claimed?"""
+        return walk.declared_total is not None and len(walk.seen_names) < walk.declared_total
+
+    try:
+        async with httpx.AsyncClient(timeout=_BOARD_FETCH_TIMEOUT) as client:
+
+            async def _walk(board_id: str) -> _BoardWalk | None:
+                """One full pass over ``board_id``; ``None`` if it 404'd and
+                a 404 is tolerated for this resource."""
+                relpaths: list[str] = []
+                seen_names: set[str] = set()
+                declared_total: int | None = None
+                offset = 0
+                for _ in range(_MAX_DTO_PAGES):
+                    params = {**filter_params, "board_id": board_id, "offset": offset}
+
+                    async def _do(
+                        headers: dict[str, str], params: dict = params
+                    ) -> httpx.Response:
+                        return await client.get(list_url, params=params, headers=headers)
+
+                    response = await _request_with_auth_fallback(
+                        base_url, username, password, _do
+                    )
+                    if response.status_code == 404 and tolerate_absent_router:
+                        logger.info(
+                            "InvokeAI backend at %s did not answer the %s listing "
+                            "for board %r (no such API, or the board is not "
+                            "readable); board %s were not listed.",
+                            base_url,
+                            resource,
+                            board_id,
+                            resource,
+                        )
+                        return None
+                    if response.status_code >= 400:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"InvokeAI backend returned {response.status_code} for "
+                                f"{resource} on board {board_id!r}: {response.text[:200]}"
+                            ),
+                        )
+                    try:
+                        payload = response.json()
+                    except ValueError as exc:
+                        raise HTTPException(
+                            status_code=502,
+                            detail=f"The {resource} listing for board {board_id!r} did not return JSON",
+                        ) from exc
+                    items = payload.get("items") if isinstance(payload, dict) else None
+                    if not isinstance(items, list):
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"The {resource} listing for board {board_id!r} "
+                                "returned an unexpected shape"
+                            ),
+                        )
+                    total = payload.get("total")
+                    if declared_total is None and isinstance(total, int) and total >= 0:
+                        declared_total = total
+                    for item in items:
+                        if not isinstance(item, dict):
+                            continue
+                        name = item.get(name_key)
+                        if isinstance(name, str):
+                            seen_names.add(name)
+                        relpath = _media_relpath(
+                            name, item.get(subfolder_key, ""), resource
+                        )
+                        if relpath is not None:
+                            relpaths.append(relpath)
+                    # A short page is the last page.
+                    if len(items) < _DTO_PAGE_SIZE:
+                        break
+                    offset += len(items)
+                    # Paging past what the server said it holds means it is
+                    # not honouring ``offset`` (a caching or query-stripping
+                    # proxy will re-serve page one forever).  Stop and let the
+                    # completeness check below report it, rather than grinding
+                    # through the whole page budget.
+                    if declared_total is not None and offset >= declared_total + _DTO_PAGE_SIZE:
+                        break
+                else:
+                    logger.warning(
+                        "Stopped paging %s on board %r after %d pages.",
+                        resource,
+                        board_id,
+                        _MAX_DTO_PAGES,
+                    )
+                return _BoardWalk(relpaths, seen_names, declared_total)
+
+            for board_id in board_ids:
+                walk = await _walk(board_id)
+                if walk is None:
+                    return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), False)
+                if _incomplete(walk):
+                    logger.warning(
+                        "InvokeAI listed %d of %d %s for board %r; the board "
+                        "changed mid-listing. Re-reading it.",
+                        len(walk.seen_names),
+                        walk.declared_total,
+                        resource,
+                        board_id,
+                    )
+                    retry = await _walk(board_id)
+                    if retry is None:
+                        return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), False)
+                    if _incomplete(retry):
+                        raise HTTPException(
+                            status_code=502,
+                            detail=(
+                                f"InvokeAI listed only {len(retry.seen_names)} of "
+                                f"{retry.declared_total} {resource} on board "
+                                f"{board_id!r}, twice in a row. Indexing was "
+                                f"stopped rather than treat the missing entries "
+                                f"as deleted; try again once the board is idle."
+                            ),
+                        )
+                    walk = retry
+                all_relpaths.extend(walk.relpaths)
+    except httpx.RequestError as exc:
+        logger.warning("InvokeAI %s listing request failed: %s", resource, exc)
+        raise HTTPException(
+            status_code=502,
+            detail=f"Could not reach InvokeAI backend at {base_url}: {exc}",
+        ) from exc
+
+    # A file belongs to one board, but overlapping selections (a board plus
+    # "none") must not index the same file twice — dedupe preserving order.
+    return BoardMediaPaths(list(dict.fromkeys(all_relpaths)), True)
+
+
+async def fetch_board_image_relpaths(
     base_url: str,
     board_ids: list[str],
     username: str | None,
     password: str | None,
 ) -> list[str]:
-    """Return the image names belonging to ``board_ids``, deduplicated.
+    """Return the board images' paths relative to ``outputs/images``.
 
-    Calls ``GET /api/v1/boards/{board_id}/image_names`` for each board.
     The special board id ``"none"`` is InvokeAI's Uncategorized bucket.
-    Returned names include their file extension (``{uuid}.png`` style).
-    Raises 502 on any network error or non-200 response.
-
-    Canvas intermediates (region masks, staging composites) and
-    control/mask-category assets are excluded, matching what InvokeAI's own
-    gallery shows.  Servers that predate these query params ignore them and
-    return the unfiltered list.
+    Names include their file extension (``{uuid}.png`` style) and are
+    prefixed by the subfolder InvokeAI filed them under, if any.  Raises 502
+    on any network error or non-200 response — unlike videos, there is no
+    InvokeAI old enough to lack an image listing, so a failure here is a
+    real failure.
     """
-    # httpx repeats list values (categories=general&categories=user), which
-    # is the encoding FastAPI expects for list[ImageCategory].
-    filter_params = {
-        "is_intermediate": "false",
-        "categories": ["general", "user"],
-    }
-    all_names: list[str] = []
-    try:
-        async with httpx.AsyncClient(timeout=_BOARD_FETCH_TIMEOUT) as client:
-            for board_id in board_ids:
-                names_url = (
-                    f"{base_url.rstrip('/')}/api/v1/boards/{board_id}/image_names"
-                )
-
-                async def _do(
-                    headers: dict[str, str], url: str = names_url
-                ) -> httpx.Response:
-                    return await client.get(url, params=filter_params, headers=headers)
-
-                response = await _request_with_auth_fallback(
-                    base_url, username, password, _do
-                )
-                if response.status_code >= 400:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=(
-                            f"InvokeAI backend returned {response.status_code} for "
-                            f"board {board_id!r}: {response.text[:200]}"
-                        ),
-                    )
-                try:
-                    names = response.json()
-                except ValueError as exc:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Image-names endpoint for board {board_id!r} did not return JSON",
-                    ) from exc
-                if not isinstance(names, list):
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Image-names endpoint for board {board_id!r} returned an unexpected shape",
-                    )
-                all_names.extend(str(name) for name in names)
-    except httpx.RequestError as exc:
-        logger.warning("InvokeAI image-names request failed: %s", exc)
-        raise HTTPException(
-            status_code=502,
-            detail=f"Could not reach InvokeAI backend at {base_url}: {exc}",
-        ) from exc
-
-    # An image can belong to only one board, but guard against overlapping
-    # selections (e.g. "none" plus a board) — dedupe preserving order.
-    return list(dict.fromkeys(all_names))
+    media = await _fetch_board_media_relpaths(
+        base_url,
+        board_ids,
+        username,
+        password,
+        resource="images",
+        name_key="image_name",
+        subfolder_key="image_subfolder",
+        tolerate_absent_router=False,
+    )
+    return media.relpaths
 
 
-class BoardVideoNames(NamedTuple):
-    """What :func:`fetch_board_video_names` learned about a board's videos.
-
-    ``api_available`` is False when the backend answered 404 for the video
-    router.  ``names`` may still be non-empty in that case (earlier boards in
-    the same call succeeded); what the flag says is that the listing is
-    incomplete, so an empty or short list must not be read as "these videos
-    were removed from the board".
-    """
-
-    names: list[str]
-    api_available: bool
-
-
-async def fetch_board_video_names(
+async def fetch_board_video_relpaths(
     base_url: str,
     board_ids: list[str],
     username: str | None,
     password: str | None,
-) -> BoardVideoNames:
-    """Return the video names belonging to ``board_ids``, deduplicated.
+) -> BoardMediaPaths:
+    """Return the board videos' paths relative to ``outputs/videos``.
 
     Videos are a separate resource from images in InvokeAI, with their own
-    router: this calls ``GET /api/v1/videos/names?board_id=...`` once per
-    board (the board is a *query* parameter here, unlike the images
-    endpoint's path parameter) and reads the ``video_names`` array out of the
-    returned ``VideoNamesResult`` object.  Returned names include their
-    extension (``{uuid}.mp4``) and resolve under
-    ``<invokeai_root>/outputs/videos``.
-
-    The same ``is_intermediate``/``categories`` filters as
-    :func:`fetch_board_image_names` are applied, and they matter just as much
-    here: a Wan pipeline writes its intermediate clips to the board too, so
-    an unfiltered listing returns videos the InvokeAI gallery itself hides.
-
-    A backend predating video support has no ``/api/v1/videos`` router at
-    all and answers **404**, which must not fail the whole index run — board
-    albums have to keep indexing their images against an older InvokeAI.
-    That case is reported as ``api_available=False`` rather than as a bare
-    empty list, because a 404 is *not* unambiguous: InvokeAI's own
-    ``get_video_names`` calls ``assert_board_read_access``, which answers 404
-    "Board not found" for a non-admin caller whose board id no longer
-    resolves, and a reverse proxy in front of InvokeAI can route
-    ``/api/v1/images`` while 404ing ``/api/v1/videos``.  An empty listing and
-    an absent listing are different facts to the caller: the first means the
-    board has no videos, the second means we do not know what it has, and
-    only the caller can decide whether dropping previously indexed videos is
-    warranted.
-
-    Names already collected from earlier boards are kept when a later board
-    404s, for the same reason: they were fetched successfully and are not
-    made wrong by a subsequent failure.
+    router and their own outputs directory, so they are listed separately.
+    A backend predating video support answers 404 and is reported as
+    ``api_available=False`` rather than as an empty board — see
+    :func:`_fetch_board_media_relpaths`.
     """
-    filter_params = {
-        "is_intermediate": "false",
-        "categories": ["general", "user"],
-    }
-    names_url = f"{base_url.rstrip('/')}/api/v1/videos/names"
-    all_names: list[str] = []
-    try:
-        async with httpx.AsyncClient(timeout=_BOARD_FETCH_TIMEOUT) as client:
-            for board_id in board_ids:
-                params = {**filter_params, "board_id": board_id}
-
-                async def _do(
-                    headers: dict[str, str], params: dict = params
-                ) -> httpx.Response:
-                    return await client.get(names_url, params=params, headers=headers)
-
-                response = await _request_with_auth_fallback(
-                    base_url, username, password, _do
-                )
-                if response.status_code == 404:
-                    logger.info(
-                        "InvokeAI backend at %s did not answer the video-names "
-                        "endpoint for board %r (no video API, or the board is "
-                        "not readable); board videos were not listed.",
-                        base_url,
-                        board_id,
-                    )
-                    return BoardVideoNames(list(dict.fromkeys(all_names)), False)
-                if response.status_code >= 400:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=(
-                            f"InvokeAI backend returned {response.status_code} for "
-                            f"videos on board {board_id!r}: {response.text[:200]}"
-                        ),
-                    )
-                try:
-                    payload = response.json()
-                except ValueError as exc:
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Video-names endpoint for board {board_id!r} did not return JSON",
-                    ) from exc
-                names = payload.get("video_names") if isinstance(payload, dict) else None
-                if not isinstance(names, list):
-                    raise HTTPException(
-                        status_code=502,
-                        detail=f"Video-names endpoint for board {board_id!r} returned an unexpected shape",
-                    )
-                all_names.extend(str(name) for name in names)
-    except httpx.RequestError as exc:
-        logger.warning("InvokeAI video-names request failed: %s", exc)
-        raise HTTPException(
-            status_code=502,
-            detail=f"Could not reach InvokeAI backend at {base_url}: {exc}",
-        ) from exc
-
-    # A video belongs to one board, but overlapping selections (a board plus
-    # "none") must not index the same file twice — dedupe preserving order.
-    return BoardVideoNames(list(dict.fromkeys(all_names)), True)
+    return await _fetch_board_media_relpaths(
+        base_url,
+        board_ids,
+        username,
+        password,
+        resource="videos",
+        name_key="video_name",
+        subfolder_key="video_subfolder",
+        tolerate_absent_router=True,
+    )
 
 
 async def delete_image(

--- a/photomap/backend/routers/index.py
+++ b/photomap/backend/routers/index.py
@@ -725,12 +725,20 @@ class BoardAlbumFiles(NamedTuple):
 async def _resolve_board_album_files(album_config) -> BoardAlbumFiles:
     """Resolve an InvokeAI-board album's images and videos to local paths.
 
-    Fetches the selected boards' image names *and* video names from the
-    InvokeAI API and maps them to ``<invokeai_root>/outputs/images/<name>``
-    and ``<invokeai_root>/outputs/videos/<name>`` respectively — the two are
-    separate resources on the InvokeAI side, listed by separate endpoints and
-    stored in separate directories, so both have to be asked for by name.
-    Names the API lists but that don't exist locally are skipped with a
+    Fetches the selected boards' images *and* videos from the InvokeAI API
+    and joins the returned paths to ``<invokeai_root>/outputs/images`` and
+    ``<invokeai_root>/outputs/videos`` respectively — the two are separate
+    resources on the InvokeAI side, listed by separate endpoints and stored
+    in separate directories, so both have to be asked for.
+
+    Those paths are *relative*, not bare filenames: InvokeAI files each
+    image and video into a subfolder chosen by a server-side strategy
+    (``flat``, ``type``, ``date``, ``hash``), recorded per row, so a board's
+    videos routinely live at ``outputs/videos/general/<name>`` rather than
+    ``outputs/videos/<name>``. The client hands back whatever prefix the
+    server reported (empty for a flat backend), and this only joins it.
+
+    Files the API lists but that don't exist locally are skipped with a
     warning; if *none* of them exist the InvokeAI root is almost certainly
     wrong, which deserves a pointed error instead of a generic "no images
     found". The error names the directory that actually came up empty, since
@@ -745,7 +753,7 @@ async def _resolve_board_album_files(album_config) -> BoardAlbumFiles:
     still on the board.
     """
     outputs = Path(album_config.invokeai_root).expanduser() / "outputs"
-    image_names = await invokeai_client.fetch_board_image_names(
+    image_relpaths = await invokeai_client.fetch_board_image_relpaths(
         album_config.invokeai_url,
         album_config.invokeai_board_ids,
         album_config.invokeai_username,
@@ -754,15 +762,18 @@ async def _resolve_board_album_files(album_config) -> BoardAlbumFiles:
     # ``api_available`` is False against an InvokeAI with no video API, so a
     # board album on an older backend keeps indexing exactly as it did before
     # — the caller only has to say so when it costs the album something.
-    video_names, video_api_available = await invokeai_client.fetch_board_video_names(
+    (
+        video_relpaths,
+        video_api_available,
+    ) = await invokeai_client.fetch_board_video_relpaths(
         album_config.invokeai_url,
         album_config.invokeai_board_ids,
         album_config.invokeai_username,
         album_config.invokeai_password,
     )
 
-    image_paths = [outputs / "images" / name for name in image_names]
-    video_paths = [outputs / "videos" / name for name in video_names]
+    image_paths = [outputs / "images" / rel for rel in image_relpaths]
+    video_paths = [outputs / "videos" / rel for rel in video_relpaths]
     paths = image_paths + video_paths
     existing = [p for p in paths if p.is_file()]
     missing = len(paths) - len(existing)

--- a/photomap/frontend/static/css/umap-floating-window.css
+++ b/photomap/frontend/static/css/umap-floating-window.css
@@ -268,6 +268,17 @@
   display: none;
 }
 
+/* The Cluster Strength field holds something the album cannot be set to — a
+   half-typed number, or one below the floor the server would silently raise.
+   umap.js answers those by doing nothing, so without a mark a refused
+   keystroke and a saved one look the same. Set from JS rather than `:invalid`
+   so it never fires on a derived strength that simply exceeds the spinner's
+   display `max`, which is a real number the map is clustering with. */
+#umapEpsSpinner.umap-eps-unusable {
+  border: 1px solid #ff8080;
+  outline: none;
+}
+
 #umapClickBehaviorContainer,
 #umapMediaFilterContainer {
   font-size: 0.85em;

--- a/photomap/frontend/static/javascript/umap.js
+++ b/photomap/frontend/static/javascript/umap.js
@@ -241,6 +241,21 @@ export function applyResolvedEps(data) {
   const epsSpinner = document.getElementById("umapEpsSpinner");
   if (epsSpinner && typeof data?.eps === "number") {
     epsSpinner.value = data.eps;
+    // Replacing the contents ends whatever edit was in there, guard included.
+    // Half-typed text holds the guard even across a blur, on purpose — but it
+    // cannot go on holding it once the text it was protecting is gone, or one
+    // abandoned "0." disables re-resolving for the rest of the session.
+    epsEditPending = false;
+    // A *stored* strength the map cannot cluster with is still marked. The
+    // spinner refuses to save one now, but versions before it did, and the
+    // config file is hand-editable — and an unmarked field is this module
+    // asserting the number is in effect when the server has floored it. A
+    // derived value is never marked, however small: floored or not, it is
+    // exactly what the map was clustered with.
+    markEpsUnusable(
+      !data.auto && !epsIsUsable(data.eps),
+      `The album stores ${data.eps}, which is below the ${epsFloor()} the map can cluster with.`
+    );
   }
   setEpsAutoBadge(Boolean(data?.auto));
 }
@@ -254,46 +269,210 @@ function setEpsAutoBadge(isAuto) {
 
 // --- EPS Spinner Debounce ---
 let epsUpdateTimer = null;
+// Whether the field holds an edit the album has not been told about yet.
+// The debounce handle cannot answer this on its own: the handler refuses to
+// arm a save for text the browser cannot parse yet ("0.", "-"), so during
+// exactly the keystrokes where the user has the most to lose there is no
+// timer for anyone to see. Cleared when the save lands, and on blur — text
+// that never becomes a number would otherwise read as mid-edit forever.
+let epsEditPending = false;
+// Bumped on every keystroke in the field. A snapshot taken before an await
+// that no longer matches on the way back means the user has typed since, and
+// whatever that await resolved to is about to be written over their edit.
+let epsEditSeq = 0;
+// Saves in the air. The debounce handle is nulled the moment the save starts,
+// and a save that started after the field was blurred leaves nothing else
+// behind — so without this the round trip is a window in which the field
+// looks idle to everything that writes into it, while the server it would be
+// re-read from is precisely the one still waiting for this POST.
+let epsSavesInFlight = 0;
+
+// Whether the Cluster Strength field belongs to a user who is part-way
+// through changing it. Anything that would write into the spinner from the
+// outside — a post-re-index re-resolve, a late reply to an earlier fetch —
+// has to ask first, or it moves the number under the cursor.
+function epsEditInProgress() {
+  return epsUpdateTimer !== null || epsEditPending || epsSavesInFlight > 0;
+}
+
+// Show that the field holds something the album cannot be set to, since the
+// handler's answer to one is to do nothing at all: without a mark, a refused
+// keystroke and a saved one look identical. Only the values this module
+// actually refuses are marked — `:invalid` would also catch a derived
+// strength above the spinner's `max`, which is a legitimate number to show.
+function markEpsUnusable(unusable, reason = "") {
+  const epsSpinner = document.getElementById("umapEpsSpinner");
+  if (!epsSpinner) {
+    return;
+  }
+  epsSpinner.classList.toggle("umap-eps-unusable", unusable);
+  if (unusable) {
+    epsSpinner.title = reason;
+  } else {
+    epsSpinner.removeAttribute("title");
+  }
+}
+
 document.getElementById("umapEpsSpinner").oninput = async () => {
+  // Drop any pending save first, and before every early return below: what
+  // the field holds now supersedes it. Leaving it armed lets a save from an
+  // earlier keystroke fire a second later carrying a number the field no
+  // longer shows.
+  if (epsUpdateTimer) {
+    clearTimeout(epsUpdateTimer);
+    epsUpdateTimer = null;
+  }
+  // Marked before the early returns, not after: a refused keystroke leaves an
+  // edit sitting in the field just as much as an accepted one does, and it is
+  // the refused ones that have no timer to stand in for them.
+  epsEditPending = true;
+  epsEditSeq++;
   // An empty field means "go back to deriving it" — otherwise the only way
   // out of a value you typed once would be to edit the config file. null is
   // sent verbatim; a numeric fallback here is what used to pin every album
   // to 0.07 the moment the field was cleared.
-  const eps = readSpinnerEps();
-  if (eps !== null && Number.isNaN(eps)) {
-    return; // mid-typing garbage ("-", "0.") — wait for something parseable
+  //
+  // But `type="number"` reports an empty value for anything it cannot parse
+  // *yet* — "0.", "-", "1e" — so an empty field alone cannot be read as the
+  // user asking for a derived strength. `validity.badInput` is what separates
+  // the two: it is set only while the input holds text the browser could not
+  // turn into a number, so a pause mid-keystroke no longer throws away the
+  // value the album was tuned to. (`Number.isNaN` cannot do this job: the
+  // sanitized value is "", never "NaN".)
+  if (document.getElementById("umapEpsSpinner").validity?.badInput) {
+    markEpsUnusable(true, "Not a number yet — the Cluster Strength is unchanged.");
+    return;
   }
+  const eps = readSpinnerEps();
+  // Below the spinner's own `min` the server floors the value
+  // (MIN_CLUSTER_EPS in cluster_eps.py), so storing one leaves the map
+  // clustering at something other than the number on screen — and DBSCAN
+  // refuses a non-positive epsilon outright. The ceiling is deliberately not
+  // enforced: `max` is a display bound, and a derived strength for a small
+  // album can legitimately exceed it (see the spinner's markup), so refusing
+  // to save above it would strand exactly those albums.
+  if (eps !== null && !epsIsUsable(eps)) {
+    markEpsUnusable(true, `The Cluster Strength must be at least ${epsFloor()}.`);
+    return;
+  }
+  markEpsUnusable(false);
   // Typing a number is what turns a derived strength into a chosen one, so
   // the badge goes immediately rather than after the debounced save. Clearing
   // the field keeps it until the derived value comes back below.
   if (eps !== null) {
     setEpsAutoBadge(false);
   }
-  if (epsUpdateTimer) {
-    clearTimeout(epsUpdateTimer);
-  }
+  // Pinned when the save is armed, not read when it fires: the user typed this
+  // number while looking at this album, and they are free to switch to another
+  // one inside the debounce window. `state.album` at fire time is whichever
+  // album they are looking at *then* — which is how a number typed for one
+  // album ends up stored on a different one.
+  const albumAtEdit = state.album;
   epsUpdateTimer = setTimeout(async () => {
     // Cleared as the save starts, not left holding a fired timer's handle:
     // it is what tells the rest of the module an edit is still pending, and
     // a stale handle would read as "forever mid-edit" after the first edit.
     epsUpdateTimer = null;
-    await fetch("set_umap_eps/", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ album: state.album, eps }),
-    });
-    if (eps === null) {
-      // Put the derived number back in the field before redrawing, so the
-      // map is fetched with the value the user can actually see.
-      await refreshResolvedEps();
+    const seq = epsEditSeq;
+    epsSavesInFlight++;
+    try {
+      // Both failure modes are handled the same way, because they mean the
+      // same thing to the user: the album is not set to what the field shows.
+      // A rejection is the server being unreachable; !ok is most often the
+      // 403 from require_no_lock, which is to say "not while this album is
+      // being indexed" — a state the user is quite likely to be tuning in.
+      let saved = false;
+      try {
+        const response = await fetch("set_umap_eps/", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ album: albumAtEdit, eps }),
+        });
+        saved = response.ok;
+      } catch (err) {
+        console.warn("Could not save the cluster strength:", err);
+      }
+      if (epsEditSeq === seq) {
+        // Nothing typed while the save was in the air, so this edit is over
+        // either way — cleared here rather than after the success check, or a
+        // failed save would leave the field reading as mid-edit forever and
+        // silently disable every re-resolve. If something *was* typed, that
+        // keystroke armed its own save and owns the flag from here.
+        epsEditPending = false;
+      }
+      // Everything below writes to the screen, so it belongs to the album on
+      // screen. If the user has moved on, the save has done its job for the
+      // album it was typed in and there is nothing here to say about it.
+      const stillShowingThisAlbum = state.album === albumAtEdit;
+      if (!saved) {
+        // Nothing was stored and nothing about the map changed, so leave the
+        // map alone — but say so on the field, which is now showing a number
+        // the album does not have. Only if it is still that field's number: a
+        // keystroke since, or another album since, and the mark would be
+        // describing something else.
+        if (stillShowingThisAlbum && epsEditSeq === seq) {
+          markEpsUnusable(true, "Could not be saved — the album still has its previous Cluster Strength.");
+        }
+        return;
+      }
+      if (!stillShowingThisAlbum) {
+        return;
+      }
+      if (eps === null) {
+        // Put the derived number back in the field before redrawing, so the
+        // map is fetched with the value the user can actually see.
+        //
+        // The sequence pinned above is passed rather than re-read: a keystroke
+        // during the save itself already means the derive is answering a
+        // question the user has moved on from.
+        await refreshResolvedEps(albumAtEdit, seq);
+      }
+      state.dataChanged = true;
+      // Not while the window is closed: Plotly would lay the plot out at zero
+      // size and consume the flag that the next open depends on to redraw.
+      // Leaving the flag set is what makes toggleUmapWindow refetch instead.
+      if (umapWindowIsOpen()) {
+        await fetchUmapData();
+      }
+    } finally {
+      epsSavesInFlight--;
     }
-    state.dataChanged = true;
-    await fetchUmapData();
   }, 1000);
 };
 
+// Leaving the field ends the edit — otherwise a value the handler refused,
+// which arms no save that could clear the flag, would read as mid-edit for
+// the rest of the session and quietly disable every re-resolve.
+//
+// Except while the field still shows text the browser cannot parse. Blur is
+// not the user saying they are done: it fires on a click anywhere else and on
+// an alt-tab, and the half-typed text goes on sitting there in the field
+// afterwards, so releasing the guard then is just the original bug with extra
+// steps. That leaves the guard held until the text is dealt with, which costs
+// only the display refresh after a re-index: the map itself is redrawn with
+// no cluster_eps at all, so it clusters at the album's own strength.
+document.getElementById("umapEpsSpinner").onblur = () => {
+  if (!document.getElementById("umapEpsSpinner").validity?.badInput) {
+    epsEditPending = false;
+  }
+};
+
+// The floor the spinner will accept, read from the element so it cannot drift
+// from the markup — which in turn mirrors MIN_CLUSTER_EPS in cluster_eps.py.
+function epsFloor() {
+  const min = parseFloat(document.getElementById("umapEpsSpinner").min);
+  return Number.isFinite(min) && min > 0 ? min : 0;
+}
+
+// Whether a number is one the album can actually be set to.
+function epsIsUsable(eps) {
+  return Number.isFinite(eps) && eps > 0 && eps >= epsFloor();
+}
+
 // The spinner's value as a number, or null when the field is empty.
-// NaN means the field holds something not yet parseable.
+// A `type="number"` element never yields anything else: it sanitizes what it
+// cannot parse to "", which is why `validity.badInput` — not a NaN check —
+// is what tells a half-typed number from a cleared field.
 function readSpinnerEps() {
   const raw = document.getElementById("umapEpsSpinner").value.trim();
   return raw === "" ? null : parseFloat(raw);
@@ -314,7 +493,22 @@ function umapWindowIsOpen() {
 // minutes, and the user is free to switch albums while it runs. Writing a
 // late reply into the shared spinner would show one album's number — and its
 // auto badge — against another album's map.
-async function refreshResolvedEps(albumKey = state.album) {
+//
+// The edit sequence is pinned for the same reason and against the same clock.
+// Clearing the field asks for a derived strength, and the derive that answers
+// it can still be running a minute later — long enough for the user to change
+// their mind and type a number, which saves and redraws on its own. Applying
+// the late reply then puts the derived value and the "auto" badge back over a
+// strength the album is actually storing. Callers that started asking before
+// the round-trip — the debounced save — pass the sequence they pinned then,
+// since a keystroke during the save counts as having moved on too.
+async function refreshResolvedEps(albumKey = state.album, seq = epsEditSeq) {
+  if (epsEditSeq !== seq) {
+    // Stale before it is even asked. Deriving is real server CPU — seconds to
+    // minutes — so don't spend it on an answer that would be discarded on
+    // arrival by the check below.
+    return false;
+  }
   try {
     const response = await fetch("get_umap_eps/", {
       method: "POST",
@@ -322,7 +516,7 @@ async function refreshResolvedEps(albumKey = state.album) {
       body: JSON.stringify({ album: albumKey }),
     });
     const data = await response.json();
-    if (!data.success || state.album !== albumKey) {
+    if (!data.success || state.album !== albumKey || epsEditSeq !== seq) {
       return false;
     }
     applyResolvedEps(data);
@@ -347,7 +541,12 @@ export async function fetchUmapData() {
     // derives the strength. Substituting a number here would quietly cluster
     // at something the user never chose and the spinner never showed.
     const eps = readSpinnerEps();
-    const epsQuery = eps !== null && !Number.isNaN(eps) ? `?cluster_eps=${eps}` : "";
+    // A value the spinner refuses to save must not be sent either. The server
+    // floors anything under MIN_CLUSTER_EPS, so sending one clusters the map
+    // at a number that is neither what the album stores nor what the field
+    // shows — the exact divergence refusing to save it is meant to prevent.
+    // Omitting it is the honest request: the album's own strength applies.
+    const epsQuery = eps !== null && epsIsUsable(eps) ? `?cluster_eps=${eps}` : "";
     const album = encodeURIComponent(state.album);
     // Fetch UMAP data and cluster labels in parallel. Labels are best-effort:
     // a failure leaves clusterLabels empty and the hover popup falls back to
@@ -2303,8 +2502,10 @@ window.addEventListener("albumIndexUpdated", async (e) => {
   // Skipped while an edit is pending: the spinner belongs to whoever is
   // typing in it, and the number they are mid-way through is about to become
   // a stored one that no derived value can override. The debounce redraws
-  // against the new coordinates a moment later anyway.
-  if (epsUpdateTimer === null && !(await refreshResolvedEps(albumKey))) {
+  // against the new coordinates a moment later anyway. "Pending" cannot be
+  // read off the debounce handle alone — half-typed text arms no save at all,
+  // and that is the state with the most to lose — so ask epsEditInProgress().
+  if (!epsEditInProgress() && !(await refreshResolvedEps(albumKey))) {
     console.warn("Redrawing the semantic map with the previous cluster strength.");
   }
   // Re-check rather than trust the checks above: resolving is a round-trip

--- a/tests/backend/test_cluster_eps.py
+++ b/tests/backend/test_cluster_eps.py
@@ -7,6 +7,7 @@ of the coordinates must not matter — which is the whole reason a fixed eps
 fails on small albums.
 """
 
+import re
 from pathlib import Path
 
 import numpy as np
@@ -225,3 +226,26 @@ def test_unwritable_cache_dir_still_returns_a_value(tmp_path, monkeypatch):
         lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")),
     )
     assert cached_adaptive_cluster_eps(blobs(), Path(tmp_path)) > 0
+
+
+def test_spinner_min_matches_the_floor_the_server_enforces():
+    """The Cluster Strength spinner refuses what the server would floor.
+
+    The frontend reads its floor off the input's own ``min`` attribute rather
+    than hardcoding a number, so the two can only drift here — and drifting
+    means either the spinner accepts a value the map then clusters at
+    something else, or it refuses one the server would have honored.
+    """
+    template = (
+        Path(__file__).parent.parent.parent
+        / "photomap"
+        / "frontend"
+        / "templates"
+        / "modules"
+        / "umap-floating-window.html"
+    ).read_text(encoding="utf-8")
+    spinner = template[template.index('id="umapEpsSpinner"') :]
+    spinner = spinner[: spinner.index(">")]
+    match = re.search(r'min="([^"]+)"', spinner)
+    assert match, "the Cluster Strength spinner has lost its min attribute"
+    assert float(match.group(1)) == pytest.approx(MIN_CLUSTER_EPS)

--- a/tests/backend/test_invokeai_board_index.py
+++ b/tests/backend/test_invokeai_board_index.py
@@ -1,10 +1,16 @@
 """Tests for indexing and curating InvokeAI board-backed albums.
 
 The InvokeAI HTTP API is stubbed at the ``invokeai_client`` layer: fake
-``fetch_board_image_names`` / ``fetch_board_video_names`` serve mutable
-board → name mappings, and the files themselves are UUID-named copies of the
+``fetch_board_image_relpaths`` / ``fetch_board_video_relpaths`` serve mutable
+board → path mappings, and the files themselves are UUID-named copies of the
 bundled fixtures laid out under fake ``<root>/outputs/images`` and
 ``<root>/outputs/videos`` directories.
+
+Those mappings hold paths *relative to* those two directories, which is what
+the real client returns: InvokeAI files each image and video into a subfolder
+chosen by a server-side strategy.  Most of the fixture is flat (every relative
+path is a bare name), matching a ``flat`` backend;
+``test_board_media_in_subfolders_are_found`` covers the organized layout.
 
 The video mapping starts out empty, so the image-only tests below run the
 same path as a board that simply has no videos. An InvokeAI too old to have
@@ -23,7 +29,7 @@ from fastapi import HTTPException
 from fixtures import media_fixture_path
 
 from photomap.backend import invokeai_client
-from photomap.backend.invokeai_client import BoardVideoNames
+from photomap.backend.invokeai_client import BoardMediaPaths
 from photomap.backend.video import VIDEO_METADATA_KEY, ffmpeg_exe
 from photomap.backend.video_cache import VideoFrameCache
 
@@ -37,6 +43,22 @@ requires_ffmpeg = pytest.mark.skipif(
 def _index_filenames(index_path: Path) -> set[str]:
     data = np.load(index_path, allow_pickle=True)
     return {Path(str(f)).name for f in data["filenames"]}
+
+
+def _index_paths(index_path: Path) -> set[str]:
+    """The full paths in the index, for assertions a basename cannot make.
+
+    Compare against :func:`_indexed_form`, not ``str(path)``: the index
+    stores ``path.resolve().as_posix()``, so on Windows every stored path is
+    forward-slash separated while ``str(Path(...))`` is not.
+    """
+    data = np.load(index_path, allow_pickle=True)
+    return {str(f) for f in data["filenames"]}
+
+
+def _indexed_form(path: Path) -> str:
+    """``path`` written the way the index writes it (see embeddings.py)."""
+    return path.resolve().as_posix()
 
 
 def _poll_until(client, album_key, statuses, timeout=60):
@@ -62,6 +84,9 @@ def board_album(client, tmp_path, monkeypatch):
     images_dir.mkdir(parents=True)
     videos_dir = tmp_path / "invokeai" / "outputs" / "videos"
     videos_dir.mkdir(parents=True)
+    # A subfolder of the kind a ``type``-organized InvokeAI files media
+    # into; the flat-layout tests simply never put anything in it.
+    (videos_dir / "user").mkdir()
     src_images = sorted(
         p for p in (Path(__file__).parent / "test_images").iterdir() if p.is_file()
     )[:4]
@@ -91,11 +116,11 @@ def board_album(client, tmp_path, monkeypatch):
 
     async def fake_fetch_videos(base_url, board_ids, username, password):
         if not video_api["available"]:
-            return BoardVideoNames(list(video_api["names_on_outage"]), False)
-        return BoardVideoNames(_merged(video_boards, board_ids), True)
+            return BoardMediaPaths(list(video_api["names_on_outage"]), False)
+        return BoardMediaPaths(_merged(video_boards, board_ids), True)
 
-    monkeypatch.setattr(invokeai_client, "fetch_board_image_names", fake_fetch)
-    monkeypatch.setattr(invokeai_client, "fetch_board_video_names", fake_fetch_videos)
+    monkeypatch.setattr(invokeai_client, "fetch_board_image_relpaths", fake_fetch)
+    monkeypatch.setattr(invokeai_client, "fetch_board_video_relpaths", fake_fetch_videos)
 
     index_path = tmp_path / "index" / "embeddings.npz"
     album = {
@@ -179,6 +204,41 @@ def test_board_videos_are_indexed_alongside_images(client, board_album):
     assert metadata["image_count"] == 4
     assert metadata["video_count"] == 1
     assert video_name in _index_filenames(board_album["index_path"])
+
+
+@requires_ffmpeg
+def test_board_media_in_subfolders_are_found(client, board_album):
+    """InvokeAI does not necessarily store a board's media flat under
+    ``outputs/images`` / ``outputs/videos``: with the ``type`` subfolder
+    strategy every non-intermediate file lands in ``general/``, and with
+    ``date`` in ``YYYY/MM/DD/``.  PhotoMap used to join the bare filename to
+    the outputs directory, so on such a backend *nothing* resolved — most
+    visibly for videos, which are written entirely under those subfolders.
+    The client now returns the subfolder-qualified path, and indexing has to
+    honour it."""
+    # A ``date``-organized image (three segments) and a ``type``-organized
+    # video (one), so the join is exercised at both depths.
+    image_rel = f"2026/08/19/{uuid.uuid4()}.png"
+    image_path = board_album["images_dir"] / image_rel
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(board_album["src_images"][0], image_path)
+    board_album["boards"]["b1"].append(image_rel)
+
+    video_rel = f"user/{uuid.uuid4()}.mp4"
+    shutil.copy(media_fixture_path("clip.mp4"), board_album["videos_dir"] / video_rel)
+    board_album["video_boards"].setdefault("b1", []).append(video_rel)
+
+    _build_index(client)
+
+    metadata = client.get(f"/index_metadata/{ALBUM_KEY}").json()
+    assert metadata["filename_count"] == 6
+    assert metadata["image_count"] == 5
+    assert metadata["video_count"] == 1
+    # Assert the *stored* paths, not the basenames: a basename check would
+    # pass even if the file had been found somewhere else entirely.
+    indexed = _index_paths(board_album["index_path"])
+    assert _indexed_form(board_album["images_dir"] / image_rel) in indexed
+    assert _indexed_form(board_album["videos_dir"] / video_rel) in indexed
 
 
 @requires_ffmpeg
@@ -465,7 +525,7 @@ def test_unreachable_invokeai_fails_indexing_and_keeps_old_index(
     async def broken_fetch(base_url, board_ids, username, password):
         raise HTTPException(status_code=502, detail="connection refused")
 
-    monkeypatch.setattr(invokeai_client, "fetch_board_image_names", broken_fetch)
+    monkeypatch.setattr(invokeai_client, "fetch_board_image_relpaths", broken_fetch)
 
     response = client.post("/update_index_async", json={"album_key": ALBUM_KEY})
     assert response.status_code == 202
@@ -642,7 +702,7 @@ def test_first_update_failure_surfaces_error_without_prior_run(
     async def broken_fetch(base_url, board_ids, username, password):
         raise HTTPException(status_code=502, detail="connection refused")
 
-    monkeypatch.setattr(invokeai_client, "fetch_board_image_names", broken_fetch)
+    monkeypatch.setattr(invokeai_client, "fetch_board_image_relpaths", broken_fetch)
 
     response = client.post("/update_index_async", json={"album_key": ALBUM_KEY})
     assert response.status_code == 202

--- a/tests/backend/test_invokeai_client.py
+++ b/tests/backend/test_invokeai_client.py
@@ -1,11 +1,15 @@
 """Tests for the raw HTTP behaviour of ``photomap.backend.invokeai_client``.
 
 The board-index tests (``test_invokeai_board_index.py``) monkeypatch
-``fetch_board_image_names`` / ``fetch_board_video_names`` wholesale, so the
-request-building details are covered here instead — most importantly that
-board fetches ask InvokeAI to exclude canvas intermediates and mask/control
-assets, mirroring what the InvokeAI gallery itself displays.
+``fetch_board_image_relpaths`` / ``fetch_board_video_relpaths`` wholesale,
+so the request-building details are covered here instead — most importantly
+that board fetches ask InvokeAI to exclude canvas intermediates and
+mask/control assets (mirroring what the InvokeAI gallery itself displays),
+and that each file's on-disk subfolder is read off its DTO rather than
+assumed flat.
 """
+
+from pathlib import Path
 
 import pytest
 from fastapi import HTTPException
@@ -55,55 +59,50 @@ def _clear_token_cache():
     invokeai_client._invalidate_token_cache()
 
 
+_UNSET = object()
+
+
+def _page(
+    items, name_key="image_name", subfolder_key="image_subfolder", total=_UNSET
+):
+    """One page of a listing endpoint, in the DTO shape InvokeAI returns.
+
+    ``total`` is the count of *all* rows matching the query, not the page's
+    own length; it defaults to the page length so single-page tests read as
+    a complete listing.  Pass ``None`` for a server that omits it.
+    """
+    body = {
+        "items": [
+            {name_key: name, subfolder_key: subfolder} for name, subfolder in items
+        ],
+        "offset": 0,
+        "limit": invokeai_client._DTO_PAGE_SIZE,
+    }
+    resolved = len(items) if total is _UNSET else total
+    if resolved is not None:
+        body["total"] = resolved
+    return _Resp(json_body=body)
+
+
 @pytest.mark.asyncio
-async def test_fetch_board_image_names_filters_out_intermediates(monkeypatch):
+async def test_fetch_board_image_relpaths_filters_out_intermediates(monkeypatch):
     """Board fetches must request only non-intermediate general/user images."""
     stub = _RecordingClient(
         [
-            _Resp(json_body=["aaa.png", "bbb.png"]),
-            _Resp(json_body=["bbb.png", "ccc.png"]),
+            _page([("aaa.png", ""), ("bbb.png", "")]),
+            _page([("bbb.png", ""), ("ccc.png", "")]),
         ]
     )
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
-    names = await invokeai_client.fetch_board_image_names(
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
         "http://localhost:9090", ["board-1", "none"], None, None
     )
 
-    assert names == ["aaa.png", "bbb.png", "ccc.png"]
+    assert relpaths == ["aaa.png", "bbb.png", "ccc.png"]
     assert [call["url"] for call in stub.calls] == [
-        "http://localhost:9090/api/v1/boards/board-1/image_names",
-        "http://localhost:9090/api/v1/boards/none/image_names",
-    ]
-    for call in stub.calls:
-        assert call["params"] == {
-            "is_intermediate": "false",
-            "categories": ["general", "user"],
-        }
-
-
-@pytest.mark.asyncio
-async def test_fetch_board_video_names_queries_each_board_with_filters(monkeypatch):
-    """Videos are listed by a query parameter, not a path segment, and get the
-    same intermediate/category filtering as images (a Wan pipeline writes its
-    intermediate clips to the board too)."""
-    stub = _RecordingClient(
-        [
-            _Resp(json_body={"video_names": ["a.mp4", "b.mp4"], "total_count": 2}),
-            _Resp(json_body={"video_names": ["b.mp4", "c.mp4"], "total_count": 2}),
-        ]
-    )
-    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
-
-    result = await invokeai_client.fetch_board_video_names(
-        "http://localhost:9090", ["board-1", "none"], None, None
-    )
-
-    assert result.names == ["a.mp4", "b.mp4", "c.mp4"]
-    assert result.api_available is True
-    assert [call["url"] for call in stub.calls] == [
-        "http://localhost:9090/api/v1/videos/names",
-        "http://localhost:9090/api/v1/videos/names",
+        "http://localhost:9090/api/v1/images/",
+        "http://localhost:9090/api/v1/images/",
     ]
     assert [call["params"]["board_id"] for call in stub.calls] == ["board-1", "none"]
     for call in stub.calls:
@@ -112,7 +111,265 @@ async def test_fetch_board_video_names_queries_each_board_with_filters(monkeypat
 
 
 @pytest.mark.asyncio
-async def test_fetch_board_video_names_tolerates_backend_without_videos(monkeypatch):
+async def test_fetch_board_relpaths_prefix_the_reported_subfolder(monkeypatch):
+    """InvokeAI files media into a subfolder chosen by a server-side strategy
+    and records it per row.  Ignoring it (the old flat assumption) means every
+    file on a ``type``-organized backend resolves to a path that is not there,
+    which is exactly how a board full of videos indexes as empty."""
+    stub = _RecordingClient(
+        [
+            _page([("aaa.png", "general"), ("bbb.png", "2026/08/19"), ("ccc.png", "")]),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/aaa.png", "2026/08/19/bbb.png", "ccc.png"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "name, subfolder",
+    [
+        ("escape.png", "../../../etc"),
+        ("absolute.png", "/etc"),
+        ("../traversal.png", "general"),
+        # Backslash spellings.  These are the dangerous ones: none of them
+        # look absolute as written, but rewriting the separators — which an
+        # earlier version of this code did, to "support" a Windows-hosted
+        # InvokeAI — turns them into absolute paths, and joining an absolute
+        # path throws the outputs directory away entirely.  InvokeAI refuses
+        # to store a backslash in a subfolder at all, so no real server
+        # reports one.
+        ("bs.png", "\\etc"),
+        ("bs-unc.png", "\\\\server\\share"),
+        ("bs-root.png", "\\"),
+        ("..\\..\\win.png", "general"),
+        # Empty and dot segments, rejected by InvokeAI's own validator too.
+        ("dot.png", "."),
+        ("empty-seg.png", "a//b"),
+        ("blank.png", " /../.."),
+    ],
+)
+async def test_fetch_board_relpaths_reject_paths_that_escape_outputs(
+    monkeypatch, name, subfolder
+):
+    """The subfolder is a server-supplied string that PhotoMap turns into a
+    local filesystem path, so anything that is not a plain relative path is
+    dropped rather than followed out of the outputs directory.
+
+    Asserted through the joined path, not just the returned string: what
+    matters is where ``outputs/images / relpath`` lands, and an absolute
+    relpath silently discards the left-hand side of that join."""
+    stub = _RecordingClient([_page([("ok.png", "general"), (name, subfolder)])])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/ok.png"]
+    outputs = Path("/invokeai/outputs/images")
+    for rel in relpaths:
+        assert (outputs / rel).is_relative_to(outputs)
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_keep_legitimate_nested_subfolders(monkeypatch):
+    """The rejection rule must not swallow the layouts InvokeAI really
+    produces — ``type`` yields one segment, ``date`` yields three."""
+    stub = _RecordingClient(
+        [_page([("a.png", "general"), ("b.png", "2026/08/19"), ("c.png", "ab")])]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/a.png", "2026/08/19/b.png", "ab/c.png"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_retry_a_listing_that_came_up_short(monkeypatch):
+    """Offset pagination is not a snapshot: deleting one row between pages
+    shifts every later row down an offset, so exactly one live row is skipped.
+    The caller prunes indexed rows this list does not mention, so a short
+    listing silently deletes a file that is still on the board — it has to be
+    caught against the server's own ``total`` and re-read."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    stub = _RecordingClient(
+        [
+            # First walk: server says 4, a deletion mid-walk means we see 3.
+            _page([("a.png", ""), ("b.png", "")], total=4),
+            _page([("d.png", "")], total=4),
+            # Re-read: quiet server, all 3 remaining rows, total agrees.
+            _page([("a.png", ""), ("b.png", "")], total=3),
+            _page([("d.png", "")], total=3),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["a.png", "b.png", "d.png"]
+    assert len(stub.calls) == 4
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_fail_rather_than_prune_a_short_listing(monkeypatch):
+    """A listing that stays short across two reads is not churn — it is a
+    backend (or an intermediary) that will not serve what it says it holds.
+    Failing leaves the previous index intact; returning the short list would
+    delete an indexed row for every entry the server withheld."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    stub = _RecordingClient(
+        [
+            _page([("a.png", ""), ("b.png", "")], total=99),
+            _page([("c.png", "")], total=99),
+            _page([("a.png", ""), ("b.png", "")], total=99),
+            _page([("c.png", "")], total=99),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await invokeai_client.fetch_board_image_relpaths(
+            "http://localhost:9090", ["board-1"], None, None
+        )
+
+    assert excinfo.value.status_code == 502
+    assert "3 of 99" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_stop_paging_a_server_that_ignores_offset(
+    monkeypatch,
+):
+    """A caching or query-stripping proxy can re-serve page one forever.  The
+    short-page rule alone never fires there, so the walk has to give up once
+    it has paged past the total the server declared — and then report the
+    listing as unusable rather than return the fragment it did get."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    same_page = [("a.png", ""), ("b.png", "")]
+    stub = _RecordingClient([_page(same_page, total=10) for _ in range(50)])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await invokeai_client.fetch_board_image_relpaths(
+            "http://localhost:9090", ["board-1"], None, None
+        )
+
+    assert excinfo.value.status_code == 502
+    # 6 pages per walk (offset runs 0..10, then passes total + one page),
+    # twice — bounded, and nowhere near the 1000-page budget.
+    assert len(stub.calls) == 12
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_tolerate_a_listing_with_no_total(monkeypatch):
+    """The completeness check is best-effort: a payload without a usable
+    ``total`` must still index, not fail."""
+    stub = _RecordingClient([_page([("a.png", "general")], total=None)])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["general/a.png"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_tolerate_rows_added_mid_walk(monkeypatch):
+    """Rows added while the walk is in flight push existing rows to a higher
+    offset, so a page can repeat what an earlier one returned.  That is a
+    duplicate, not a gap: it must dedupe, not trigger a re-read."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    stub = _RecordingClient(
+        [
+            _page([("b.png", ""), ("c.png", "")], total=3),
+            # "a.png" was created mid-walk and sorts first, so page two
+            # re-shows c.png before reaching d.png.
+            _page([("c.png", ""), ("d.png", "")], total=4),
+            _page([], total=4),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == ["b.png", "c.png", "d.png"]
+    assert len(stub.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_relpaths_page_until_a_short_page(monkeypatch):
+    """The listing endpoint is paginated and clamped server-side, so a board
+    bigger than one page must be walked — stopping at the first page would
+    silently index only the newest 1000 files."""
+    monkeypatch.setattr(invokeai_client, "_DTO_PAGE_SIZE", 2)
+    stub = _RecordingClient(
+        [
+            # ``total`` is the whole board, not the page — every page repeats
+            # the same figure, which is what the real endpoint does.
+            _page([("a.png", "general"), ("b.png", "general")], total=5),
+            _page([("c.png", "general"), ("d.png", "general")], total=5),
+            _page([("e.png", "general")], total=5),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    relpaths = await invokeai_client.fetch_board_image_relpaths(
+        "http://localhost:9090", ["board-1"], None, None
+    )
+
+    assert relpaths == [f"general/{n}.png" for n in "abcde"]
+    assert [call["params"]["offset"] for call in stub.calls] == [0, 2, 4]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_video_relpaths_queries_the_video_router(monkeypatch):
+    """Videos are a separate resource with their own outputs directory, and
+    get the same intermediate/category filtering as images (a Wan pipeline
+    writes its intermediate clips to the board too)."""
+    stub = _RecordingClient(
+        [
+            _page([("a.mp4", "general")], "video_name", "video_subfolder"),
+            _page(
+                [("a.mp4", "general"), ("c.mp4", "user")],
+                "video_name",
+                "video_subfolder",
+            ),
+        ]
+    )
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    result = await invokeai_client.fetch_board_video_relpaths(
+        "http://localhost:9090", ["board-1", "none"], None, None
+    )
+
+    assert result.relpaths == ["general/a.mp4", "user/c.mp4"]
+    assert result.api_available is True
+    assert [call["url"] for call in stub.calls] == [
+        "http://localhost:9090/api/v1/videos/",
+        "http://localhost:9090/api/v1/videos/",
+    ]
+    assert [call["params"]["board_id"] for call in stub.calls] == ["board-1", "none"]
+    for call in stub.calls:
+        assert call["params"]["is_intermediate"] == "false"
+        assert call["params"]["categories"] == ["general", "user"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_video_relpaths_tolerates_backend_without_videos(monkeypatch):
     """An InvokeAI predating the video API 404s the whole router; that must
     not fail the index run, and it must be distinguishable from a board that
     genuinely holds no videos — the caller prunes rows for anything absent
@@ -120,45 +377,60 @@ async def test_fetch_board_video_names_tolerates_backend_without_videos(monkeypa
     stub = _RecordingClient([_Resp(status_code=404, text="Not Found")])
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
-    result = await invokeai_client.fetch_board_video_names(
+    result = await invokeai_client.fetch_board_video_relpaths(
         "http://localhost:9090", ["board-1"], None, None
     )
 
-    assert result.names == []
+    assert result.relpaths == []
     assert result.api_available is False
 
 
 @pytest.mark.asyncio
-async def test_fetch_board_video_names_keeps_names_from_earlier_boards(monkeypatch):
+async def test_fetch_board_image_relpaths_raise_on_a_404(monkeypatch):
+    """There is no InvokeAI old enough to lack an image listing, so unlike
+    videos a 404 here is a real failure and must not be swallowed into an
+    empty — and therefore index-pruning — result."""
+    stub = _RecordingClient([_Resp(status_code=404, text="Not Found")])
+    monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await invokeai_client.fetch_board_image_relpaths(
+            "http://localhost:9090", ["board-1"], None, None
+        )
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_video_relpaths_keeps_paths_from_earlier_boards(monkeypatch):
     """A 404 on a later board must not discard what earlier boards returned.
     InvokeAI answers 404 for a board a non-admin cannot read, not only for a
     missing video router, so the successful listings are still good data."""
     stub = _RecordingClient(
         [
-            _Resp(json_body={"video_names": ["a.mp4"], "total_count": 1}),
+            _page([("a.mp4", "general")], "video_name", "video_subfolder"),
             _Resp(status_code=404, text="Board not found"),
         ]
     )
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
-    result = await invokeai_client.fetch_board_video_names(
+    result = await invokeai_client.fetch_board_video_relpaths(
         "http://localhost:9090", ["board-1", "board-gone"], None, None
     )
 
-    assert result.names == ["a.mp4"]
+    assert result.relpaths == ["general/a.mp4"]
     assert result.api_available is False
 
 
 @pytest.mark.asyncio
-async def test_fetch_board_video_names_rejects_unexpected_shape(monkeypatch):
-    """A bare list (the *images* endpoint's shape) is not silently accepted —
-    reading no names off a successful response would quietly drop every video
-    from the album."""
+async def test_fetch_board_video_relpaths_rejects_unexpected_shape(monkeypatch):
+    """A bare list (the shape the retired ``/names`` endpoints returned) is not
+    silently accepted — reading no items off a successful response would
+    quietly drop every video from the album."""
     stub = _RecordingClient([_Resp(json_body=["a.mp4"])])
     monkeypatch.setattr(invokeai_client.httpx, "AsyncClient", stub)
 
     with pytest.raises(HTTPException) as excinfo:
-        await invokeai_client.fetch_board_video_names(
+        await invokeai_client.fetch_board_video_relpaths(
             "http://localhost:9090", ["board-1"], None, None
         )
     assert excinfo.value.status_code == 502

--- a/tests/frontend/umap-eps-debounce.test.js
+++ b/tests/frontend/umap-eps-debounce.test.js
@@ -1,0 +1,491 @@
+// The Cluster Strength debounce: what reaches set_umap_eps, and when.
+//
+// An empty field is a deliberate signal here -- it means "go back to a
+// derived strength". The trap is that `<input type="number">` also reports an
+// empty value for anything it cannot parse *yet*: "0.", "-", "1e". So a pause
+// of one second while retyping looked exactly like asking for a derived
+// value, and threw the album's tuned number away.
+//
+// `validity.badInput` is what separates them, and it is the one thing here
+// jsdom cannot produce: it sets value to "" for unparseable input but never
+// sets badInput (verified -- see `typeUnparseable`). The tests below drive it
+// with a stub, so they pin THIS MODULE's logic; that badInput is really set by
+// a browser for a half-typed number is a platform guarantee, not something
+// this suite proves.
+//
+// See umap-harness.js for why umap.js needs a harness to be importable.
+//
+// This file re-imports umap.js per test, and nothing unregisters the window
+// listeners a previous import left behind. So do not assert on what a
+// `window.dispatchEvent` did here — every stale module answers it too, and the
+// one with no edit pending will happily satisfy an assertion the module under
+// test failed. Those cases belong in umap-reindex-refresh.test.js, which
+// imports once.
+
+import { jest, describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+
+import { installFetchMock, installPlotlyMock, loadUmapDom, removePlotlyMock } from "./umap-harness.js";
+
+const JS = "../../photomap/frontend/static/javascript";
+
+const mockState = {
+  album: "test-album",
+  dataChanged: true,
+  autotaggingEnabled: false,
+  umapMediaFilter: "both",
+  umapShowLandmarks: false,
+  umapShowHoverThumbnails: false,
+  umapExitFullscreenOnSelection: false,
+  umapClickSelectsCluster: true,
+  umapControlsVisible: true,
+  umapClickSelectsImage: false,
+  searchType: "clear",
+  searchResults: [],
+};
+
+const setUmapMediaFilter = jest.fn((v) => {
+  mockState.umapMediaFilter = v;
+});
+const setSearchResults = jest.fn();
+// Mutable so a test can put the swiper on a specific image.
+const currentSlideIndex = [-1, 0, null];
+
+jest.unstable_mockModule(`${JS}/state.js`, () => ({
+  state: mockState,
+  setUmapMediaFilter,
+  setUmapShowLandmarks: jest.fn((v) => {
+    mockState.umapShowLandmarks = v;
+  }),
+  setUmapClickSelectsCluster: jest.fn(),
+  setUmapControlsVisible: jest.fn(),
+  setUmapExitFullscreenOnSelection: jest.fn(),
+  setUmapShowHoverThumbnails: jest.fn(),
+  saveSettingsToLocalStorage: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/album-manager.js`, () => ({
+  albumManager: { fetchAvailableAlbums: jest.fn(() => Promise.resolve([])), setSwiperManager: jest.fn() },
+  checkAlbumIndex: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/back-stack.js`, () => ({
+  backStack: { markNextAsJump: jest.fn(), popOne: jest.fn(), init: jest.fn(), setNavigator: jest.fn() },
+}));
+jest.unstable_mockModule(`${JS}/cluster-utils.js`, () => ({
+  CLUSTER_PALETTE: ["#ff0000", "#00ff00", "#0000ff"],
+  getClusterLabelInfo: jest.fn(() => null),
+  getImageLabelInfo: jest.fn(() => null),
+  setClusterLabels: jest.fn(),
+  trackVocabBuildRequest: jest.fn((p) => p),
+}));
+jest.unstable_mockModule(`${JS}/search-ui.js`, () => ({ exitSearchMode: jest.fn() }));
+jest.unstable_mockModule(`${JS}/search.js`, () => ({
+  getImagePath: jest.fn(() => Promise.resolve("/photos/example.jpg")),
+  setSearchResults,
+}));
+jest.unstable_mockModule(`${JS}/settings.js`, () => ({ switchAlbum: jest.fn() }));
+jest.unstable_mockModule(`${JS}/slide-state.js`, () => ({
+  slideState: { navigateToIndex: jest.fn(), getCurrentSlide: jest.fn(() => ({ globalIndex: 0 })) },
+  getCurrentSlideIndex: jest.fn(() => currentSlideIndex),
+}));
+jest.unstable_mockModule(`${JS}/umap-reindex.js`, () => ({
+  checkUmapReindexOngoing: jest.fn(),
+  initUmapReindexButton: jest.fn(),
+}));
+jest.unstable_mockModule(`${JS}/utils.js`, () => ({
+  // Real debounce, capped so the 500ms landmark coalescing doesn't dominate
+  // the suite's runtime.
+  debounce: (fn, delay) => {
+    const wait = Math.min(delay, 10);
+    let timer = null;
+    return function (...args) {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => fn.apply(this, args), wait);
+    };
+  },
+  getPercentile: (arr, p) => {
+    const sorted = [...arr].sort((a, b) => a - b);
+    return sorted[Math.floor(((p / 100) * (sorted.length - 1)) | 0)] ?? 0;
+  },
+  isColorLight: () => false,
+  makeDraggable: jest.fn(),
+  showToast: jest.fn(),
+}));
+
+const SAVE_DEBOUNCE_MS = 1000;
+
+const spinner = () => document.getElementById("umapEpsSpinner");
+const badge = () => document.getElementById("umapEpsAutoBadge");
+
+/** Everything POSTed to set_umap_eps, in order. */
+let savedEps;
+/** The full body of each of those POSTs, so a test can check the album. */
+let savedBodies;
+
+function installEpsFetchMock() {
+  savedEps = [];
+  savedBodies = [];
+  fetched = [];
+  global.fetch = (url, options) => {
+    const href = String(url);
+    fetched.push(href);
+    if (href.startsWith("set_umap_eps")) {
+      savedBodies.push(JSON.parse(options.body));
+      savedEps.push(JSON.parse(options.body).eps);
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true }) });
+    }
+    if (href.startsWith("umap_data/")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, eps: 0.35 }) });
+  };
+}
+
+/** Type into the spinner the way a user does: set the value, fire input. */
+function type(value) {
+  const el = spinner();
+  if (el.dataset.realValidity) {
+    // Whatever the browser could not parse is gone, and so is badInput.
+    Object.defineProperty(el, "validity", { value: realValidity.get(el), configurable: true });
+    delete el.dataset.realValidity;
+  }
+  el.value = value;
+  el.dispatchEvent(new Event("input"));
+}
+
+/**
+ * A copy of a ValidityState with badInput forced on.
+ *
+ * Spreading it would produce `{}` — every flag is a getter on the prototype,
+ * so none of them is an own enumerable property. `for...in` walks the
+ * prototype chain and reads each getter against the real object, which is
+ * what keeps the stub honest as umap.js starts consulting other flags.
+ */
+function validityWithBadInput(real) {
+  const copy = {};
+  for (const key in real) {
+    copy[key] = real[key];
+  }
+  copy.badInput = true;
+  copy.valid = false;
+  return copy;
+}
+
+/**
+ * Put the field into the state a real browser reports for text it cannot turn
+ * into a number yet ("0.", "-", "1e"): value "" and validity.badInput set.
+ *
+ * jsdom does the first but not the second, so badInput is stubbed. The stub
+ * stays installed — a browser does not stop reporting badInput just because
+ * the keystroke is over, and the field goes on showing the unparseable text
+ * until something replaces it. `type()` takes it back off, the way entering a
+ * parseable value does.
+ */
+function typeUnparseable() {
+  const el = spinner();
+  if (!el.dataset.realValidity) {
+    realValidity.set(el, el.validity);
+    el.dataset.realValidity = "stubbed";
+  }
+  Object.defineProperty(el, "validity", {
+    value: validityWithBadInput(realValidity.get(el)),
+    configurable: true,
+  });
+  el.value = "";
+  el.dispatchEvent(new Event("input"));
+}
+
+const realValidity = new WeakMap();
+
+/**
+ * Run out the debounce.
+ *
+ * Fake timers rather than a real 1.15s wait per assertion: the debounce is a
+ * second long by design, and five of those waits cost more wall clock than
+ * the rest of the frontend suite put together. `advanceTimersByTimeAsync`
+ * drains the microtask queue between firings, so the fetch chain the timer
+ * starts finishes before this returns.
+ */
+const pastTheDebounce = () => jest.advanceTimersByTimeAsync(SAVE_DEBOUNCE_MS + 150);
+
+/** Whether the field is marked as holding a value that cannot be saved. */
+const isMarkedUnusable = () => spinner().classList.contains("umap-eps-unusable");
+
+/** URLs fetched, in order — so a test can see what the map was asked for. */
+let fetched;
+
+let umap;
+
+describe("Cluster Strength debounce", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    loadUmapDom();
+    installPlotlyMock();
+    installFetchMock([]);
+    umap = await import(`${JS}/umap.js`);
+    installEpsFetchMock();
+    // The map is on screen: a save redraws it, which is the path every one of
+    // these tests should be running unless it says otherwise.
+    document.getElementById("umapFloatingWindow").style.display = "block";
+    mockState.dataChanged = true;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    removePlotlyMock();
+    delete global.fetch;
+    document.body.innerHTML = "";
+    jest.resetModules();
+  });
+
+  it("does not clear the album's strength when the user pauses mid-number", async () => {
+    // The bug: "0." sanitizes to "", which is the deliberate-clear signal,
+    // so hesitating for a second threw away the tuned value and put the
+    // album back on a derived one.
+    type("0.4");
+    await pastTheDebounce();
+    savedEps.length = 0;
+
+    typeUnparseable();
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([]);
+  });
+
+  it("still treats a genuinely emptied field as a request to derive one", async () => {
+    // The other half: this must keep working, or clearing the field stops
+    // being a way back to an automatic strength.
+    type("");
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([null]);
+  });
+
+  it("saves the number once the user finishes typing it", async () => {
+    typeUnparseable();
+    type("0.4");
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([0.4]);
+  });
+
+  it("does not let a pending save land after the field goes unparseable", async () => {
+    // The save armed by "0.4" must not fire a second later: the field no
+    // longer shows that number. This is why the timer is cleared before the
+    // early return rather than after it.
+    type("0.4");
+    typeUnparseable();
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([]);
+  });
+
+  it("refuses to save a strength DBSCAN cannot use", async () => {
+    // A stored 0 or negative leaves the map clustering at the floor while
+    // the spinner and the info modal both report the number the user typed.
+    type("0");
+    await pastTheDebounce();
+    type("-2");
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([]);
+  });
+
+  it("refuses a strength the server would silently raise", async () => {
+    // Positive, but under the spinner's own min and the server's
+    // MIN_CLUSTER_EPS: storing it means the map clusters at 0.01 while the
+    // spinner and the cluster-info modal both report 0.005.
+    type("0.005");
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([]);
+  });
+
+  it("saves a strength above the spinner's display max", async () => {
+    // The ceiling is not enforced: a derived strength for a small album can
+    // legitimately exceed it, and refusing those would leave the albums that
+    // need tuning most unable to be tuned.
+    type("4.5");
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([4.5]);
+  });
+
+  it("marks the field while it holds something that cannot be saved", async () => {
+    // The handler answers a value it will not store by doing nothing, so
+    // without a mark a refused keystroke looks exactly like a saved one.
+    typeUnparseable();
+    expect(isMarkedUnusable()).toBe(true);
+    expect(spinner().title).not.toBe("");
+
+    type("0.005");
+    expect(isMarkedUnusable()).toBe(true);
+
+    type("0.4");
+    expect(isMarkedUnusable()).toBe(false);
+    expect(spinner().hasAttribute("title")).toBe(false);
+
+    await pastTheDebounce();
+    expect(savedEps).toEqual([0.4]);
+  });
+
+  it("does not put a derived strength back over a number typed since", async () => {
+    // Clearing the field asks the server to derive one, and on a large album
+    // that answer can be a minute coming — long enough for the user to change
+    // their mind and type a number, which saves and redraws on its own.
+    // Applying the late reply then shows a derived value and an "auto" badge
+    // for an album that is storing the user's number.
+    let releaseDerive;
+    const realFetch = global.fetch;
+    global.fetch = (url, options) => {
+      if (String(url).startsWith("get_umap_eps")) {
+        return new Promise((resolve) => {
+          releaseDerive = () =>
+            resolve({ ok: true, json: () => Promise.resolve({ success: true, eps: 0.07, auto: true }) });
+        });
+      }
+      return realFetch(url, options);
+    };
+
+    type("");
+    await pastTheDebounce();
+    expect(savedEps).toEqual([null]);
+
+    // The derive is still running; the user types a strength instead.
+    type("0.5");
+    await pastTheDebounce();
+    expect(savedEps).toEqual([null, 0.5]);
+
+    releaseDerive();
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(spinner().value).toBe("0.5");
+    expect(badge().hidden).toBe(true);
+  });
+
+  it("does not redraw the map when the save fails", async () => {
+    // A rejection is the server being unreachable. Nothing was stored, so
+    // redrawing would show the map at a strength the album does not have.
+    const realFetch = global.fetch;
+    global.fetch = (url, options) =>
+      String(url).startsWith("set_umap_eps") ? Promise.reject(new Error("offline")) : realFetch(url, options);
+
+    type("0.5");
+    await pastTheDebounce();
+
+    expect(fetched.some((u) => u.startsWith("umap_data/"))).toBe(false);
+    expect(isMarkedUnusable()).toBe(true);
+  });
+
+  it("does not redraw the map when the server refuses the save", async () => {
+    // The refusal in practice is the 403 from require_no_lock: the album is
+    // being indexed, which is exactly when someone is likely to be tuning it.
+    const realFetch = global.fetch;
+    global.fetch = (url, options) =>
+      String(url).startsWith("set_umap_eps")
+        ? Promise.resolve({ ok: false, status: 403, json: () => Promise.resolve({ detail: "locked" }) })
+        : realFetch(url, options);
+
+    type("0.5");
+    await pastTheDebounce();
+
+    expect(fetched.some((u) => u.startsWith("umap_data/"))).toBe(false);
+    expect(isMarkedUnusable()).toBe(true);
+  });
+
+  it("leaves the redraw to the next window open when the save lands on a closed map", async () => {
+    // Plotly lays a plot out at zero size in a hidden container, and the
+    // redraw would consume the flag the next open depends on to refetch.
+    type("0.5");
+    document.getElementById("umapFloatingWindow").style.display = "none";
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([0.5]);
+    expect(fetched.some((u) => u.startsWith("umap_data/"))).toBe(false);
+    expect(mockState.dataChanged).toBe(true);
+  });
+
+  it("does not send a strength it refused to save", async () => {
+    // Refusing to store 0.005 but still asking the map for it gets the map
+    // clustered at the server's floor — the very divergence the refusal is
+    // there to prevent.
+    type("0.005");
+    await pastTheDebounce();
+    fetched.length = 0;
+
+    mockState.dataChanged = true;
+    await umap.fetchUmapData();
+
+    expect(savedEps).toEqual([]);
+    const mapUrl = fetched.find((u) => u.startsWith("umap_data/"));
+    expect(mapUrl).toBe("umap_data/test-album");
+  });
+
+  it("saves the number to the album it was typed in, not the one in view a second later", async () => {
+    // Switching albums inside the debounce window used to hand the number to
+    // whichever album `state.album` pointed at when the timer fired: album B
+    // silently acquired a Cluster Strength typed for album A, and nothing on
+    // screen said so until the next time B's map was opened.
+    type("0.4");
+    mockState.album = "other-album";
+    await pastTheDebounce();
+
+    expect(savedBodies).toEqual([{ album: "test-album", eps: 0.4 }]);
+    // And the other album's map is not redrawn with it.
+    expect(fetched.some((u) => u.startsWith("umap_data/"))).toBe(false);
+  });
+
+  it("marks a stored strength the map cannot cluster with", async () => {
+    // Versions before the spinner refused these could store them, and the
+    // config file is hand-editable. Leaving it unmarked is this module saying
+    // the number is in effect when the server has floored it.
+    umap.applyResolvedEps({ success: true, eps: 0.005, auto: false });
+
+    expect(spinner().value).toBe("0.005");
+    expect(isMarkedUnusable()).toBe(true);
+  });
+
+  it("does not mark a derived strength, however small", async () => {
+    // A degenerate album can derive its way below the floor. The spinner
+    // would refuse the number, but it is the one the map is clustered with.
+    umap.applyResolvedEps({ success: true, eps: 9.3e-7, auto: true });
+
+    expect(isMarkedUnusable()).toBe(false);
+  });
+
+  it("does not put a derived strength back over a number typed during the save", async () => {
+    // The same race one step earlier: the keystroke lands while the clear is
+    // still being POSTed, before the derive has even been asked for. Reading
+    // the edit sequence when the derive starts would miss it, which is why
+    // the save pins the sequence it began with and passes that down.
+    let releaseSave;
+    let held = true;
+    const realFetch = global.fetch;
+    global.fetch = (url, options) => {
+      if (held && String(url).startsWith("set_umap_eps")) {
+        held = false;
+        return new Promise((resolve) => {
+          releaseSave = () => {
+            realFetch(url, options);
+            resolve({ ok: true, json: () => Promise.resolve({ success: true }) });
+          };
+        });
+      }
+      return realFetch(url, options);
+    };
+
+    type("");
+    await pastTheDebounce();
+
+    // The clear is in the air; the user changes their mind before it lands.
+    type("0.5");
+    releaseSave();
+    await pastTheDebounce();
+
+    expect(savedEps).toEqual([null, 0.5]);
+    expect(spinner().value).toBe("0.5");
+    expect(badge().hidden).toBe(true);
+  });
+});

--- a/tests/frontend/umap-reindex-refresh.test.js
+++ b/tests/frontend/umap-reindex-refresh.test.js
@@ -95,6 +95,44 @@ const flushAsync = async () => {
 
 const reindexed = (albumKey) => window.dispatchEvent(new CustomEvent("albumIndexUpdated", { detail: { albumKey } }));
 
+/**
+ * Type something the browser cannot parse into a number yet ("0.", "-").
+ *
+ * A real number input reports value "" and sets validity.badInput; jsdom does
+ * the first but not the second, so the flag is stubbed — and left in place,
+ * because the field goes on showing the unparseable text after the keystroke
+ * and a browser goes on reporting badInput for it. `restoreValidity` takes it
+ * back off. See umap-eps-debounce.test.js for what the stub does and does not
+ * prove.
+ */
+function typeUnparseable() {
+  const el = spinner();
+  const copy = {};
+  for (const key in el.validity) {
+    copy[key] = el.validity[key];
+  }
+  copy.badInput = true;
+  copy.valid = false;
+  if (!realValidity) {
+    realValidity = el.validity;
+  }
+  Object.defineProperty(el, "validity", { value: copy, configurable: true });
+  el.value = "";
+  el.dispatchEvent(new Event("input"));
+}
+
+let realValidity = null;
+
+function restoreValidity() {
+  if (realValidity) {
+    Object.defineProperty(spinner(), "validity", { value: realValidity, configurable: true });
+    realValidity = null;
+  }
+}
+
+/** Blur the field, the way clicking anywhere else on the page does. */
+const blurField = () => spinner().dispatchEvent(new Event("blur"));
+
 // A fetch mock whose get_umap_eps reply is held open until released, so a
 // test can act inside the window the real resolve leaves open.
 function deferredEpsFetch(eps) {
@@ -149,8 +187,13 @@ beforeEach(() => {
   mockState.album = "test-album";
   mockState.dataChanged = true;
   mapWindow().style.display = "block";
-  // The map is showing a derived strength for an album that had none.
+  // The module is imported once for the whole file, so its idea of whether an
+  // edit is in progress outlives any single test. Put the field back to a
+  // parseable value and blur it, which is what clears that flag — cleanup a
+  // test does at its own end is cleanup a failing test skips.
+  restoreValidity();
   umap.applyResolvedEps({ success: true, eps: 0.2, auto: true });
+  blurField();
 });
 
 describe("albumIndexUpdated on the album being shown", () => {
@@ -225,6 +268,138 @@ describe("albumIndexUpdated on the album being shown", () => {
     await flushAsync();
 
     expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
+  });
+
+  it("leaves the spinner alone while the user is mid-number", async () => {
+    // Half-typed text arms no save at all — that is the whole point of the
+    // badInput guard — so the debounce handle cannot stand in for "an edit is
+    // pending" here. This is the state with the most to lose: overwriting it
+    // moves the number under the cursor while the user is still typing it.
+    const calls = immediateFetch({ eps: 0.49 });
+    typeUnparseable();
+
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(false);
+    expect(spinner().value).toBe("");
+  });
+
+  it("keeps holding the field when the user clicks away mid-number", async () => {
+    // Blur is not the user saying they are done: it fires on a click anywhere
+    // else and on an alt-tab, and the browser goes on showing the half-typed
+    // text afterwards. Releasing the field then would put the number back
+    // under a user who is about to carry on typing it.
+    const calls = immediateFetch({ eps: 0.49 });
+    typeUnparseable();
+    blurField();
+
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(false);
+    expect(spinner().value).toBe("");
+  });
+
+  it("resumes re-resolving once a refused value is left behind", async () => {
+    // A value the handler refuses arms no save that could ever clear the
+    // flag, so blur has to — one 0.005 must not disable every re-resolve for
+    // the rest of the session.
+    spinner().value = "0.005";
+    spinner().dispatchEvent(new Event("input"));
+    blurField();
+
+    const calls = immediateFetch({ eps: 0.49 });
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
+    expect(spinner().value).toBe("0.49");
+  });
+
+  it("stops holding the field once its contents have been replaced", async () => {
+    // Half-typed text holds the guard across a blur on purpose. But the hold
+    // has to end when the text does: re-opening the map refills the field
+    // from the server, and a guard still set for a value that is no longer
+    // there disables every re-resolve for the rest of the session.
+    typeUnparseable();
+    blurField();
+    restoreValidity();
+    umap.applyResolvedEps({ success: true, eps: 0.4, auto: false });
+
+    const calls = immediateFetch({ eps: 0.49 });
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
+    expect(spinner().value).toBe("0.49");
+  });
+
+  it("does not let a failed save leave the field reading as mid-edit", async () => {
+    // The flag that says "someone is typing in here" suppresses this
+    // re-resolve. Stranded on an error path — the save rejects, and the user
+    // has not clicked away, so no blur clears it — it would suppress every
+    // re-resolve for the rest of the session.
+    const calls = [];
+    global.fetch = (url) => {
+      calls.push(String(url));
+      if (String(url).startsWith("set_umap_eps")) {
+        return Promise.reject(new Error("connection lost"));
+      }
+      if (String(url).startsWith("get_umap_eps")) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ success: true, eps: 0.49, auto: true }) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+    };
+
+    spinner().value = "0.5";
+    spinner().dispatchEvent(new Event("input"));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    calls.length = 0;
+
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(true);
+  });
+
+  it("holds the field while the save it armed is still in the air", async () => {
+    // The debounce handle is dropped the moment the save starts, and a save
+    // that started after a blur leaves nothing else behind — so this window
+    // used to look idle while the server it would be re-read from was the one
+    // still waiting for the POST. Re-resolving inside it puts the pre-save
+    // value and the "auto" badge back over the number just stored.
+    let releaseSave;
+    const calls = [];
+    global.fetch = async (url) => {
+      calls.push(String(url));
+      if (String(url).startsWith("set_umap_eps")) {
+        await new Promise((resolve) => {
+          releaseSave = resolve;
+        });
+        return { ok: true, json: () => Promise.resolve({ success: true }) };
+      }
+      if (String(url).startsWith("get_umap_eps")) {
+        return { ok: true, json: () => Promise.resolve({ success: true, eps: 0.2, auto: true }) };
+      }
+      return { ok: true, json: () => Promise.resolve([]) };
+    };
+
+    spinner().value = "0.5";
+    spinner().dispatchEvent(new Event("input"));
+    blurField();
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+
+    // The POST is in the air. A re-index completing now must not re-resolve.
+    reindexed("test-album");
+    await flushAsync();
+
+    expect(calls.some((u) => u.startsWith("get_umap_eps"))).toBe(false);
+    expect(spinner().value).toBe("0.5");
+    expect(badge().hidden).toBe(true);
+
+    releaseSave();
+    await flushAsync();
   });
 });
 


### PR DESCRIPTION
Indexing an InvokeAI board album skipped almost everything — "386 of 387 file(s) listed by InvokeAI were not found on disk and were skipped" against a backend at `localhost:9090` with a correct InvokeAI root.

The resolution code had not been changed. It had been deleted.

## What happened

PR #382 (the iPad fullscreen-panel fix) carried stale copies of files it never meant to touch, and squash-merging it rolled two already-merged PRs back to their exact pre-merge state:

| Reverted PR | Files taken back |
| --- | --- |
| #378 — Resolve InvokeAI board media through their recorded subfolder | `photomap/backend/invokeai_client.py`, `photomap/backend/routers/index.py`, `tests/backend/test_invokeai_client.py`, `tests/backend/test_invokeai_board_index.py` |
| #376 — Pausing mid-edit no longer discards the Cluster Strength | `photomap/frontend/static/javascript/umap.js`, `photomap/frontend/static/css/umap-floating-window.css`, `tests/backend/test_cluster_eps.py`, `tests/frontend/umap-eps-debounce.test.js` (deleted outright), `tests/frontend/umap-reindex-refresh.test.js` |

Every one of those files was byte-identical to its pre-merge content on master, tests included — which is why nothing failed. The tests that would have caught it went back with the code they covered.

The user-visible symptom is #378's: board albums went back to joining the bare filename to `<invokeai_root>/outputs/{images,videos}`, so on a backend whose subfolder strategy is not `flat`, almost nothing resolves. #376's loss is silent until someone pauses mid-edit over the Cluster Strength spinner.

## What this does

Restores both commits verbatim — cherry-picked onto current master, no conflicts. #377's `asyncio.to_thread` hunk in `index.py`, which landed after the revert in an untouched region, is preserved.

No new logic: every line here has already been reviewed and merged once.

## Verification

Live against the reporter's InvokeAI at `localhost:9090`, the same album that failed:

```
resolved: 386  missing: 1  video_api: True
videos: 296  images: 90
  /home/lstein/invokeai-main/outputs/images/user/d3d43dd3-….png
  /home/lstein/invokeai-main/outputs/videos/general/610600c3-….mp4
```

The inverse of the reported failure. The one remaining miss is a genuine gap rather than a resolution bug — InvokeAI lists a video whose subfolder resolves correctly and whose directory exists, but the file is not on disk.

Backend 844 passed, frontend 656 passed (633 before this PR, the difference being `umap-eps-debounce.test.js` coming back), ruff clean. Confirmed working in the app by the reporter.

Checked the seam between the restored #376 and #375, which was authored against the already-reverted tree: both floor the Cluster Strength at `MIN_CLUSTER_EPS` (0.01, the spinner's own `min`), so they agree.

## Worth doing separately

Any branch opened before 2026-08-20 can carry the same staleness. This loop reports files a later commit took back to their pre-merge state:

```bash
for c in $(git log --format=%h -15); do
  for f in $(git show --name-only --format="" $c); do
    git cat-file -e $c^:"$f" 2>/dev/null &&
      git diff --quiet $c^ HEAD -- "$f" && echo "$c LOST: $f"
  done
done
```

(It misses files a commit *created*; a drop in the test count between PRs is the other tell.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtGdMfK3k6z2tazjDjMFtE